### PR TITLE
feat: primitive conversion from FFI abstraction

### DIFF
--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -18,6 +18,7 @@ pub use transaction_4337::{
     EncodedSafeOpStruct, PackedUserOperation, UserOperation, ENTRYPOINT_4337,
     GNOSIS_SAFE_4337_MODULE,
 };
+
 /// Errors that can occur when working with Safe Smart Accounts.
 #[crate::bedrock_error]
 pub enum SafeSmartAccountError {
@@ -41,6 +42,9 @@ pub enum SafeSmartAccountError {
         /// Explicit failure message for the attribute validation.
         message: String,
     },
+    /// An error occurred with a primitive type. See `PrimitiveError` for more details.
+    #[error(transparent)]
+    PrimitiveError(#[from] crate::primitives::PrimitiveError),
 }
 
 /// A Safe Smart Account (previously Gnosis Safe) is the representation of a Safe smart contract.

--- a/bedrock/tests/test_smart_account.rs
+++ b/bedrock/tests/test_smart_account.rs
@@ -284,8 +284,11 @@ async fn test_integration_personal_sign() {
     println!("✓ Safe integration test completed successfully!");
 }
 
+/// Integration test for the encoding, signging and execution of a 4337 transaction.
+///
+/// This test deploys two Safe Smart Accounts, and transfers 1 ETH from Safe 1 to Safe 2 using a 4337 transaction.
 #[tokio::test]
-async fn test_execute_erc4337_tx() -> anyhow::Result<()> {
+async fn test_integration_erc4337_transaction_execution() -> anyhow::Result<()> {
     let anvil = setup_anvil();
     let owner_signer = PrivateKeySigner::random();
 


### PR DESCRIPTION
Introduces a `ParseFromForeignBinding` trait so that we can re-use conversions from types that can be lifted from foreign bindings into alloy primitives.