### PR TITLE
feat: sign typed data for smart accounts

### DIFF
--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -339,6 +339,7 @@ mod tests {
         .unwrap();
         let chain_id = 10;
 
+        // Example from specs: https://eips.ethereum.org/EIPS/eip-712#specification-of-the-eth_signtypeddata-json-rpc
         let typed_data = json!({
              "types":{
                 "EIP712Domain":[

--- a/bedrock/tests/test_smart_account.rs
+++ b/bedrock/tests/test_smart_account.rs
@@ -1,4 +1,5 @@
 use alloy::{
+    dyn_abi::TypedData,
     network::Ethereum,
     node_bindings::AnvilInstance,
     primitives::{address, keccak256, Address, Bytes, U256},
@@ -11,6 +12,7 @@ use bedrock::smart_account::{
     EncodedSafeOpStruct, PackedUserOperation, SafeSmartAccount, SafeSmartAccountSigner,
     UserOperation, ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE,
 };
+use serde_json::json;
 
 sol!(
     #[allow(missing_docs)]
@@ -284,6 +286,126 @@ async fn test_integration_personal_sign() {
     println!("✓ Safe integration test completed successfully!");
 }
 
+/// Ensures signature verification fails if the message wasn't signed for the correct chain
+#[tokio::test]
+async fn test_integration_personal_sign_failure_on_incorrect_chain_id() {
+    let anvil = setup_anvil();
+    let owner_signer = PrivateKeySigner::random();
+
+    let owner_key_hex = hex::encode(owner_signer.to_bytes());
+
+    let owner = owner_signer.address();
+
+    let provider = ProviderBuilder::new()
+        .wallet(owner_signer)
+        .connect_http(anvil.endpoint_url());
+
+    provider
+        .anvil_set_balance(owner, U256::from(10).pow(U256::from(18)))
+        .await
+        .expect("Failed to set balance");
+
+    let safe_address = deploy_safe(&provider, owner, U256::ZERO)
+        .await
+        .expect("Failed to deploy Safe");
+
+    let safe_contract = ISafe::new(safe_address, &provider);
+
+    let message = "Hello from Safe integration test!";
+    let chain_id = 10; // Note: This is not World Chain, verification will fail
+
+    let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())
+        .expect("Failed to create SafeSmartAccount");
+
+    let signature = safe_account
+        .personal_sign(chain_id, message.to_string())
+        .expect("Failed to sign message")
+        .to_hex_string();
+
+    let sig_bytes = hex::decode(&signature[2..]).expect("Failed to decode signature");
+
+    let message_hash = keccak256(
+        format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message)
+            .as_bytes(),
+    );
+
+    let is_valid_result = safe_contract
+        .isValidSignature(message_hash, Bytes::from(sig_bytes))
+        .call()
+        .await
+        .unwrap_err();
+
+    match is_valid_result {
+        alloy::contract::Error::TransportError(e) => {
+            // https://github.com/safe-global/safe-smart-account/blob/v1.4.1/docs/error_codes.md?plain=1#L21
+            assert_eq!(
+                e.as_error_resp().unwrap().message,
+                "execution reverted: GS026"
+            );
+        }
+        _ => panic!("Expected TransportError error, got {:?}", is_valid_result),
+    }
+}
+
+/// Ensures signature verification fails if the message wasn't signed for the correct EIP-191 prefix
+#[tokio::test]
+async fn test_integration_personal_sign_failure_on_incorrect_eip_191_prefix() {
+    let anvil = setup_anvil();
+    let owner_signer = PrivateKeySigner::random();
+
+    let owner_key_hex = hex::encode(owner_signer.to_bytes());
+
+    let owner = owner_signer.address();
+
+    let provider = ProviderBuilder::new()
+        .wallet(owner_signer)
+        .connect_http(anvil.endpoint_url());
+
+    provider
+        .anvil_set_balance(owner, U256::from(10).pow(U256::from(18)))
+        .await
+        .expect("Failed to set balance");
+
+    let safe_address = deploy_safe(&provider, owner, U256::ZERO)
+        .await
+        .expect("Failed to deploy Safe");
+
+    let safe_contract = ISafe::new(safe_address, &provider);
+
+    let message = "Hello from Safe integration test!";
+    let chain_id = 480;
+
+    let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())
+        .expect("Failed to create SafeSmartAccount");
+
+    let signature = safe_account
+        .personal_sign(chain_id, message.to_string())
+        .expect("Failed to sign message")
+        .to_hex_string();
+
+    let sig_bytes = hex::decode(&signature[2..]).expect("Failed to decode signature");
+
+    // Note the omission of the EIP-191 prefix
+    let message_hash = keccak256(message.as_bytes());
+
+    let is_valid_result = safe_contract
+        .isValidSignature(message_hash, Bytes::from(sig_bytes))
+        .call()
+        .await
+        .unwrap_err();
+
+    match is_valid_result {
+        alloy::contract::Error::TransportError(e) => {
+            // https://github.com/safe-global/safe-smart-account/blob/v1.4.1/docs/error_codes.md?plain=1#L21
+            assert_eq!(
+                e.as_error_resp().unwrap().message,
+                "execution reverted: GS026"
+            );
+        }
+        _ => panic!("Expected TransportError error, got {:?}", is_valid_result),
+    }
+}
+
 /// Integration test for the encoding, signing and execution of a 4337 transaction.
 ///
 /// This test deploys two Safe Smart Accounts, and transfers 1 ETH from Safe 1 to Safe 2 using a 4337 transaction.
@@ -385,4 +507,140 @@ async fn test_integration_erc4337_transaction_execution() -> anyhow::Result<()> 
         "Native ETH transfer did not succeed"
     );
     Ok(())
+}
+
+#[tokio::test]
+async fn test_integration_sign_typed_data() {
+    let anvil = setup_anvil();
+    let owner_signer = PrivateKeySigner::random();
+
+    let owner_key_hex = hex::encode(owner_signer.to_bytes());
+
+    let owner = owner_signer.address();
+
+    let provider = ProviderBuilder::new()
+        .wallet(owner_signer)
+        .connect_http(anvil.endpoint_url());
+
+    provider
+        .anvil_set_balance(owner, U256::from(10).pow(U256::from(18)))
+        .await
+        .expect("Failed to set balance");
+
+    println!("✓ Using owner address: {}", owner);
+
+    // Deploy a Safe
+    let safe_address = deploy_safe(&provider, owner, U256::ZERO)
+        .await
+        .expect("Failed to deploy Safe");
+
+    let safe_contract = ISafe::new(safe_address, &provider);
+
+    let typed_data = json!({
+         "types":{
+            "EIP712Domain":[
+               {
+                  "name":"name",
+                  "type":"string"
+               },
+               {
+                  "name":"version",
+                  "type":"string"
+               },
+               {
+                  "name":"chainId",
+                  "type":"uint256"
+               },
+               {
+                  "name":"verifyingContract",
+                  "type":"address"
+               }
+            ],
+            "Person":[
+               {
+                  "name":"name",
+                  "type":"string"
+               },
+               {
+                  "name":"wallet",
+                  "type":"address"
+               }
+            ],
+            "Mail":[
+               {
+                  "name":"from",
+                  "type":"Person"
+               },
+               {
+                  "name":"to",
+                  "type":"Person"
+               },
+               {
+                  "name":"contents",
+                  "type":"string"
+               }
+            ]
+         },
+         "primaryType":"Mail",
+         "domain":{
+            "name":"Ether Mail",
+            "version":"1",
+            "chainId":1,
+            "verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+         },
+         "message":{
+            "from":{
+               "name":"Cow",
+               "wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            "to":{
+               "name":"Bob",
+               "wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            "contents":"Hello, Bob!"
+         }
+    });
+
+    let chain_id = 480;
+
+    let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())
+        .expect("Failed to create SafeSmartAccount");
+
+    let signature = safe_account
+        .sign_typed_data(chain_id, &typed_data.to_string())
+        .expect("Failed to sign message");
+
+    let signature = signature.as_str();
+
+    assert_eq!(signature.len(), 132, "Invalid signature length");
+    assert!(
+        signature.starts_with("0x"),
+        "Signature should start with 0x"
+    );
+
+    let sig_bytes = hex::decode(&signature[2..]).expect("Failed to decode signature");
+    assert_eq!(sig_bytes.len(), 65, "Signature should be 65 bytes");
+
+    let message: TypedData = serde_json::from_str(&typed_data.to_string())
+        .expect("Failed to parse typed data");
+    let message_hash = message
+        .eip712_signing_hash()
+        .expect("Failed to calculate EIP-712 signing hash");
+
+    let is_valid_result = safe_contract
+        .isValidSignature(message_hash, Bytes::from(sig_bytes))
+        .call()
+        .await
+        .expect("Failed to call isValidSignature");
+
+    const EIP1271_MAGIC_VALUE: [u8; 4] = [0x16, 0x26, 0xba, 0x7e];
+    let expected_signature =
+        alloy::primitives::FixedBytes::<4>::from(EIP1271_MAGIC_VALUE);
+
+    assert_eq!(
+        is_valid_result, expected_signature,
+        "Signature verification failed on-chain"
+    );
+
+    println!("✓ Signature validation for EIP-712 typed datapassed");
 }


### PR DESCRIPTION
### Changes
1. Introduces `sign_typed_data` method which allows a Safe Smart Account to sign arbitrary EIP-712 typed data (with relevant unit and functional tests). Note tests don't cover the correct hashing of typed data as this is already part of Alloy.
2. Introduces failure integration tests for signing where the correct EIP-191 prefix is not added or the incorrect chain is specified.