### PR TITLE
feat: add x86_64‑linux‑android target

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -143,6 +143,7 @@ jobs:
         settings:
           - target: aarch64-linux-android
           - target: armv7-linux-androideabi
+          - target: x86_64‑linux‑android
 
     steps:
       - name: Checkout code
@@ -198,9 +199,10 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir -p kotlin/bedrock-android/src/main/jniLibs && cd kotlin/bedrock-android/src/main/jniLibs
-          mkdir armeabi-v7a arm64-v8a
-          mv /home/runner/work/bedrock/bedrock/android-armv7-linux-androideabi/libbedrock.so ./armeabi-v7a/libbedrock.so
+          mkdir armeabi-v7a arm64-v8a x86_64
           mv /home/runner/work/bedrock/bedrock/android-aarch64-linux-android/libbedrock.so ./arm64-v8a/libbedrock.so
+          mv /home/runner/work/bedrock/bedrock/android-armv7-linux-androideabi/libbedrock.so ./armeabi-v7a/libbedrock.so
+          mv /home/runner/work/bedrock/bedrock/android-x86_64-linux-android/libbedrock.so ./x86_64/libbedrock.so
 
       - name: Generate bindings
         working-directory: kotlin

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,12 +3,13 @@ channel = "stable"
 profile = "default"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = [
+    # iOS
     "aarch64-apple-ios-sim",
     "aarch64-apple-ios",
     "x86_64-apple-ios",
-    "x86_64-unknown-linux-gnu",
-    # 32‑bit ARM (for device support on old devices, <1% active installs)
-    "armv7-linux-androideabi",
-    # 64-bit
-    "aarch64-linux-android"
+
+    # Android
+    "armv7-linux-androideabi", # 32‑bit ARM (for device support on old devices, <1% active installs)
+    "x86_64‑linux‑android", # required by Play Store for desktop
+    "aarch64-linux-android" # 64-bit
 ]


### PR DESCRIPTION
Play Store requires the x86_64 for the lab testing (e.g. on "Android 12L (SDK 32)")