### PR TITLE
fix: rust target typo

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -143,7 +143,7 @@ jobs:
         settings:
           - target: aarch64-linux-android
           - target: armv7-linux-androideabi
-          - target: x86_64‑linux‑android
+          - target: x86_64-linux-android
 
     steps:
       - name: Checkout code

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,6 +10,6 @@ targets = [
 
     # Android
     "armv7-linux-androideabi", # 32‑bit ARM (for device support on old devices, <1% active installs)
-    "x86_64‑linux‑android", # required by Play Store for desktop
+    "x86_64-linux-android", # required by Play Store for desktop
     "aarch64-linux-android" # 64-bit
 ]


### PR DESCRIPTION
where on earth did that fake hyphen came from?