### PR TITLE
fix: test `odd number of digits` -> `Odd number of digits`

### DIFF
--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -632,7 +632,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("invalid input on permitted.token: odd number of digits")
+            format!("invalid input on permitted.token: Odd number of digits")
         );
     }
 


### PR DESCRIPTION
Fixes failing test ie: https://github.com/worldcoin/bedrock/actions/runs/16231232954/job/45834306015