### PR TITLE
feat: add http header support to AuthenticatedClient

### DIFF
--- a/bedrock/src/primitives/http_client.rs
+++ b/bedrock/src/primitives/http_client.rs
@@ -27,6 +27,7 @@ pub trait AuthenticatedHttpClient: Send + Sync {
     /// # Arguments
     /// * `url` - The URL to fetch data from
     /// * `method` - The HTTP method to use for the request
+    /// * `headers` - Additional headers to include in the request
     /// * `body` - Optional request body data for POST requests
     ///
     /// # Returns
@@ -45,6 +46,7 @@ pub trait AuthenticatedHttpClient: Send + Sync {
         &self,
         url: String,
         method: HttpMethod,
+        headers: Vec<HttpHeader>,
         body: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, HttpError>;
 }
@@ -56,6 +58,15 @@ pub enum HttpMethod {
     Get,
     /// HTTP POST method for sending data
     Post,
+}
+
+/// Simple name/value HTTP header pair for passing additional headers
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct HttpHeader {
+    /// Header name (case-insensitive per RFC)
+    pub name: String,
+    /// Header value
+    pub value: String,
 }
 
 /// Represents HTTP-related errors that can occur during network requests.
@@ -205,6 +216,7 @@ mod tests {
             &self,
             _url: String,
             _method: HttpMethod,
+            _headers: Vec<HttpHeader>,
             _body: Option<Vec<u8>>,
         ) -> Result<Vec<u8>, HttpError> {
             Ok(b"mock response".to_vec())

--- a/bedrock/src/transaction/rpc.rs
+++ b/bedrock/src/transaction/rpc.rs
@@ -5,7 +5,7 @@
 //! - Submit signed `UserOperations` via `eth_sendUserOperation`
 
 use crate::{
-    primitives::http_client::get_http_client,
+    primitives::http_client::{get_http_client, HttpHeader},
     primitives::{
         AuthenticatedHttpClient, HttpError, HttpMethod, Network, PrimitiveError,
     },
@@ -201,12 +201,20 @@ impl RpcClient {
             serde_json::to_vec(&request).map_err(|_| RpcError::JsonError)?;
 
         // Send the HTTP request
+        // Build additional headers Bedrock wants to send via the app's HTTP client
+        let provider_name = "alchemy";
+        let headers = vec![HttpHeader {
+            name: "provider-name".to_string(),
+            value: provider_name.to_string(),
+        }];
+
         let response_bytes = self
             .http_client
             .as_ref()
             .fetch_from_app_backend(
                 Self::rpc_endpoint(network),
                 HttpMethod::Post,
+                headers,
                 Some(request_body),
             )
             .await?;


### PR DESCRIPTION
* Added a new `HttpHeader` struct for name/value pairs.
* Updated `AuthenticatedHttpClient` trait to include a `headers` parameter in the `fetch_from_app_backend` method.