### PR TITLE
chore: move contract definitions to primitives

### DIFF
--- a/bedrock/src/primitives/contracts.rs
+++ b/bedrock/src/primitives/contracts.rs
@@ -1,11 +1,11 @@
+use crate::primitives::{HttpError, PrimitiveError};
+use crate::transaction::rpc::SponsorUserOperationResponse;
+use alloy::hex::FromHex;
+use alloy::primitives::{aliases::U48, keccak256, Address, Bytes, FixedBytes};
 use alloy::sol;
-use alloy::primitives::{Address, Bytes, FixedBytes, keccak256, aliases::U48};
 use alloy::sol_types::SolValue;
 use ruint::aliases::U256;
 use std::{str::FromStr, sync::LazyLock};
-use crate::primitives::{PrimitiveError, HttpError};
-use crate::transaction::rpc::SponsorUserOperationResponse;
-use alloy::hex::FromHex;
 
 /// <https://github.com/safe-global/safe-modules/blob/4337/v0.3.0/modules/4337/contracts/Safe4337Module.sol#L53>
 static SAFE_OP_TYPEHASH: LazyLock<FixedBytes<32>> = LazyLock::new(|| {

--- a/bedrock/src/primitives/contracts.rs
+++ b/bedrock/src/primitives/contracts.rs
@@ -1,0 +1,361 @@
+use alloy::sol;
+use alloy::primitives::{Address, Bytes, FixedBytes, keccak256, aliases::U48};
+use alloy::sol_types::SolValue;
+use ruint::aliases::U256;
+use std::{str::FromStr, sync::LazyLock};
+use crate::primitives::{PrimitiveError, HttpError};
+use crate::transaction::rpc::SponsorUserOperationResponse;
+use alloy::hex::FromHex;
+
+/// <https://github.com/safe-global/safe-modules/blob/4337/v0.3.0/modules/4337/contracts/Safe4337Module.sol#L53>
+static SAFE_OP_TYPEHASH: LazyLock<FixedBytes<32>> = LazyLock::new(|| {
+    FixedBytes::from_hex(
+        "0xc03dfc11d8b10bf9cf703d558958c8c42777f785d998c62060d85a4f0ef6ea7f",
+    )
+    .expect("error initializing `SAFE_OP_TYPEHASH`")
+});
+
+/// v0.7 `EntryPoint`
+pub static ENTRYPOINT_4337: LazyLock<Address> = LazyLock::new(|| {
+    Address::from_str("0x0000000071727De22E5E9d8BAf0edAc6f37da032")
+        .expect("failed to decode ENTRYPOINT_4337")
+});
+
+/// Multichain address for the v0.3.0 `Safe4337Module`
+pub static GNOSIS_SAFE_4337_MODULE: LazyLock<Address> = LazyLock::new(|| {
+    Address::from_str("0x75cf11467937ce3f2f357ce24ffc3dbf8fd5c226")
+        .expect("failed to decode GNOSIS_SAFE_4337_MODULE")
+});
+
+/// The length of a 4337 `UserOperation` signature.
+///
+/// This is the length of a regular ECDSA signature with r,s,v (32 + 32 + 1 = 65 bytes) + 12 bytes for the validity timestamps.
+const USER_OPERATION_SIGNATURE_LENGTH: usize = 77;
+
+// --- JSON serialization helpers for ERC-4337 ---
+
+fn serialize_u128_as_hex<S: serde::Serializer>(
+    value: &u128,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    // Always hex with 0x prefix per spec
+    let s = format!("0x{value:x}");
+    serializer.serialize_str(&s)
+}
+
+fn serialize_u256_as_hex<S: serde::Serializer>(
+    value: &U256,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let s = format!("0x{value:x}");
+    serializer.serialize_str(&s)
+}
+
+sol! {
+
+    /// Interface for the `Safe4337Module` contract.
+    ///
+    /// Reference: <https://github.com/safe-global/safe-modules/blob/4337/v0.3.0/modules/4337/contracts/Safe4337Module.sol#L172>
+    #[sol(all_derives)]
+    interface ISafe4337Module {
+        function executeUserOp(address to, uint256 value, bytes calldata data, uint8 operation) external;
+    }
+
+    /// The structure of a generic 4337 `UserOperation`.
+    ///
+    /// `UserOperation`s are not used on-chain, they are used by RPCs to bundle transactions as `PackedUserOperation`s.
+    ///
+    /// For the flow of World App:
+    /// - A `UserOperation` is created by the user and passed to the World App RPC to request sponsorship through the `wa_sponsorUserOperation` method.
+    /// - The final signed `UserOperation` is then passed to the World App RPC to be executed through the standard `eth_sendUserOperation` method.
+    ///
+    /// Reference: <https://eips.ethereum.org/EIPS/eip-4337#useroperation>
+    #[sol(rename_all = "camelcase")]
+    #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct UserOperation {
+        /// The Account making the `UserOperation`
+        address sender;
+        /// Anti-replay protection
+        #[serde(serialize_with = "serialize_u256_as_hex")]
+        uint256 nonce;
+        /// Account Factory for new Accounts OR `0x7702` flag for EIP-7702 Accounts, otherwise address(0)
+        address factory;
+        /// Data for the Account Factory if factory is provided OR EIP-7702 initialization data, or empty array
+        bytes factory_data;
+        /// The data to pass to the sender during the main execution call
+        bytes call_data;
+        /// Gas limit for the main execution call.
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 call_gas_limit;
+        /// Gas limit for the verification call
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 verification_gas_limit;
+        /// Extra gas to pay the bundler
+        #[serde(serialize_with = "serialize_u256_as_hex")]
+        uint256 pre_verification_gas;
+        /// Maximum fee per gas (similar to [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_fee_per_gas`)
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 max_fee_per_gas;
+        /// Maximum priority fee per gas (similar to [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas`)
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 max_priority_fee_per_gas;
+        /// Address of paymaster contract, (or empty, if the sender pays for gas by itself)
+        address paymaster;
+        /// The amount of gas to allocate for the paymaster validation code (only if paymaster exists)
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is expected as `uint128` for `paymasterAndData` validation.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 paymaster_verification_gas_limit;
+        /// The amount of gas to allocate for the paymaster post-operation code (only if paymaster exists)
+        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is expected as `uint128` for `paymasterAndData` validation.
+        #[serde(serialize_with = "serialize_u128_as_hex")]
+        uint128 paymaster_post_op_gas_limit;
+        /// Data for paymaster (only if paymaster exists)
+        bytes paymaster_data;
+        /// Data passed into the sender to verify authorization
+        bytes signature;
+    }
+
+    /// The EIP-712 type-hash for a `SafeOp`, representing the structure of a User Operation for the Safe.
+    ///
+    /// Reference: <https://eips.ethereum.org/EIPS/eip-4337#useroperation>
+    #[sol(rename_all = "camelcase")]
+    struct EncodedSafeOpStruct {
+        bytes32 type_hash;
+        address safe;
+        uint256 nonce;
+        bytes32 init_code_hash;
+        bytes32 call_data_hash;
+        uint128 verification_gas_limit;
+        uint128 call_gas_limit;
+        uint256 pre_verification_gas;
+        uint128 max_priority_fee_per_gas;
+        uint128 max_fee_per_gas;
+        bytes32 paymaster_and_data_hash;
+        uint48 valid_after;
+        uint48 valid_until;
+        address entry_point;
+    }
+}
+
+impl UserOperation {
+    /// Initializes a new `UserOperation` with default values.
+    ///
+    /// In particular, it sets default values for gas limits & fees, paymaster and sets a dummy signature.
+    pub fn new_with_defaults(sender: Address, nonce: U256, call_data: Bytes) -> Self {
+        Self {
+            sender,
+            nonce,
+            call_data,
+            signature: vec![0xff; USER_OPERATION_SIGNATURE_LENGTH].into(),
+            ..Default::default()
+        }
+    }
+
+    /// Gathers the factory+factoryData as `initCode`.
+    pub fn get_init_code(&self) -> Bytes {
+        // Check if `factory` is present
+        if self.factory.is_zero() {
+            return Bytes::new();
+        }
+
+        let mut out = Vec::new();
+        out.extend_from_slice(self.factory.as_slice());
+        out.extend_from_slice(&self.factory_data);
+        out.into()
+    }
+
+    /// Extract `validAfter` and `validUntil` from a signature as `U256` values.
+    ///
+    /// Expects at least 12 bytes additional bytes in the signature.
+    ///
+    /// # Errors
+    /// - Returns an error if the signature is too short.
+    pub fn extract_validity_timestamps(&self) -> Result<(U48, U48), PrimitiveError> {
+        // timestamp validity (12 bytes) + regular ECDSA signature (65 bytes)
+        if self.signature.len() != 77 {
+            return Err(PrimitiveError::InvalidInput {
+                attribute: "signature",
+                message: "signature does not have the correct length (77 bytes)"
+                    .to_string(),
+            });
+        }
+
+        let mut valid_after = [0u8; 6];
+        let mut valid_until = [0u8; 6];
+
+        valid_after.copy_from_slice(&self.signature[0..6]);
+        valid_until.copy_from_slice(&self.signature[6..12]);
+
+        // Extract 6-byte validAfter and validUntil slices and convert them to U256
+        let valid_after = U48::from_be_bytes(valid_after);
+        let valid_until = U48::from_be_bytes(valid_until);
+
+        Ok((valid_after, valid_until))
+    }
+
+    /// Merges all paymaster related data into a single `paymasterAndData` attribute.
+    pub fn get_paymaster_and_data(&self) -> Bytes {
+        if self.paymaster.is_zero() {
+            return Bytes::new();
+        }
+
+        let mut out = Vec::new();
+        // Append paymaster address (20 bytes)
+        out.extend_from_slice(self.paymaster.as_slice());
+
+        // Append paymasterVerificationGasLimit (16 bytes)
+        out.extend_from_slice(&self.paymaster_verification_gas_limit.to_be_bytes());
+
+        // Append paymasterPostOpGasLimit (16 bytes)
+        out.extend_from_slice(&self.paymaster_post_op_gas_limit.to_be_bytes());
+
+        // Append paymasterData if it exists
+        if !self.paymaster_data.is_empty() {
+            out.extend_from_slice(&self.paymaster_data);
+        }
+
+        out.into()
+    }
+
+    /// Merges paymaster data from sponsorship response into the `UserOperation`
+    ///
+    /// # Errors
+    /// Returns an error if any U128 to u128 conversion fails
+    pub fn with_paymaster_data(
+        mut self,
+        sponsor_response: SponsorUserOperationResponse,
+    ) -> Result<Self, HttpError> {
+        self.paymaster = sponsor_response.paymaster;
+        self.paymaster_data = sponsor_response.paymaster_data;
+        self.paymaster_verification_gas_limit = sponsor_response
+            .paymaster_verification_gas_limit
+            .try_into()
+            .unwrap_or(0);
+        self.paymaster_post_op_gas_limit = sponsor_response
+            .paymaster_post_op_gas_limit
+            .try_into()
+            .unwrap_or(0);
+
+        // Update gas fields if they were estimated by the RPC
+        if self.pre_verification_gas.is_zero() {
+            self.pre_verification_gas = sponsor_response.pre_verification_gas;
+        }
+        if self.verification_gas_limit == 0 {
+            self.verification_gas_limit = sponsor_response
+                .verification_gas_limit
+                .try_into()
+                .unwrap_or(0);
+        }
+        if self.call_gas_limit == 0 {
+            self.call_gas_limit =
+                sponsor_response.call_gas_limit.try_into().unwrap_or(0);
+        }
+        if self.max_fee_per_gas == 0 {
+            self.max_fee_per_gas =
+                sponsor_response.max_fee_per_gas.try_into().unwrap_or(0);
+        }
+        if self.max_priority_fee_per_gas == 0 {
+            self.max_priority_fee_per_gas = sponsor_response
+                .max_priority_fee_per_gas
+                .try_into()
+                .unwrap_or(0);
+        }
+
+        Ok(self)
+    }
+}
+
+impl EncodedSafeOpStruct {
+    /// Builds an `EncodedSafeOpStruct` from a `UserOperation`, injecting explicit validity timestamps.
+    ///
+    /// # Errors
+    /// Returns `PrimitiveError` if hashing or conversions fail when deriving fields
+    /// from the provided `user_op`. Currently this can occur if internal helpers
+    /// on `user_op` return invalid data for hashing.
+    pub fn from_user_op_with_validity(
+        user_op: &UserOperation,
+        valid_after: U48,
+        valid_until: U48,
+    ) -> Result<Self, PrimitiveError> {
+        Ok(Self {
+            type_hash: *SAFE_OP_TYPEHASH,
+            safe: user_op.sender,
+            nonce: user_op.nonce,
+            init_code_hash: keccak256(user_op.get_init_code()),
+            call_data_hash: keccak256(&user_op.call_data),
+            verification_gas_limit: user_op.verification_gas_limit,
+            call_gas_limit: user_op.call_gas_limit,
+            pre_verification_gas: user_op.pre_verification_gas,
+            max_priority_fee_per_gas: user_op.max_priority_fee_per_gas,
+            max_fee_per_gas: user_op.max_fee_per_gas,
+            paymaster_and_data_hash: keccak256(user_op.get_paymaster_and_data()),
+            valid_after,
+            valid_until,
+            entry_point: *ENTRYPOINT_4337,
+        })
+    }
+
+    /// computes the hash of the userOp
+    #[must_use]
+    pub fn into_transaction_hash(self) -> FixedBytes<32> {
+        keccak256(self.abi_encode())
+    }
+}
+
+sol! {
+    contract IMulticall3 {
+        #[derive(Default)]
+        struct Call3 {
+            address target;
+            bool allowFailure;
+            bytes callData;
+        }
+    }
+
+    contract IEntryPoint {
+        #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
+        struct PackedUserOperation {
+            address sender;
+            uint256 nonce;
+            bytes initCode;
+            bytes callData;
+            bytes32 accountGasLimits;
+            uint256 preVerificationGas;
+            bytes32 gasFees;
+            bytes paymasterAndData;
+            bytes signature;
+        }
+
+        #[derive(Default)]
+        struct UserOpsPerAggregator {
+            PackedUserOperation[] userOps;
+            address aggregator;
+            bytes signature;
+        }
+    }
+
+    contract IPBHEntryPoint {
+        #[derive(Default)]
+        struct PBHPayload {
+            uint256 root;
+            uint256 pbhExternalNullifier;
+            uint256 nullifierHash;
+            uint256[8] proof;
+        }
+
+        function handleAggregatedOps(
+            IEntryPoint.UserOpsPerAggregator[] calldata,
+            address payable
+        ) external;
+
+        function pbhMulticall(
+            IMulticall3.Call3[] calls,
+            PBHPayload payload,
+        ) external;
+    }
+}

--- a/bedrock/src/primitives/mod.rs
+++ b/bedrock/src/primitives/mod.rs
@@ -59,6 +59,9 @@ pub mod http_client;
 #[cfg(feature = "tooling_tests")]
 pub mod tooling_tests;
 
+/// Contract interfaces and data structures for ERC-4337 account abstraction
+pub mod contracts;
+
 /// Supported blockchain networks for Bedrock operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 #[repr(u32)]

--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -33,7 +33,8 @@ mod transaction;
 mod permit2;
 
 pub use crate::primitives::contracts::{
-    EncodedSafeOpStruct, UserOperation, ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE, ISafe4337Module,
+    EncodedSafeOpStruct, ISafe4337Module, UserOperation, ENTRYPOINT_4337,
+    GNOSIS_SAFE_4337_MODULE,
 };
 
 pub use nonce::{InstructionFlag, NonceKeyV1, TransactionTypeId};

--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -6,7 +6,7 @@ use alloy::{
     signers::{k256::ecdsa::SigningKey, local::LocalSigner},
 };
 pub use signer::SafeSmartAccountSigner;
-pub use transaction_4337::{ISafe4337Module, Is4337Encodable};
+pub use transaction_4337::Is4337Encodable;
 
 #[cfg(any(test, doc))]
 use crate::primitives::Network;
@@ -32,8 +32,8 @@ mod transaction;
 /// Reference: <https://docs.uniswap.org/contracts/permit2/overview>
 mod permit2;
 
-pub use transaction_4337::{
-    EncodedSafeOpStruct, UserOperation, ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE,
+pub use crate::primitives::contracts::{
+    EncodedSafeOpStruct, UserOperation, ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE, ISafe4337Module,
 };
 
 pub use nonce::{InstructionFlag, NonceKeyV1, TransactionTypeId};

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -3,14 +3,12 @@
 //! A transaction can be initialized through a `UserOperation` struct.
 //!
 
+use crate::primitives::contracts::{EncodedSafeOpStruct, UserOperation};
 use crate::primitives::{Network, PrimitiveError};
-use crate::primitives::contracts::{UserOperation, EncodedSafeOpStruct};
 use crate::smart_account::SafeSmartAccountSigner;
 use crate::transaction::rpc::{RpcError, SponsorUserOperationResponse};
 
-use alloy::{
-    primitives::{aliases::U48, Address, Bytes, FixedBytes},
-};
+use alloy::primitives::{aliases::U48, Address, Bytes, FixedBytes};
 use chrono::{Duration, Utc};
 
 use crate::primitives::contracts::{ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE};
@@ -74,7 +72,6 @@ pub trait Is4337Encodable {
         safe_account: &crate::smart_account::SafeSmartAccount,
         self_sponsor_token: Option<Address>,
         metadata: Option<Self::MetadataArg>,
-        _pbh: bool
     ) -> Result<FixedBytes<32>, RpcError> {
         // Get the global RPC client
         let rpc_client = crate::transaction::rpc::get_rpc_client()?;
@@ -138,32 +135,6 @@ pub trait Is4337Encodable {
 
         Ok(user_op_hash)
     }
-
-
-    /// Generates a Privacy-Preserving Biometric Hash (PBH) proof for account abstraction transactions.
-    ///
-    /// This function is intended to create cryptographic proofs that verify human uniqueness
-    /// without revealing biometric data, as part of the Person Bound Transactions (PBT) system.
-    ///
-    /// # Returns
-    /// * `Result<Bytes, PrimitiveError>` - The generated PBH proof bytes on success
-    ///
-    /// # Errors
-    /// * Returns `PrimitiveError` if proof generation fails
-    ///
-    /// # Note
-    /// This is currently unimplemented and will return a todo!() error.
-    fn generate_pbh_proof() -> Result<Bytes, PrimitiveError> {
-        todo!("PBH proof generation not yet implemented")
-    }
-    
-    // pub fn hash_user_op(user_op: &PackedUserOperation) -> Field {
-    //     let hash = SolValue::abi_encode_packed(&(&user_op.sender, &user_op.nonce, &user_op.callData));
-
-    //     hash_to_field(hash.as_slice())
-    // }
-
-
 }
 
 #[cfg(test)]

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -3,46 +3,17 @@
 //! A transaction can be initialized through a `UserOperation` struct.
 //!
 
-use crate::primitives::{HttpError, Network, PrimitiveError};
+use crate::primitives::{Network, PrimitiveError};
+use crate::primitives::contracts::{UserOperation, EncodedSafeOpStruct};
 use crate::smart_account::SafeSmartAccountSigner;
 use crate::transaction::rpc::{RpcError, SponsorUserOperationResponse};
 
-use alloy::hex::FromHex;
 use alloy::{
-    primitives::{aliases::U48, keccak256, Address, Bytes, FixedBytes},
-    sol,
-    sol_types::SolValue,
+    primitives::{aliases::U48, Address, Bytes, FixedBytes},
 };
 use chrono::{Duration, Utc};
-use ruint::aliases::U256;
-use std::{str::FromStr, sync::LazyLock};
 
-use serde::Serializer;
-
-/// <https://github.com/safe-global/safe-modules/blob/4337/v0.3.0/modules/4337/contracts/Safe4337Module.sol#L53>
-static SAFE_OP_TYPEHASH: LazyLock<FixedBytes<32>> = LazyLock::new(|| {
-    FixedBytes::from_hex(
-        "0xc03dfc11d8b10bf9cf703d558958c8c42777f785d998c62060d85a4f0ef6ea7f",
-    )
-    .expect("error initializing `SAFE_OP_TYPEHASH`")
-});
-
-/// v0.7 `EntryPoint`
-pub static ENTRYPOINT_4337: LazyLock<Address> = LazyLock::new(|| {
-    Address::from_str("0x0000000071727De22E5E9d8BAf0edAc6f37da032")
-        .expect("failed to decode ENTRYPOINT_4337")
-});
-
-/// Multichain address for the v0.3.0 `Safe4337Module`
-pub static GNOSIS_SAFE_4337_MODULE: LazyLock<Address> = LazyLock::new(|| {
-    Address::from_str("0x75cf11467937ce3f2f357ce24ffc3dbf8fd5c226")
-        .expect("failed to decode GNOSIS_SAFE_4337_MODULE")
-});
-
-/// The length of a 4337 `UserOperation` signature.
-///
-/// This is the length of a regular ECDSA signature with r,s,v (32 + 32 + 1 = 65 bytes) + 12 bytes for the validity timestamps.
-const USER_OPERATION_SIGNATURE_LENGTH: usize = 77;
+use crate::primitives::contracts::{ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE};
 
 /// The default validity duration for 4337 `UserOperation` signatures.
 ///
@@ -103,6 +74,7 @@ pub trait Is4337Encodable {
         safe_account: &crate::smart_account::SafeSmartAccount,
         self_sponsor_token: Option<Address>,
         metadata: Option<Self::MetadataArg>,
+        _pbh: bool
     ) -> Result<FixedBytes<32>, RpcError> {
         // Get the global RPC client
         let rpc_client = crate::transaction::rpc::get_rpc_client()?;
@@ -166,285 +138,39 @@ pub trait Is4337Encodable {
 
         Ok(user_op_hash)
     }
-}
 
-sol! {
 
-    /// Interface for the `Safe4337Module` contract.
+    /// Generates a Privacy-Preserving Biometric Hash (PBH) proof for account abstraction transactions.
     ///
-    /// Reference: <https://github.com/safe-global/safe-modules/blob/4337/v0.3.0/modules/4337/contracts/Safe4337Module.sol#L172>
-    interface ISafe4337Module {
-        function executeUserOp(address to, uint256 value, bytes calldata data, uint8 operation) external;
-    }
-
-    /// The structure of a generic 4337 `UserOperation`.
+    /// This function is intended to create cryptographic proofs that verify human uniqueness
+    /// without revealing biometric data, as part of the Person Bound Transactions (PBT) system.
     ///
-    /// `UserOperation`s are not used on-chain, they are used by RPCs to bundle transactions as `PackedUserOperation`s.
-    ///
-    /// For the flow of World App:
-    /// - A `UserOperation` is created by the user and passed to the World App RPC to request sponsorship through the `wa_sponsorUserOperation` method.
-    /// - The final signed `UserOperation` is then passed to the World App RPC to be executed through the standard `eth_sendUserOperation` method.
-    ///
-    /// Reference: <https://eips.ethereum.org/EIPS/eip-4337#useroperation>
-    #[sol(rename_all = "camelcase")]
-    #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct UserOperation {
-        /// The Account making the `UserOperation`
-        address sender;
-        /// Anti-replay protection
-        #[serde(serialize_with = "serialize_u256_as_hex")]
-        uint256 nonce;
-        /// Account Factory for new Accounts OR `0x7702` flag for EIP-7702 Accounts, otherwise address(0)
-        address factory;
-        /// Data for the Account Factory if factory is provided OR EIP-7702 initialization data, or empty array
-        bytes factory_data;
-        /// The data to pass to the sender during the main execution call
-        bytes call_data;
-        /// Gas limit for the main execution call.
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 call_gas_limit;
-        /// Gas limit for the verification call
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 verification_gas_limit;
-        /// Extra gas to pay the bundler
-        #[serde(serialize_with = "serialize_u256_as_hex")]
-        uint256 pre_verification_gas;
-        /// Maximum fee per gas (similar to [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_fee_per_gas`)
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 max_fee_per_gas;
-        /// Maximum priority fee per gas (similar to [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas`)
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is `uint128`. We enforce `uint128` to avoid overflows.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 max_priority_fee_per_gas;
-        /// Address of paymaster contract, (or empty, if the sender pays for gas by itself)
-        address paymaster;
-        /// The amount of gas to allocate for the paymaster validation code (only if paymaster exists)
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is expected as `uint128` for `paymasterAndData` validation.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 paymaster_verification_gas_limit;
-        /// The amount of gas to allocate for the paymaster post-operation code (only if paymaster exists)
-        /// Even though the type is `uint256`, in the `Safe4337Module` (see `EncodedSafeOpStruct`), it is expected as `uint128` for `paymasterAndData` validation.
-        #[serde(serialize_with = "serialize_u128_as_hex")]
-        uint128 paymaster_post_op_gas_limit;
-        /// Data for paymaster (only if paymaster exists)
-        bytes paymaster_data;
-        /// Data passed into the sender to verify authorization
-        bytes signature;
-    }
-
-    /// The EIP-712 type-hash for a `SafeOp`, representing the structure of a User Operation for the Safe.
-    ///
-    /// Reference: <https://eips.ethereum.org/EIPS/eip-4337#useroperation>
-    #[sol(rename_all = "camelcase")]
-    struct EncodedSafeOpStruct {
-        bytes32 type_hash;
-        address safe;
-        uint256 nonce;
-        bytes32 init_code_hash;
-        bytes32 call_data_hash;
-        uint128 verification_gas_limit;
-        uint128 call_gas_limit;
-        uint256 pre_verification_gas;
-        uint128 max_priority_fee_per_gas;
-        uint128 max_fee_per_gas;
-        bytes32 paymaster_and_data_hash;
-        uint48 valid_after;
-        uint48 valid_until;
-        address entry_point;
-    }
-}
-
-impl UserOperation {
-    /// Initializes a new `UserOperation` with default values.
-    ///
-    /// In particular, it sets default values for gas limits & fees, paymaster and sets a dummy signature.
-    pub fn new_with_defaults(sender: Address, nonce: U256, call_data: Bytes) -> Self {
-        Self {
-            sender,
-            nonce,
-            call_data,
-            signature: vec![0xff; USER_OPERATION_SIGNATURE_LENGTH].into(),
-            ..Default::default()
-        }
-    }
-
-    /// Gathers the factory+factoryData as `initCode`.
-    pub fn get_init_code(&self) -> Bytes {
-        // Check if `factory` is present
-        if self.factory.is_zero() {
-            return Bytes::new();
-        }
-
-        let mut out = Vec::new();
-        out.extend_from_slice(self.factory.as_slice());
-        out.extend_from_slice(&self.factory_data);
-        out.into()
-    }
-
-    /// Extract `validAfter` and `validUntil` from a signature as `U256` values.
-    ///
-    /// Expects at least 12 bytes additional bytes in the signature.
+    /// # Returns
+    /// * `Result<Bytes, PrimitiveError>` - The generated PBH proof bytes on success
     ///
     /// # Errors
-    /// - Returns an error if the signature is too short.
-    pub fn extract_validity_timestamps(&self) -> Result<(U48, U48), PrimitiveError> {
-        // timestamp validity (12 bytes) + regular ECDSA signature (65 bytes)
-        if self.signature.len() != 77 {
-            return Err(PrimitiveError::InvalidInput {
-                attribute: "signature",
-                message: "signature does not have the correct length (77 bytes)"
-                    .to_string(),
-            });
-        }
-
-        let mut valid_after = [0u8; 6];
-        let mut valid_until = [0u8; 6];
-
-        valid_after.copy_from_slice(&self.signature[0..6]);
-        valid_until.copy_from_slice(&self.signature[6..12]);
-
-        // Extract 6-byte validAfter and validUntil slices and convert them to U256
-        let valid_after = U48::from_be_bytes(valid_after);
-        let valid_until = U48::from_be_bytes(valid_until);
-
-        Ok((valid_after, valid_until))
-    }
-
-    /// Merges all paymaster related data into a single `paymasterAndData` attribute.
-    pub fn get_paymaster_and_data(&self) -> Bytes {
-        if self.paymaster.is_zero() {
-            return Bytes::new();
-        }
-
-        let mut out = Vec::new();
-        // Append paymaster address (20 bytes)
-        out.extend_from_slice(self.paymaster.as_slice());
-
-        // Append paymasterVerificationGasLimit (16 bytes)
-        out.extend_from_slice(&self.paymaster_verification_gas_limit.to_be_bytes());
-
-        // Append paymasterPostOpGasLimit (16 bytes)
-        out.extend_from_slice(&self.paymaster_post_op_gas_limit.to_be_bytes());
-
-        // Append paymasterData if it exists
-        if !self.paymaster_data.is_empty() {
-            out.extend_from_slice(&self.paymaster_data);
-        }
-
-        out.into()
-    }
-
-    /// Merges paymaster data from sponsorship response into the `UserOperation`
+    /// * Returns `PrimitiveError` if proof generation fails
     ///
-    /// # Errors
-    /// Returns an error if any U128 to u128 conversion fails
-    pub fn with_paymaster_data(
-        mut self,
-        sponsor_response: SponsorUserOperationResponse,
-    ) -> Result<Self, HttpError> {
-        self.paymaster = sponsor_response.paymaster;
-        self.paymaster_data = sponsor_response.paymaster_data;
-        self.paymaster_verification_gas_limit = sponsor_response
-            .paymaster_verification_gas_limit
-            .try_into()
-            .unwrap_or(0);
-        self.paymaster_post_op_gas_limit = sponsor_response
-            .paymaster_post_op_gas_limit
-            .try_into()
-            .unwrap_or(0);
-
-        // Update gas fields if they were estimated by the RPC
-        if self.pre_verification_gas.is_zero() {
-            self.pre_verification_gas = sponsor_response.pre_verification_gas;
-        }
-        if self.verification_gas_limit == 0 {
-            self.verification_gas_limit = sponsor_response
-                .verification_gas_limit
-                .try_into()
-                .unwrap_or(0);
-        }
-        if self.call_gas_limit == 0 {
-            self.call_gas_limit =
-                sponsor_response.call_gas_limit.try_into().unwrap_or(0);
-        }
-        if self.max_fee_per_gas == 0 {
-            self.max_fee_per_gas =
-                sponsor_response.max_fee_per_gas.try_into().unwrap_or(0);
-        }
-        if self.max_priority_fee_per_gas == 0 {
-            self.max_priority_fee_per_gas = sponsor_response
-                .max_priority_fee_per_gas
-                .try_into()
-                .unwrap_or(0);
-        }
-
-        Ok(self)
+    /// # Note
+    /// This is currently unimplemented and will return a todo!() error.
+    fn generate_pbh_proof() -> Result<Bytes, PrimitiveError> {
+        todo!("PBH proof generation not yet implemented")
     }
-}
+    
+    // pub fn hash_user_op(user_op: &PackedUserOperation) -> Field {
+    //     let hash = SolValue::abi_encode_packed(&(&user_op.sender, &user_op.nonce, &user_op.callData));
 
-impl EncodedSafeOpStruct {
-    /// Builds an `EncodedSafeOpStruct` from a `UserOperation`, injecting explicit validity timestamps.
-    ///
-    /// # Errors
-    /// Returns `PrimitiveError` if hashing or conversions fail when deriving fields
-    /// from the provided `user_op`. Currently this can occur if internal helpers
-    /// on `user_op` return invalid data for hashing.
-    pub fn from_user_op_with_validity(
-        user_op: &UserOperation,
-        valid_after: U48,
-        valid_until: U48,
-    ) -> Result<Self, PrimitiveError> {
-        Ok(Self {
-            type_hash: *SAFE_OP_TYPEHASH,
-            safe: user_op.sender,
-            nonce: user_op.nonce,
-            init_code_hash: keccak256(user_op.get_init_code()),
-            call_data_hash: keccak256(&user_op.call_data),
-            verification_gas_limit: user_op.verification_gas_limit,
-            call_gas_limit: user_op.call_gas_limit,
-            pre_verification_gas: user_op.pre_verification_gas,
-            max_priority_fee_per_gas: user_op.max_priority_fee_per_gas,
-            max_fee_per_gas: user_op.max_fee_per_gas,
-            paymaster_and_data_hash: keccak256(user_op.get_paymaster_and_data()),
-            valid_after,
-            valid_until,
-            entry_point: *ENTRYPOINT_4337,
-        })
-    }
+    //     hash_to_field(hash.as_slice())
+    // }
 
-    /// computes the hash of the userOp
-    #[must_use]
-    pub fn into_transaction_hash(self) -> FixedBytes<32> {
-        keccak256(self.abi_encode())
-    }
-}
 
-// --- JSON serialization helpers for ERC-7769 ---
-
-fn serialize_u128_as_hex<S: Serializer>(
-    value: &u128,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    // Always hex with 0x prefix per spec
-    let s = format!("0x{value:x}");
-    serializer.serialize_str(&s)
-}
-
-fn serialize_u256_as_hex<S: Serializer>(
-    value: &U256,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    let s = format!("0x{value:x}");
-    serializer.serialize_str(&s)
 }
 
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, U128};
+    use ruint::aliases::U256;
+    use std::str::FromStr;
 
     use super::*;
     use crate::{

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -75,7 +75,7 @@ impl SafeSmartAccount {
 
         // Sign and execute the transaction (uses global RPC client automatically)
         let user_op_hash = transaction
-            .sign_and_execute(network, self, None, None, false)
+            .sign_and_execute(network, self, None, None)
             .await
             .map_err(|e| TransactionError::Generic {
                 message: format!("Failed to execute transaction: {e}"),

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -75,7 +75,7 @@ impl SafeSmartAccount {
 
         // Sign and execute the transaction (uses global RPC client automatically)
         let user_op_hash = transaction
-            .sign_and_execute(network, self, None, None)
+            .sign_and_execute(network, self, None, None, false)
             .await
             .map_err(|e| TransactionError::Generic {
                 message: format!("Failed to execute transaction: {e}"),


### PR DESCRIPTION
We were defining smart account types inside transaction_4337 file. Also added PBH contracts so this will better organize where all contracts will inside primitives. 