### PR TITLE
feat: introduce owner rotation for Safe account

### DIFF
--- a/bedrock/src/primitives/mod.rs
+++ b/bedrock/src/primitives/mod.rs
@@ -9,14 +9,7 @@ use std::str::FromStr;
 // Re-export HTTP client types for external use
 pub use http_client::{AuthenticatedHttpClient, HttpError, HttpMethod};
 
-/// The prefix for Bedrock-generated transactions.
-pub static BEDROCK_NONCE_PREFIX_CONST: &[u8; 5] = b"bdrck";
-
-/// The prefix for PBHTX-generated transactions.
-#[allow(dead_code)]
-pub static PBH_NONCE_PREFIX_CONST: &[u8; 5] = b"pbhtx";
-
-// Serde helper functions for skip_serializing_if
+// ---- Serde helper functions for `skip_serializing_if` ----
 
 /// Helper function to check if an `Address` is zero for serde `skip_serializing_if`
 #[must_use]
@@ -58,9 +51,6 @@ pub mod http_client;
 /// The elements in this module are only used in Foreign Tests and are not available in built binaries.
 #[cfg(feature = "tooling_tests")]
 pub mod tooling_tests;
-
-/// Contract interfaces and data structures for ERC-4337 account abstraction
-pub mod contracts;
 
 /// Supported blockchain networks for Bedrock operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]

--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -11,8 +11,12 @@ pub use transaction_4337::Is4337Encodable;
 #[cfg(any(test, doc))]
 use crate::primitives::Network;
 use crate::{
-    bedrock_export, debug, error, primitives::HexEncodedData,
-    transaction::foreign::UnparsedUserOperation,
+    bedrock_export, debug, error,
+    primitives::HexEncodedData,
+    transaction::{
+        foreign::UnparsedUserOperation, EncodedSafeOpStruct, UserOperation,
+        GNOSIS_SAFE_4337_MODULE,
+    },
 };
 
 /// Enables signing of messages and EIP-712 typed data for Safe Smart Accounts.
@@ -32,12 +36,9 @@ mod transaction;
 /// Reference: <https://docs.uniswap.org/contracts/permit2/overview>
 mod permit2;
 
-pub use crate::primitives::contracts::{
-    EncodedSafeOpStruct, ISafe4337Module, UserOperation, ENTRYPOINT_4337,
-    GNOSIS_SAFE_4337_MODULE,
+pub use nonce::{
+    InstructionFlag, NonceKeyV1, TransactionTypeId, BEDROCK_NONCE_PREFIX_CONST,
 };
-
-pub use nonce::{InstructionFlag, NonceKeyV1, TransactionTypeId};
 
 // Import the generated types from permit2 module
 pub use permit2::{
@@ -234,7 +235,7 @@ impl SafeSmartAccount {
             &user_op,
             valid_after,
             valid_until,
-        )?;
+        );
 
         let signature = self.sign_digest(
             encoded_safe_op_struct.into_transaction_hash(),

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -10,7 +10,12 @@
 
 use ruint::aliases::U256;
 
-use crate::primitives::BEDROCK_NONCE_PREFIX_CONST;
+/// The prefix for Bedrock-generated transactions.
+pub static BEDROCK_NONCE_PREFIX_CONST: &[u8; 5] = b"bdrck";
+
+/// The prefix for PBHTX-generated transactions.
+#[allow(dead_code)]
+pub static PBH_NONCE_PREFIX_CONST: &[u8; 5] = b"pbhtx";
 
 /// Stable, never-reordered identifiers for transaction classes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -18,6 +18,8 @@ use crate::primitives::BEDROCK_NONCE_PREFIX_CONST;
 pub enum TransactionTypeId {
     /// ERC-20 transfer
     Transfer = 1,
+    /// Swap Safe Owner
+    SwapOwner = 188,
 }
 
 impl TransactionTypeId {

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -3,18 +3,16 @@
 //! A transaction can be initialized through a `UserOperation` struct.
 //!
 
-use crate::primitives::contracts::{
-    EncodedSafeOpStruct, ISafe4337Module, UserOperation,
-};
 use crate::primitives::{Network, PrimitiveError};
 use crate::smart_account::{SafeOperation, SafeSmartAccountSigner};
-use crate::transaction::rpc::{RpcError, RpcProviderName};
+use crate::transaction::{
+    EncodedSafeOpStruct, ISafe4337Module, RpcError, RpcProviderName, UserOperation,
+    ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE,
+};
 
 use alloy::primitives::{aliases::U48, Address, Bytes, FixedBytes, U256};
 use alloy::sol_types::SolCall;
 use chrono::{Duration, Utc};
-
-use crate::primitives::contracts::{ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE};
 
 /// The default validity duration for 4337 `UserOperation` signatures.
 ///
@@ -114,7 +112,7 @@ pub trait Is4337Encodable {
             .await?;
 
         // 3. Merge paymaster data
-        user_operation = user_operation.with_paymaster_data(sponsor_response)?;
+        user_operation = user_operation.with_paymaster_data(sponsor_response);
 
         // 4. Compute validity timestamps
         // validAfter = 0 (immediately valid)
@@ -135,7 +133,7 @@ pub trait Is4337Encodable {
             &user_operation,
             valid_after_u48,
             valid_until_u48,
-        )?;
+        );
 
         let signature = safe_account.sign_digest(
             encoded_safe_op.into_transaction_hash(),
@@ -199,8 +197,7 @@ mod tests {
             &user_op,
             valid_after,
             valid_until,
-        )
-        .unwrap();
+        );
         let hash = encoded_safe_op.into_transaction_hash();
 
         let smart_account = SafeSmartAccount::random();
@@ -286,10 +283,8 @@ mod tests {
             max_fee_per_gas: U128::from(900),
         };
 
-        let result = user_op.with_paymaster_data(sponsor_response);
-        assert!(result.is_ok());
+        let updated_user_op = user_op.with_paymaster_data(sponsor_response);
 
-        let updated_user_op = result.unwrap();
         assert_eq!(
             updated_user_op.paymaster,
             address!("0x2222222222222222222222222222222222222222")
@@ -332,10 +327,7 @@ mod tests {
             max_fee_per_gas: U128::from(900),
         };
 
-        let result = user_op.with_paymaster_data(sponsor_response);
-        assert!(result.is_ok());
-
-        let updated_user_op = result.unwrap();
+        let updated_user_op = user_op.with_paymaster_data(sponsor_response);
 
         // Paymaster fields should always be updated
         assert_eq!(

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -7,7 +7,7 @@ use crate::primitives::contracts::{
     EncodedSafeOpStruct, ISafe4337Module, UserOperation,
 };
 use crate::primitives::{Network, PrimitiveError};
-use crate::smart_account::SafeSmartAccountSigner;
+use crate::smart_account::{SafeOperation, SafeSmartAccountSigner};
 use crate::transaction::rpc::{RpcError, RpcProviderName};
 
 use alloy::primitives::{aliases::U48, Address, Bytes, FixedBytes, U256};
@@ -46,7 +46,7 @@ pub trait Is4337Encodable {
             to: self.target_address(),
             value: U256::ZERO,
             data: self.call_data(),
-            operation: 0, // SafeOperation::Call as u8
+            operation: SafeOperation::Call as u8,
         }
         .abi_encode()
         .into()

--- a/bedrock/src/transaction/contracts/entrypoint.rs
+++ b/bedrock/src/transaction/contracts/entrypoint.rs
@@ -1,4 +1,8 @@
-use crate::primitives::{HttpError, PrimitiveError};
+//! This module introduces the contract interface for:
+//! - the `EntryPoint` contract, including support for ERC-4337 in the Safe Smart Account
+//! - the `PBHEntryPoint` contract, which is to execute Priority Blockspace for Humans transactions
+
+use crate::primitives::PrimitiveError;
 use crate::transaction::rpc::SponsorUserOperationResponse;
 use alloy::hex::FromHex;
 use alloy::primitives::{aliases::U48, keccak256, Address, Bytes, FixedBytes};
@@ -53,6 +57,67 @@ fn serialize_u256_as_hex<S: serde::Serializer>(
 }
 
 sol! {
+    /// `EntryPoint` contract (0.7.0)
+    /// Reference: <https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/core/EntryPoint.sol>
+    interface IEntryPoint {
+        #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
+        #[sol(rename_all = "camelCase")]
+        struct PackedUserOperation {
+            address sender;
+            uint256 nonce;
+            bytes init_code;
+            bytes call_data;
+            bytes32 account_gas_limits;
+            uint256 pre_verification_gas;
+            bytes32 gas_fees;
+            bytes paymaster_and_data;
+            bytes signature;
+        }
+
+        #[derive(Default)]
+        struct UserOpsPerAggregator {
+            PackedUserOperation[] userOps;
+            address aggregator;
+            bytes signature;
+        }
+    }
+
+    /// `Multicall3` contract. Aggregates results from multiple calls in a single transaction.
+    ///
+    /// Reference: <https://github.com/worldcoin/world-chain/blob/646bb294dac87bd993be9a218cc357ab1b4a8f6d/contracts/src/interfaces/IMulticall3.sol#L4C1-L4C10>
+    /// Reference: <https://github.com/mds1/multicall3/blob/main/src/Multicall3.sol#L13>
+    interface IMulticall3 {
+        #[derive(Default)]
+        struct Call3 {
+            address target;
+            bool allowFailure;
+            bytes callData;
+        }
+    }
+
+    // FIXME: Currently PBHEntryPoint is not in use. Depending on how it ends up being used, some of these functions might not be needed (e.g. `PackedUserOperation`).
+    /// `PBHEntryPoint` contract. An entry point contract that supports Priority Blockspace for Humans (PBH) transactions.
+    ///
+    /// Reference: <https://github.com/worldcoin/world-chain/blob/646bb294dac87bd993be9a218cc357ab1b4a8f6d/contracts/src/interfaces/IPBHEntryPoint.sol>
+    interface IPBHEntryPoint {
+        #[derive(Default)]
+        struct PBHPayload {
+            uint256 root;
+            uint256 pbhExternalNullifier;
+            uint256 nullifierHash;
+            uint256[8] proof;
+        }
+
+        function handleAggregatedOps(
+            IEntryPoint.UserOpsPerAggregator[] calldata,
+            address payable
+        ) external;
+
+        function pbhMulticall(
+            IMulticall3.Call3[] calls,
+            PBHPayload payload,
+        ) external;
+    }
 
     /// Interface for the `Safe4337Module` contract.
     ///
@@ -223,14 +288,15 @@ impl UserOperation {
         out.into()
     }
 
-    /// Merges paymaster data from sponsorship response into the `UserOperation`
+    /// Merges paymaster data from sponsorship response into the existing `UserOperation`
     ///
     /// # Errors
-    /// Returns an error if any U128 to u128 conversion fails
+    /// Returns an error if any parameter conversion fails
+    #[must_use]
     pub fn with_paymaster_data(
         mut self,
         sponsor_response: SponsorUserOperationResponse,
-    ) -> Result<Self, HttpError> {
+    ) -> Self {
         self.paymaster = sponsor_response.paymaster;
         self.paymaster_data = sponsor_response.paymaster_data;
         self.paymaster_verification_gas_limit = sponsor_response
@@ -267,7 +333,7 @@ impl UserOperation {
                 .unwrap_or(0);
         }
 
-        Ok(self)
+        self
     }
 }
 
@@ -282,8 +348,8 @@ impl EncodedSafeOpStruct {
         user_op: &UserOperation,
         valid_after: U48,
         valid_until: U48,
-    ) -> Result<Self, PrimitiveError> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             type_hash: *SAFE_OP_TYPEHASH,
             safe: user_op.sender,
             nonce: user_op.nonce,
@@ -298,65 +364,12 @@ impl EncodedSafeOpStruct {
             valid_after,
             valid_until,
             entry_point: *ENTRYPOINT_4337,
-        })
+        }
     }
 
     /// computes the hash of the userOp
     #[must_use]
     pub fn into_transaction_hash(self) -> FixedBytes<32> {
         keccak256(self.abi_encode())
-    }
-}
-
-sol! {
-    contract IMulticall3 {
-        #[derive(Default)]
-        struct Call3 {
-            address target;
-            bool allowFailure;
-            bytes callData;
-        }
-    }
-
-    contract IEntryPoint {
-        #[derive(Default, serde::Serialize, serde::Deserialize, Debug)]
-        struct PackedUserOperation {
-            address sender;
-            uint256 nonce;
-            bytes initCode;
-            bytes callData;
-            bytes32 accountGasLimits;
-            uint256 preVerificationGas;
-            bytes32 gasFees;
-            bytes paymasterAndData;
-            bytes signature;
-        }
-
-        #[derive(Default)]
-        struct UserOpsPerAggregator {
-            PackedUserOperation[] userOps;
-            address aggregator;
-            bytes signature;
-        }
-    }
-
-    contract IPBHEntryPoint {
-        #[derive(Default)]
-        struct PBHPayload {
-            uint256 root;
-            uint256 pbhExternalNullifier;
-            uint256 nullifierHash;
-            uint256[8] proof;
-        }
-
-        function handleAggregatedOps(
-            IEntryPoint.UserOpsPerAggregator[] calldata,
-            address payable
-        ) external;
-
-        function pbhMulticall(
-            IMulticall3.Call3[] calls,
-            PBHPayload payload,
-        ) external;
     }
 }

--- a/bedrock/src/transaction/contracts/erc20.rs
+++ b/bedrock/src/transaction/contracts/erc20.rs
@@ -8,8 +8,7 @@ use alloy::{
 
 use crate::primitives::PrimitiveError;
 use crate::smart_account::{
-    ISafe4337Module, InstructionFlag, Is4337Encodable, NonceKeyV1, SafeOperation,
-    TransactionTypeId, UserOperation,
+    InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId, UserOperation,
 };
 
 sol! {
@@ -87,16 +86,12 @@ pub struct MetadataArg {
 impl Is4337Encodable for Erc20 {
     type MetadataArg = MetadataArg;
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
-        ISafe4337Module::executeUserOpCall {
-            // The token address
-            to: self.token_address,
-            value: U256::ZERO,
-            data: self.call_data.clone().into(),
-            operation: SafeOperation::Call as u8,
-        }
-        .abi_encode()
-        .into()
+    fn target_address(&self) -> Address {
+        self.token_address
+    }
+
+    fn call_data(&self) -> Bytes {
+        self.call_data.clone().into()
     }
 
     fn as_preflight_user_operation(

--- a/bedrock/src/transaction/contracts/erc20.rs
+++ b/bedrock/src/transaction/contracts/erc20.rs
@@ -6,10 +6,10 @@ use alloy::{
     sol_types::SolCall,
 };
 
-use crate::primitives::PrimitiveError;
 use crate::smart_account::{
-    InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId, UserOperation,
+    InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId,
 };
+use crate::{primitives::PrimitiveError, transaction::UserOperation};
 
 sol! {
     /// The ERC20 contract interface.
@@ -133,7 +133,7 @@ mod tests {
     use alloy::primitives::bytes;
     use std::str::FromStr;
 
-    use crate::primitives::BEDROCK_NONCE_PREFIX_CONST;
+    use crate::smart_account::BEDROCK_NONCE_PREFIX_CONST;
 
     use super::*;
 

--- a/bedrock/src/transaction/contracts/mod.rs
+++ b/bedrock/src/transaction/contracts/mod.rs
@@ -2,3 +2,5 @@
 //! that power the common transactions for the crypto wallet.
 
 pub mod erc20;
+
+pub mod safe_owner;

--- a/bedrock/src/transaction/contracts/mod.rs
+++ b/bedrock/src/transaction/contracts/mod.rs
@@ -1,6 +1,6 @@
 //! This module introduces contract definitions for all the smart contracts
 //! that power the common transactions for the crypto wallet.
 
+pub mod entrypoint;
 pub mod erc20;
-
 pub mod safe_owner;

--- a/bedrock/src/transaction/contracts/safe_owner.rs
+++ b/bedrock/src/transaction/contracts/safe_owner.rs
@@ -1,0 +1,94 @@
+//! This module introduces the contract interface for the Safe contract.
+//!
+//! Explicitly this only allows management of the Safe Smart Account. Executing transactions with the Safe Smart Account
+//! is done via the `SafeSmartAccount` module.
+
+use alloy::{
+    primitives::{address, Address, Bytes, U256},
+    sol,
+    sol_types::SolCall,
+};
+
+use crate::{
+    primitives::PrimitiveError,
+    smart_account::{
+        ISafe4337Module, InstructionFlag, Is4337Encodable, NonceKeyV1, SafeOperation,
+        TransactionTypeId, UserOperation,
+    },
+};
+
+const SENTINEL_ADDRESS: Address =
+    address!("0x0000000000000000000000000000000000000001");
+
+sol! {
+    ///Owner Manager Interface for the Safe
+    ///
+    /// Reference: <https://github.com/safe-global/safe-smart-account/blob/v1.4.1/contracts/base/OwnerManager.sol>
+    #[derive(serde::Serialize)]
+    #[sol(rename_all = "camelcase")]
+    interface IOwnerManager {
+        function swapOwner(address prev_owner, address old_owner, address new_owner) public;
+    }
+}
+
+pub struct SafeOwner {
+    /// The inner call data for the ERC-20 `transferCall` function.
+    call_data: Vec<u8>,
+    /// The address of the Safe Smart Account.
+    wallet_address: Address,
+}
+
+impl SafeOwner {
+    pub fn new(
+        wallet_address: Address,
+        old_owner: Address,
+        new_owner: Address,
+    ) -> Self {
+        Self {
+            call_data: IOwnerManager::swapOwnerCall {
+                prev_owner: SENTINEL_ADDRESS,
+                old_owner,
+                new_owner,
+            }
+            .abi_encode(),
+            wallet_address,
+        }
+    }
+}
+
+impl Is4337Encodable for SafeOwner {
+    type MetadataArg = ();
+
+    // TODO: Make this the default in Is4337Encodable trait, it's a sensible default.
+    fn as_execute_user_op_call_data(&self) -> Bytes {
+        ISafe4337Module::executeUserOpCall {
+            to: self.wallet_address,
+            value: U256::ZERO,
+            data: self.call_data.clone().into(),
+            operation: SafeOperation::Call as u8,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn as_preflight_user_operation(
+        &self,
+        wallet_address: Address,
+        _metadata: Option<Self::MetadataArg>,
+    ) -> Result<UserOperation, PrimitiveError> {
+        let call_data = self.as_execute_user_op_call_data();
+
+        let key = NonceKeyV1::new(
+            TransactionTypeId::SwapOwner,
+            InstructionFlag::Default,
+            [0u8; 10],
+        );
+        let nonce = key.encode_with_sequence(0);
+
+        Ok(UserOperation::new_with_defaults(
+            wallet_address,
+            nonce,
+            call_data,
+        ))
+    }
+}

--- a/bedrock/src/transaction/contracts/safe_owner.rs
+++ b/bedrock/src/transaction/contracts/safe_owner.rs
@@ -4,7 +4,7 @@
 //! is done via the `SafeSmartAccount` module.
 
 use alloy::{
-    primitives::{address, Address, Bytes, U256},
+    primitives::{address, Address, Bytes},
     sol,
     sol_types::SolCall,
 };
@@ -12,8 +12,7 @@ use alloy::{
 use crate::{
     primitives::PrimitiveError,
     smart_account::{
-        ISafe4337Module, InstructionFlag, Is4337Encodable, NonceKeyV1, SafeOperation,
-        TransactionTypeId, UserOperation,
+        InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId, UserOperation,
     },
 };
 
@@ -59,16 +58,12 @@ impl SafeOwner {
 impl Is4337Encodable for SafeOwner {
     type MetadataArg = ();
 
-    // TODO: Make this the default in Is4337Encodable trait, it's a sensible default.
-    fn as_execute_user_op_call_data(&self) -> Bytes {
-        ISafe4337Module::executeUserOpCall {
-            to: self.wallet_address,
-            value: U256::ZERO,
-            data: self.call_data.clone().into(),
-            operation: SafeOperation::Call as u8,
-        }
-        .abi_encode()
-        .into()
+    fn target_address(&self) -> Address {
+        self.wallet_address
+    }
+
+    fn call_data(&self) -> Bytes {
+        self.call_data.clone().into()
     }
 
     fn as_preflight_user_operation(

--- a/bedrock/src/transaction/contracts/safe_owner.rs
+++ b/bedrock/src/transaction/contracts/safe_owner.rs
@@ -11,9 +11,8 @@ use alloy::{
 
 use crate::{
     primitives::PrimitiveError,
-    smart_account::{
-        InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId, UserOperation,
-    },
+    smart_account::{InstructionFlag, Is4337Encodable, NonceKeyV1, TransactionTypeId},
+    transaction::UserOperation,
 };
 
 const SENTINEL_ADDRESS: Address =

--- a/bedrock/src/transaction/contracts/safe_owner.rs
+++ b/bedrock/src/transaction/contracts/safe_owner.rs
@@ -30,6 +30,7 @@ sol! {
     }
 }
 
+/// Represents a Safe owner swap transaction for key rotation.
 pub struct SafeOwner {
     /// The inner call data for the ERC-20 `transferCall` function.
     call_data: Vec<u8>,
@@ -38,6 +39,13 @@ pub struct SafeOwner {
 }
 
 impl SafeOwner {
+    /// Creates a new `SafeOwner` transaction for swapping Safe owners.
+    ///
+    /// # Arguments
+    /// - `wallet_address`: The address of the Safe Smart Account
+    /// - `old_owner`: The current owner to be replaced
+    /// - `new_owner`: The new owner to replace the old owner
+    #[must_use]
     pub fn new(
         wallet_address: Address,
         old_owner: Address,

--- a/bedrock/src/transaction/foreign.rs
+++ b/bedrock/src/transaction/foreign.rs
@@ -3,10 +3,8 @@
 
 use alloy::primitives::{Address, Bytes, U256};
 
-use crate::{
-    primitives::{ParseFromForeignBinding, PrimitiveError},
-    smart_account::UserOperation,
-};
+use crate::primitives::{ParseFromForeignBinding, PrimitiveError};
+use crate::transaction::UserOperation;
 
 /// A pseudo-transaction object for EIP-4337. Used to execute transactions through the Safe Smart Account.
 ///

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -46,7 +46,7 @@ impl SafeSmartAccount {
     /// # let safe_account = SafeSmartAccount::new("test_key".to_string(), "0x1234567890123456789012345678901234567890").unwrap();
     ///
     /// // Transfer USDC on World Chain
-    /// let tx_hash = safe_account.transaction_transfer(
+    /// let tx_hash = safe_account.tx_transfer(
     ///     Network::WorldChain,
     ///     "0x79A02482A880BCE3F13E09Da970dC34DB4cD24d1", // USDC on World Chain
     ///     "0x1234567890123456789012345678901234567890",

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -11,6 +11,10 @@ mod contracts;
 pub mod foreign;
 pub mod rpc;
 
+pub use contracts::entrypoint::{
+    EncodedSafeOpStruct, ISafe4337Module, UserOperation, ENTRYPOINT_4337,
+    GNOSIS_SAFE_4337_MODULE,
+};
 pub use contracts::safe_owner::SafeOwner;
 pub use rpc::{RpcClient, RpcError, RpcProviderName, SponsorUserOperationResponse};
 

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -107,7 +107,6 @@ impl SafeSmartAccount {
         let old_owner = Address::parse_from_ffi(old_owner, "old_owner")?;
         let new_owner = Address::parse_from_ffi(new_owner, "new_owner")?;
 
-        // TODO: RPC call to check if the old owner is the current owner.
         // TODO: Check if we derive new_owner through key derivation directly in Bedrock.
         // TODO: Check if rotation on Optimism is also necessary.
 

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -4,13 +4,14 @@ use bedrock_macros::bedrock_export;
 use crate::{
     primitives::{HexEncodedData, Network, ParseFromForeignBinding},
     smart_account::{Is4337Encodable, SafeSmartAccount},
-    transaction::contracts::{erc20::Erc20, safe_owner::SafeOwner},
+    transaction::contracts::erc20::Erc20,
 };
 
 mod contracts;
 pub mod foreign;
 pub mod rpc;
 
+pub use contracts::safe_owner::SafeOwner;
 pub use rpc::{RpcClient, RpcError, RpcProviderName, SponsorUserOperationResponse};
 
 /// Errors that can occur when interacting with transaction operations.
@@ -110,7 +111,7 @@ impl SafeSmartAccount {
 
         // TODO: Check if we derive new_owner through key derivation directly in Bedrock.
 
-        let transaction = SafeOwner::new(self.wallet_address, old_owner, new_owner);
+        let transaction = crate::transaction::SafeOwner::new(self.wallet_address, old_owner, new_owner);
 
         // TODO: Check if rotation on Optimism is also necessary.
         let user_op_hash = transaction

--- a/bedrock/src/transaction/mod.rs
+++ b/bedrock/src/transaction/mod.rs
@@ -108,12 +108,15 @@ impl SafeSmartAccount {
         let new_owner = Address::parse_from_ffi(new_owner, "new_owner")?;
 
         // TODO: RPC call to check if the old owner is the current owner.
-
         // TODO: Check if we derive new_owner through key derivation directly in Bedrock.
-
-        let transaction = crate::transaction::SafeOwner::new(self.wallet_address, old_owner, new_owner);
-
         // TODO: Check if rotation on Optimism is also necessary.
+
+        let transaction = crate::transaction::SafeOwner::new(
+            self.wallet_address,
+            old_owner,
+            new_owner,
+        );
+
         let user_op_hash = transaction
             .sign_and_execute(
                 Network::WorldChain,

--- a/bedrock/src/transaction/rpc.rs
+++ b/bedrock/src/transaction/rpc.rs
@@ -5,11 +5,12 @@
 //! - Submit signed `UserOperations` via `eth_sendUserOperation`
 
 use crate::{
-    primitives::http_client::{get_http_client, HttpHeader},
     primitives::{
+        http_client::{get_http_client, HttpHeader},
         AuthenticatedHttpClient, HttpError, HttpMethod, Network, PrimitiveError,
     },
-    smart_account::{SafeSmartAccountError, UserOperation},
+    smart_account::SafeSmartAccountError,
+    transaction::UserOperation,
 };
 use alloy::hex::FromHex;
 use alloy::primitives::{Address, Bytes, FixedBytes, U128, U256};

--- a/bedrock/tests/common.rs
+++ b/bedrock/tests/common.rs
@@ -1,13 +1,22 @@
 use alloy::{
     network::Ethereum,
     node_bindings::AnvilInstance,
-    primitives::{address, Address, FixedBytes, Log, U256},
+    primitives::{address, keccak256, Address, FixedBytes, Log, U256},
     providers::{ext::AnvilApi, Provider},
     sol,
-    sol_types::{SolCall, SolEvent},
+    sol_types::{SolCall, SolEvent, SolValue},
 };
 
-use bedrock::{primitives::PrimitiveError, smart_account::UserOperation};
+use bedrock::{
+    primitives::{
+        http_client::{AuthenticatedHttpClient, HttpError, HttpHeader, HttpMethod},
+        PrimitiveError,
+    },
+    smart_account::{UserOperation, ENTRYPOINT_4337},
+    transaction::foreign::UnparsedUserOperation,
+};
+use serde::Serialize;
+use serde_json::json;
 
 sol!(
     #[allow(missing_docs)]
@@ -216,5 +225,192 @@ impl TryFrom<&UserOperation> for PackedUserOperation {
             paymaster_and_data: user_op.get_paymaster_and_data(),
             signature: user_op.signature.clone(),
         })
+    }
+}
+
+/// A mock HTTP client that intercepts 4337 RPC calls for testing.
+/// - `wa_sponsorUserOperation`: Will mock a response with default gas values and no paymaster.
+/// - `eth_sendUserOperation`: Executes the user operation on Anvil via the `EntryPoint` contract
+#[derive(Clone)]
+pub struct AnvilBackedHttpClient<P>
+where
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
+{
+    pub provider: P,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SponsorUserOperationResponseLite<'a> {
+    paymaster: &'a str,
+    paymaster_data: &'a str,
+    pre_verification_gas: String,
+    verification_gas_limit: String,
+    call_gas_limit: String,
+    paymaster_verification_gas_limit: String,
+    paymaster_post_op_gas_limit: String,
+    max_priority_fee_per_gas: String,
+    max_fee_per_gas: String,
+}
+
+#[async_trait::async_trait]
+impl<P> AuthenticatedHttpClient for AnvilBackedHttpClient<P>
+where
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
+{
+    async fn fetch_from_app_backend(
+        &self,
+        _url: String,
+        method: HttpMethod,
+        _headers: Vec<HttpHeader>,
+        body: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, HttpError> {
+        if method != HttpMethod::Post {
+            return Err(HttpError::Generic {
+                message: "unsupported method".into(),
+            });
+        }
+
+        let body = body.ok_or(HttpError::Generic {
+            message: "missing body".into(),
+        })?;
+
+        let root: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|_| HttpError::Generic {
+                message: "invalid json".into(),
+            })?;
+
+        let method =
+            root.get("method")
+                .and_then(|m| m.as_str())
+                .ok_or(HttpError::Generic {
+                    message: "invalid json".into(),
+                })?;
+        let id = root.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let params = root
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        match method {
+            // Intercept sponsor request and return minimal gas values with no paymaster
+            "wa_sponsorUserOperation" => {
+                let result = SponsorUserOperationResponseLite {
+                    paymaster: "0x0000000000000000000000000000000000000000",
+                    paymaster_data: "0x",
+                    pre_verification_gas: "0x20000".into(),
+                    verification_gas_limit: "0x20000".into(),
+                    call_gas_limit: "0x20000".into(),
+                    paymaster_verification_gas_limit: "0x0".into(),
+                    paymaster_post_op_gas_limit: "0x0".into(),
+                    max_priority_fee_per_gas: "0x3B9ACA00".into(), // 1 gwei
+                    max_fee_per_gas: "0x3B9ACA00".into(),          // 1 gwei
+                };
+
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": result,
+                });
+
+                Ok(serde_json::to_vec(&response).unwrap())
+            }
+            // Execute the user operation on Anvil
+            "eth_sendUserOperation" => {
+                let params = params.as_array().ok_or(HttpError::Generic {
+                    message: "invalid params".into(),
+                })?;
+                let user_op_val = params.first().ok_or(HttpError::Generic {
+                    message: "missing userOp param".into(),
+                })?;
+                let _entry_point_str = params.get(1).and_then(|v| v.as_str()).ok_or(
+                    HttpError::Generic {
+                        message: "missing entryPoint param".into(),
+                    },
+                )?;
+
+                // Build UnparsedUserOperation from JSON (which uses hex strings), then convert
+                let obj = user_op_val.as_object().ok_or(HttpError::Generic {
+                    message: "userOp param must be an object".into(),
+                })?;
+
+                let get_opt = |k: &str| -> Option<String> {
+                    obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string())
+                };
+                let get_or_zero = |k: &str| -> String {
+                    get_opt(k).unwrap_or_else(|| "0x0".to_string())
+                };
+                let get_required = |k: &str| -> Result<String, HttpError> {
+                    get_opt(k).ok_or(HttpError::Generic {
+                        message: format!("missing or invalid {k}"),
+                    })
+                };
+
+                let unparsed = UnparsedUserOperation {
+                    sender: get_required("sender")?,
+                    nonce: get_required("nonce")?,
+                    call_data: get_required("callData")?,
+                    call_gas_limit: get_or_zero("callGasLimit"),
+                    verification_gas_limit: get_or_zero("verificationGasLimit"),
+                    pre_verification_gas: get_or_zero("preVerificationGas"),
+                    max_fee_per_gas: get_or_zero("maxFeePerGas"),
+                    max_priority_fee_per_gas: get_or_zero("maxPriorityFeePerGas"),
+                    paymaster: get_opt("paymaster"),
+                    paymaster_verification_gas_limit: get_or_zero(
+                        "paymasterVerificationGasLimit",
+                    ),
+                    paymaster_post_op_gas_limit: get_or_zero("paymasterPostOpGasLimit"),
+                    paymaster_data: get_opt("paymasterData"),
+                    signature: get_required("signature")?,
+                    factory: get_opt("factory"),
+                    factory_data: get_opt("factoryData"),
+                };
+
+                let parsed_op: UserOperation =
+                    unparsed.try_into().map_err(|e| HttpError::Generic {
+                        message: format!("invalid userOp: {e}"),
+                    })?;
+
+                // Execute on Anvil via EntryPoint
+                let entry_point_contract =
+                    IEntryPoint::new(*ENTRYPOINT_4337, &self.provider);
+                let packed_op =
+                    PackedUserOperation::try_from(&parsed_op).map_err(|e| {
+                        HttpError::Generic {
+                            message: format!("failed to pack user operation: {e}"),
+                        }
+                    })?;
+                let handle_ops = entry_point_contract
+                    .handleOps(vec![packed_op], parsed_op.sender)
+                    .gas(5_000_000)
+                    .send()
+                    .await
+                    .map_err(|e| HttpError::Generic {
+                        message: format!("failed to execute user operation: {e}"),
+                    })?;
+
+                let _receipt =
+                    handle_ops
+                        .get_receipt()
+                        .await
+                        .map_err(|e| HttpError::Generic {
+                            message: format!("failed to get receipt: {e}"),
+                        })?;
+
+                // Create a user operation hash
+                let user_op_hash = keccak256(parsed_op.abi_encode());
+
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": format!("0x{}", hex::encode(user_op_hash)),
+                });
+
+                Ok(serde_json::to_vec(&response).unwrap())
+            }
+            _ => Err(HttpError::Generic {
+                message: format!("unsupported method: {method}"),
+            }),
+        }
     }
 }

--- a/bedrock/tests/test_smart_account_erc4337_transaction_execution.rs
+++ b/bedrock/tests/test_smart_account_erc4337_transaction_execution.rs
@@ -6,16 +6,16 @@ use alloy::{
 };
 use bedrock::{
     primitives::Network,
-    smart_account::{
-        EncodedSafeOpStruct, SafeSmartAccount, SafeSmartAccountSigner, UserOperation,
+    smart_account::{SafeSmartAccount, SafeSmartAccountSigner},
+    transaction::{
+        foreign::UnparsedUserOperation, EncodedSafeOpStruct, UserOperation,
         ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE,
     },
-    transaction::foreign::UnparsedUserOperation,
 };
 
 mod common;
 use common::{
-    deploy_safe, setup_anvil, IEntryPoint, ISafe4337Module, PackedUserOperation,
+    deploy_safe, setup_anvil, IEntryPointForTests, ISafe4337Module, PackedUserOperation,
 };
 
 /// Integration test for the encoding, signing and execution of a 4337 transaction.
@@ -48,7 +48,7 @@ async fn test_integration_erc4337_transaction_execution() -> anyhow::Result<()> 
     let before_balance = provider.get_balance(safe_address2).await?;
 
     // Fund EntryPoint deposit for the Safe
-    let entry_point = IEntryPoint::new(*ENTRYPOINT_4337, &provider);
+    let entry_point = IEntryPointForTests::new(*ENTRYPOINT_4337, &provider);
     let _ = entry_point
         .depositTo(safe_address)
         .value(U256::from(1e18))
@@ -99,7 +99,6 @@ async fn test_integration_erc4337_transaction_execution() -> anyhow::Result<()> 
         .expect("Failed to create SafeSmartAccount");
     let (va, vu) = user_op.extract_validity_timestamps()?;
     let op_hash = EncodedSafeOpStruct::from_user_op_with_validity(&user_op, va, vu)
-        .unwrap()
         .into_transaction_hash();
 
     let worldchain_chain_id = Network::WorldChain as u32;

--- a/bedrock/tests/test_smart_account_nonce.rs
+++ b/bedrock/tests/test_smart_account_nonce.rs
@@ -8,9 +8,8 @@ use alloy::{
     sol,
 };
 
-use bedrock::{
-    primitives::BEDROCK_NONCE_PREFIX_CONST,
-    smart_account::{InstructionFlag, NonceKeyV1, TransactionTypeId},
+use bedrock::smart_account::{
+    InstructionFlag, NonceKeyV1, TransactionTypeId, BEDROCK_NONCE_PREFIX_CONST,
 };
 
 mod common;

--- a/bedrock/tests/test_smart_account_safe_owner_swap.rs
+++ b/bedrock/tests/test_smart_account_safe_owner_swap.rs
@@ -1,25 +1,18 @@
 use std::sync::Arc;
 
 use alloy::{
-    network::Ethereum,
-    primitives::{keccak256, U256},
-    providers::{ext::AnvilApi, Provider, ProviderBuilder},
+    primitives::U256,
+    providers::{ext::AnvilApi, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol,
-    sol_types::SolValue,
 };
 use bedrock::{
-    primitives::{
-        http_client::{set_http_client, AuthenticatedHttpClient, HttpError, HttpHeader, HttpMethod},
-    },
+    primitives::http_client::set_http_client,
     smart_account::{SafeSmartAccount, ENTRYPOINT_4337},
-    transaction::foreign::UnparsedUserOperation,
 };
-use serde::Serialize;
-use serde_json::json;
 
 mod common;
-use common::{deploy_safe, setup_anvil, IEntryPoint, PackedUserOperation};
+use common::{deploy_safe, setup_anvil, AnvilBackedHttpClient, IEntryPoint};
 
 sol! {
     /// Safe owner management interface
@@ -28,184 +21,6 @@ sol! {
         function getOwners() external view returns (address[] memory);
         function isOwner(address owner) external view returns (bool);
         function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
-    }
-}
-
-// ------------------ Mock HTTP client that intercepts sponsor and executes on Anvil ------------------
-#[derive(Clone)]
-struct AnvilBackedHttpClient<P>
-where
-    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
-{
-    provider: P,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SponsorUserOperationResponseLite<'a> {
-    paymaster: &'a str,
-    paymaster_data: &'a str,
-    pre_verification_gas: String,
-    verification_gas_limit: String,
-    call_gas_limit: String,
-    paymaster_verification_gas_limit: String,
-    paymaster_post_op_gas_limit: String,
-    max_priority_fee_per_gas: String,
-    max_fee_per_gas: String,
-}
-
-#[async_trait::async_trait]
-impl<P> AuthenticatedHttpClient for AnvilBackedHttpClient<P>
-where
-    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
-{
-    async fn fetch_from_app_backend(
-        &self,
-        _url: String,
-        method: HttpMethod,
-        _headers: Vec<HttpHeader>,
-        body: Option<Vec<u8>>,
-    ) -> Result<Vec<u8>, HttpError> {
-        if method != HttpMethod::Post {
-            return Err(HttpError::Generic {
-                message: "unsupported method".into(),
-            });
-        }
-
-        let body = body.ok_or(HttpError::Generic {
-            message: "missing body".into(),
-        })?;
-
-        let root: serde_json::Value =
-            serde_json::from_slice(&body).map_err(|_| HttpError::Generic {
-                message: "invalid json".into(),
-            })?;
-
-        let method =
-            root.get("method")
-                .and_then(|m| m.as_str())
-                .ok_or(HttpError::Generic {
-                    message: "invalid json".into(),
-                })?;
-        let id = root.get("id").cloned().unwrap_or(serde_json::Value::Null);
-        let params = root
-            .get("params")
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
-
-        match method {
-            // Intercept sponsor request and return minimal gas values with no paymaster
-            "wa_sponsorUserOperation" => {
-                let result = SponsorUserOperationResponseLite {
-                    paymaster: "0x0000000000000000000000000000000000000000",
-                    paymaster_data: "0x",
-                    pre_verification_gas: "0x20000".into(),
-                    verification_gas_limit: "0x20000".into(),
-                    call_gas_limit: "0x20000".into(),
-                    paymaster_verification_gas_limit: "0x0".into(),
-                    paymaster_post_op_gas_limit: "0x0".into(),
-                    max_priority_fee_per_gas: "0x3B9ACA00".into(), // 1 gwei
-                    max_fee_per_gas: "0x3B9ACA00".into(),          // 1 gwei
-                };
-
-                let response = json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": result,
-                });
-
-                Ok(serde_json::to_vec(&response).unwrap())
-            }
-            // Execute the user operation on Anvil
-            "eth_sendUserOperation" => {
-                let params = params.as_array().ok_or(HttpError::Generic {
-                    message: "invalid params".into(),
-                })?;
-                let user_op_val = params.first().ok_or(HttpError::Generic {
-                    message: "missing userOp param".into(),
-                })?;
-                let _entry_point_str = params.get(1).and_then(|v| v.as_str()).ok_or(
-                    HttpError::Generic {
-                        message: "missing entryPoint param".into(),
-                    },
-                )?;
-
-                // Build UnparsedUserOperation from JSON (which uses hex strings), then convert
-                let obj = user_op_val.as_object().ok_or(HttpError::Generic {
-                    message: "userOp param must be an object".into(),
-                })?;
-
-                let get_opt = |k: &str| -> Option<String> {
-                    obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string())
-                };
-                let get_or_zero = |k: &str| -> String {
-                    get_opt(k).unwrap_or_else(|| "0x0".to_string())
-                };
-                let get_required = |k: &str| -> Result<String, HttpError> {
-                    get_opt(k).ok_or(HttpError::Generic {
-                        message: format!("missing or invalid {k}"),
-                    })
-                };
-
-                let unparsed = UnparsedUserOperation {
-                    sender: get_required("sender")?,
-                    nonce: get_required("nonce")?,
-                    call_data: get_required("callData")?,
-                    call_gas_limit: get_or_zero("callGasLimit"),
-                    verification_gas_limit: get_or_zero("verificationGasLimit"),
-                    pre_verification_gas: get_or_zero("preVerificationGas"),
-                    max_fee_per_gas: get_or_zero("maxFeePerGas"),
-                    max_priority_fee_per_gas: get_or_zero("maxPriorityFeePerGas"),
-                    paymaster: get_opt("paymaster"),
-                    paymaster_verification_gas_limit: get_or_zero(
-                        "paymasterVerificationGasLimit",
-                    ),
-                    paymaster_post_op_gas_limit: get_or_zero("paymasterPostOpGasLimit"),
-                    paymaster_data: get_opt("paymasterData"),
-                    signature: get_required("signature")?,
-                    factory: get_opt("factory"),
-                    factory_data: get_opt("factoryData"),
-                };
-
-                let parsed_op: bedrock::smart_account::UserOperation =
-                    unparsed.try_into().map_err(|e| HttpError::Generic {
-                        message: format!("invalid userOp: {e}"),
-                    })?;
-
-                // Execute on Anvil via EntryPoint
-                let entry_point_contract = IEntryPoint::new(*ENTRYPOINT_4337, &self.provider);
-                let packed_op = PackedUserOperation::try_from(&parsed_op)
-                    .map_err(|e| HttpError::Generic {
-                        message: format!("failed to pack user operation: {e}"),
-                    })?;
-                let handle_ops = entry_point_contract
-                    .handleOps(vec![packed_op], parsed_op.sender)
-                    .gas(5_000_000)
-                    .send()
-                    .await
-                    .map_err(|e| HttpError::Generic {
-                        message: format!("failed to execute user operation: {e}"),
-                    })?;
-
-                let _receipt = handle_ops.get_receipt().await.map_err(|e| HttpError::Generic {
-                    message: format!("failed to get receipt: {e}"),
-                })?;
-
-                // Create a user operation hash
-                let user_op_hash = keccak256(parsed_op.abi_encode());
-
-                let response = json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": format!("0x{}", hex::encode(user_op_hash)),
-                });
-
-                Ok(serde_json::to_vec(&response).unwrap())
-            }
-            _ => Err(HttpError::Generic {
-                message: format!("unsupported method: {method}"),
-            }),
-        }
     }
 }
 
@@ -276,16 +91,13 @@ async fn test_safe_owner_swap_e2e() -> anyhow::Result<()> {
     // Execute the owner swap using tx_swap_safe_owner
     println!("→ Executing tx_swap_safe_owner to swap owners...");
     let tx_hash = safe_account
-        .tx_swap_safe_owner(
-            &initial_owner.to_string(),
-            &new_owner.to_string(),
-        )
+        .tx_swap_safe_owner(&initial_owner.to_string(), &new_owner.to_string())
         .await?;
 
-    println!("✓ Executed owner swap transaction: {}", tx_hash.to_hex_string());
-    
-    // Wait a bit for the transaction to be processed
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    println!(
+        "✓ Executed owner swap transaction: {}",
+        tx_hash.to_hex_string()
+    );
 
     // Verify the owner swap was successful
     let final_owners = safe_contract.getOwners().call().await?;

--- a/bedrock/tests/test_smart_account_safe_owner_swap.rs
+++ b/bedrock/tests/test_smart_account_safe_owner_swap.rs
@@ -1,0 +1,308 @@
+use std::sync::Arc;
+
+use alloy::{
+    network::Ethereum,
+    primitives::{keccak256, U256},
+    providers::{ext::AnvilApi, Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::SolValue,
+};
+use bedrock::{
+    primitives::{
+        http_client::{set_http_client, AuthenticatedHttpClient, HttpError, HttpHeader, HttpMethod},
+    },
+    smart_account::{SafeSmartAccount, ENTRYPOINT_4337},
+    transaction::foreign::UnparsedUserOperation,
+};
+use serde::Serialize;
+use serde_json::json;
+
+mod common;
+use common::{deploy_safe, setup_anvil, IEntryPoint, PackedUserOperation};
+
+sol! {
+    /// Safe owner management interface
+    #[sol(rpc)]
+    interface IOwnerManager {
+        function getOwners() external view returns (address[] memory);
+        function isOwner(address owner) external view returns (bool);
+        function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
+    }
+}
+
+// ------------------ Mock HTTP client that intercepts sponsor and executes on Anvil ------------------
+#[derive(Clone)]
+struct AnvilBackedHttpClient<P>
+where
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
+{
+    provider: P,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SponsorUserOperationResponseLite<'a> {
+    paymaster: &'a str,
+    paymaster_data: &'a str,
+    pre_verification_gas: String,
+    verification_gas_limit: String,
+    call_gas_limit: String,
+    paymaster_verification_gas_limit: String,
+    paymaster_post_op_gas_limit: String,
+    max_priority_fee_per_gas: String,
+    max_fee_per_gas: String,
+}
+
+#[async_trait::async_trait]
+impl<P> AuthenticatedHttpClient for AnvilBackedHttpClient<P>
+where
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
+{
+    async fn fetch_from_app_backend(
+        &self,
+        _url: String,
+        method: HttpMethod,
+        _headers: Vec<HttpHeader>,
+        body: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, HttpError> {
+        if method != HttpMethod::Post {
+            return Err(HttpError::Generic {
+                message: "unsupported method".into(),
+            });
+        }
+
+        let body = body.ok_or(HttpError::Generic {
+            message: "missing body".into(),
+        })?;
+
+        let root: serde_json::Value =
+            serde_json::from_slice(&body).map_err(|_| HttpError::Generic {
+                message: "invalid json".into(),
+            })?;
+
+        let method =
+            root.get("method")
+                .and_then(|m| m.as_str())
+                .ok_or(HttpError::Generic {
+                    message: "invalid json".into(),
+                })?;
+        let id = root.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let params = root
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        match method {
+            // Intercept sponsor request and return minimal gas values with no paymaster
+            "wa_sponsorUserOperation" => {
+                let result = SponsorUserOperationResponseLite {
+                    paymaster: "0x0000000000000000000000000000000000000000",
+                    paymaster_data: "0x",
+                    pre_verification_gas: "0x20000".into(),
+                    verification_gas_limit: "0x20000".into(),
+                    call_gas_limit: "0x20000".into(),
+                    paymaster_verification_gas_limit: "0x0".into(),
+                    paymaster_post_op_gas_limit: "0x0".into(),
+                    max_priority_fee_per_gas: "0x3B9ACA00".into(), // 1 gwei
+                    max_fee_per_gas: "0x3B9ACA00".into(),          // 1 gwei
+                };
+
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": result,
+                });
+
+                Ok(serde_json::to_vec(&response).unwrap())
+            }
+            // Execute the user operation on Anvil
+            "eth_sendUserOperation" => {
+                let params = params.as_array().ok_or(HttpError::Generic {
+                    message: "invalid params".into(),
+                })?;
+                let user_op_val = params.first().ok_or(HttpError::Generic {
+                    message: "missing userOp param".into(),
+                })?;
+                let _entry_point_str = params.get(1).and_then(|v| v.as_str()).ok_or(
+                    HttpError::Generic {
+                        message: "missing entryPoint param".into(),
+                    },
+                )?;
+
+                // Build UnparsedUserOperation from JSON (which uses hex strings), then convert
+                let obj = user_op_val.as_object().ok_or(HttpError::Generic {
+                    message: "userOp param must be an object".into(),
+                })?;
+
+                let get_opt = |k: &str| -> Option<String> {
+                    obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string())
+                };
+                let get_or_zero = |k: &str| -> String {
+                    get_opt(k).unwrap_or_else(|| "0x0".to_string())
+                };
+                let get_required = |k: &str| -> Result<String, HttpError> {
+                    get_opt(k).ok_or(HttpError::Generic {
+                        message: format!("missing or invalid {k}"),
+                    })
+                };
+
+                let unparsed = UnparsedUserOperation {
+                    sender: get_required("sender")?,
+                    nonce: get_required("nonce")?,
+                    call_data: get_required("callData")?,
+                    call_gas_limit: get_or_zero("callGasLimit"),
+                    verification_gas_limit: get_or_zero("verificationGasLimit"),
+                    pre_verification_gas: get_or_zero("preVerificationGas"),
+                    max_fee_per_gas: get_or_zero("maxFeePerGas"),
+                    max_priority_fee_per_gas: get_or_zero("maxPriorityFeePerGas"),
+                    paymaster: get_opt("paymaster"),
+                    paymaster_verification_gas_limit: get_or_zero(
+                        "paymasterVerificationGasLimit",
+                    ),
+                    paymaster_post_op_gas_limit: get_or_zero("paymasterPostOpGasLimit"),
+                    paymaster_data: get_opt("paymasterData"),
+                    signature: get_required("signature")?,
+                    factory: get_opt("factory"),
+                    factory_data: get_opt("factoryData"),
+                };
+
+                let parsed_op: bedrock::smart_account::UserOperation =
+                    unparsed.try_into().map_err(|e| HttpError::Generic {
+                        message: format!("invalid userOp: {e}"),
+                    })?;
+
+                // Execute on Anvil via EntryPoint
+                let entry_point_contract = IEntryPoint::new(*ENTRYPOINT_4337, &self.provider);
+                let packed_op = PackedUserOperation::try_from(&parsed_op)
+                    .map_err(|e| HttpError::Generic {
+                        message: format!("failed to pack user operation: {e}"),
+                    })?;
+                let handle_ops = entry_point_contract
+                    .handleOps(vec![packed_op], parsed_op.sender)
+                    .gas(5_000_000)
+                    .send()
+                    .await
+                    .map_err(|e| HttpError::Generic {
+                        message: format!("failed to execute user operation: {e}"),
+                    })?;
+
+                let _receipt = handle_ops.get_receipt().await.map_err(|e| HttpError::Generic {
+                    message: format!("failed to get receipt: {e}"),
+                })?;
+
+                // Create a user operation hash
+                let user_op_hash = keccak256(parsed_op.abi_encode());
+
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": format!("0x{}", hex::encode(user_op_hash)),
+                });
+
+                Ok(serde_json::to_vec(&response).unwrap())
+            }
+            _ => Err(HttpError::Generic {
+                message: format!("unsupported method: {method}"),
+            }),
+        }
+    }
+}
+
+/// End-to-end integration test for swapping Safe owners using tx_swap_safe_owner.
+///
+/// This test:
+/// 1. Deploys a Safe with an initial owner
+/// 2. Sets up a custom RPC client that intercepts sponsor requests
+/// 3. Executes the owner swap using tx_swap_safe_owner
+/// 4. Verifies the swap was executed successfully on-chain
+#[tokio::test]
+async fn test_safe_owner_swap_e2e() -> anyhow::Result<()> {
+    let anvil = setup_anvil();
+
+    // Setup initial and new owners
+    let initial_owner_signer = PrivateKeySigner::random();
+    let initial_owner = initial_owner_signer.address();
+    let initial_owner_key_hex = hex::encode(initial_owner_signer.to_bytes());
+
+    let new_owner_signer = PrivateKeySigner::random();
+    let new_owner = new_owner_signer.address();
+
+    println!("✓ Initial owner address: {initial_owner}");
+    println!("✓ New owner address: {new_owner}");
+
+    let provider = ProviderBuilder::new()
+        .wallet(initial_owner_signer.clone())
+        .connect_http(anvil.endpoint_url());
+
+    // Deploy Safe with initial owner
+    let safe_address = deploy_safe(&provider, initial_owner, U256::ZERO).await?;
+    println!("✓ Deployed Safe at: {safe_address}");
+
+    // Fund the Safe for gas
+    provider
+        .anvil_set_balance(safe_address, U256::from(1e18))
+        .await?;
+
+    // Fund EntryPoint deposit for the Safe
+    let entry_point = IEntryPoint::new(*ENTRYPOINT_4337, &provider);
+    let _deposit_tx = entry_point
+        .depositTo(safe_address)
+        .value(U256::from(1e18))
+        .send()
+        .await?;
+    println!("✓ Funded Safe and EntryPoint deposit");
+
+    // Verify initial owner
+    let safe_contract = IOwnerManager::new(safe_address, &provider);
+    let initial_owners = safe_contract.getOwners().call().await?;
+    assert_eq!(initial_owners.len(), 1);
+    assert_eq!(initial_owners[0], initial_owner);
+    assert!(safe_contract.isOwner(initial_owner).call().await?);
+    assert!(!safe_contract.isOwner(new_owner).call().await?);
+    println!("✓ Verified initial owner");
+
+    // Set up custom HTTP client that intercepts sponsor requests and executes on Anvil
+    let anvil_http_client = AnvilBackedHttpClient {
+        provider: provider.clone(),
+    };
+    set_http_client(Arc::new(anvil_http_client));
+
+    // Create SafeSmartAccount instance
+    let safe_account =
+        SafeSmartAccount::new(initial_owner_key_hex, &safe_address.to_string())
+            .expect("Failed to create SafeSmartAccount");
+
+    // Execute the owner swap using tx_swap_safe_owner
+    println!("→ Executing tx_swap_safe_owner to swap owners...");
+    let tx_hash = safe_account
+        .tx_swap_safe_owner(
+            &initial_owner.to_string(),
+            &new_owner.to_string(),
+        )
+        .await?;
+
+    println!("✓ Executed owner swap transaction: {}", tx_hash.to_hex_string());
+    
+    // Wait a bit for the transaction to be processed
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Verify the owner swap was successful
+    let final_owners = safe_contract.getOwners().call().await?;
+    assert_eq!(final_owners.len(), 1, "Should still have exactly 1 owner");
+    assert_eq!(final_owners[0], new_owner, "Owner should be the new owner");
+
+    // Verify ownership status
+    assert!(
+        !safe_contract.isOwner(initial_owner).call().await?,
+        "Initial owner should no longer be an owner"
+    );
+    assert!(
+        safe_contract.isOwner(new_owner).call().await?,
+        "New owner should be an owner"
+    );
+
+    println!("✅ Successfully swapped Safe owner from {initial_owner} to {new_owner}");
+
+    Ok(())
+}

--- a/bedrock/tests/test_smart_account_safe_owner_swap.rs
+++ b/bedrock/tests/test_smart_account_safe_owner_swap.rs
@@ -7,12 +7,12 @@ use alloy::{
     sol,
 };
 use bedrock::{
-    primitives::http_client::set_http_client,
-    smart_account::{SafeSmartAccount, ENTRYPOINT_4337},
+    primitives::http_client::set_http_client, smart_account::SafeSmartAccount,
+    transaction::ENTRYPOINT_4337,
 };
 
 mod common;
-use common::{deploy_safe, setup_anvil, AnvilBackedHttpClient, IEntryPoint};
+use common::{deploy_safe, setup_anvil, AnvilBackedHttpClient, IEntryPointForTests};
 
 sol! {
     /// Safe owner management interface
@@ -60,7 +60,7 @@ async fn test_safe_owner_swap_e2e() -> anyhow::Result<()> {
         .await?;
 
     // Fund EntryPoint deposit for the Safe
-    let entry_point = IEntryPoint::new(*ENTRYPOINT_4337, &provider);
+    let entry_point = IEntryPointForTests::new(*ENTRYPOINT_4337, &provider);
     let _deposit_tx = entry_point
         .depositTo(safe_address)
         .value(U256::from(1e18))

--- a/bedrock/tests/test_smart_account_transfer.rs
+++ b/bedrock/tests/test_smart_account_transfer.rs
@@ -234,11 +234,10 @@ where
     }
 }
 
-// ------------------ The test for the full transaction_transfer flow ------------------
+// ------------------ The test for the full tx_transfer flow ------------------
 
 #[tokio::test]
-async fn test_transaction_transfer_full_flow_executes_user_operation(
-) -> anyhow::Result<()> {
+async fn test_tx_transfer_full_flow_executes_user_operation() -> anyhow::Result<()> {
     // 1) Spin up anvil fork
     let anvil = setup_anvil();
 
@@ -292,7 +291,7 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
     };
     let _ = set_http_client(Arc::new(client));
 
-    // 8) Execute high-level transfer via transaction_transfer
+    // 8) Execute high-level transfer via tx_transfer
     let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())?;
     let amount = "1000000000000000000"; // 1 WLD
     let _user_op_hash = safe_account
@@ -304,7 +303,7 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
             RpcProviderName::Alchemy,
         )
         .await
-        .expect("transaction_transfer failed");
+        .expect("tx_transfer failed");
 
     // 9) Verify balances updated
     let after_recipient = wld.balanceOf(recipient).call().await?;

--- a/bedrock/tests/test_smart_account_transfer.rs
+++ b/bedrock/tests/test_smart_account_transfer.rs
@@ -291,7 +291,7 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
     let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())?;
     let amount = "1000000000000000000"; // 1 WLD
     let _user_op_hash = safe_account
-        .transaction_transfer(
+        .tx_transfer(
             Network::WorldChain,
             &wld_token_address.to_string(),
             &recipient.to_string(),


### PR DESCRIPTION
### Changes
- Enables key rotation by calling `swapOwner` on the Safe contract to rotate the owner of the Safe.
- Refactors `as_execute_user_op_call_data` in the `Is4337Encodable` as for types of transactions this code will be exactly the same.
- Introduces an on-chain integration test to swap the Safe owner and a generic mock RPC HTTP client for other integration tests.


### ⚠️ Breaking Changes
- Renames `transaction_transfer` to `tx_transfer`. Less verbosity, especially as we introduce other types of transactions.


### 🔜 Changes coming soon
- Rotating owners in Optimism too

### Notes
- Tests assisted by AI (manually reviewed)