### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @paolodamico @marioradonic @tomislavhoman @lukejmann @andy-t-wang @aurel-fr @murph
+* @paolodamico @sideround @tomislavhoman @lukejmann @andy-t-wang @aurel-fr @murph
+.github/CODEOWNERS @paolodamico @murph


### PR DESCRIPTION
Keeping the list up-to-date. Adds @sideround, removes marioradonic