### PR TITLE
chore: only allow releases from main

### DIFF
--- a/.github/workflows/initiate-release.yml
+++ b/.github/workflows/initiate-release.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   initiate-release:
     runs-on: ubuntu-latest
+    # running releases is only allowed on main
+    if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: write # required to open the PR and generate release notes


### PR DESCRIPTION
Creating releases from non-main branches may lead to accidentally releasing something that's not ready (as it hasn't been reviewed and merged)