### PR TITLE
refactor!: Return ciphertext in bytes

### DIFF
--- a/bedrock/src/nitro_enclave/mod.rs
+++ b/bedrock/src/nitro_enclave/mod.rs
@@ -160,7 +160,7 @@ impl EnclaveAttestationVerifier {
 
         Ok(VerifiedAttestationWithCiphertext {
             verified_attestation,
-            ciphertext_base64: STANDARD.encode(ciphertext),
+            ciphertext,
         })
     }
 }

--- a/bedrock/src/nitro_enclave/tests.rs
+++ b/bedrock/src/nitro_enclave/tests.rs
@@ -155,12 +155,8 @@ fn test_verify_attestation_document_and_encrypt() {
         public_key_base64
     );
 
-    let result_ciphertext = STANDARD
-        .decode(result.ciphertext_base64)
-        .expect("failed to decode ciphertext");
-
     let decrypted_ciphertext = secret_key
-        .unseal(&result_ciphertext)
+        .unseal(&result.ciphertext)
         .expect("decrypt error");
     assert_eq!(decrypted_ciphertext, plaintext);
 }

--- a/bedrock/src/nitro_enclave/types.rs
+++ b/bedrock/src/nitro_enclave/types.rs
@@ -104,6 +104,6 @@ impl VerifiedAttestation {
 pub struct VerifiedAttestationWithCiphertext {
     /// The verified attestation
     pub verified_attestation: VerifiedAttestation,
-    /// The base64 encoded ciphertext
-    pub ciphertext_base64: String,
+    /// The ciphertext bytes
+    pub ciphertext: Vec<u8>,
 }


### PR DESCRIPTION
This PR updates `VerifiedAttestationWithCiphertext` to return `ciphertext` in byte form.

Mobile client had to do some encoding gymnastics when they want it to convert the ciphertext to hex encoding. (Base64 -> bytes -> Hex) By returning the byte array we let the client handle encoding

We can afford this breaking changes since this module is not deployed yet. Will create a `minor` version for it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return `ciphertext` as raw bytes in `VerifiedAttestationWithCiphertext` and update encryption code and tests accordingly.
> 
> - **API Change**
>   - `types::VerifiedAttestationWithCiphertext`: replace `ciphertext_base64: String` with `ciphertext: Vec<u8>`.
> - **Encryption Flow**
>   - `mod.rs::verify_attestation_document_and_encrypt`: now returns raw `ciphertext` bytes instead of base64-encoding them.
> - **Tests**
>   - Update to use `result.ciphertext` directly for decryption; remove base64 decode step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370b2fbb83a087a71111cb2159d1f7a7e9a02a99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->