### PR TITLE
feat: add detailed logging to backup restore

### DIFF
--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -257,6 +257,18 @@ impl ManifestManager {
     pub fn write_manifest(&self, manifest: &BackupManifest) -> Result<(), BackupError> {
         let serialized =
             serde_json::to_vec(manifest).context("serialize BackupManifest")?;
+        let BackupManifest::V0(manifest) = manifest;
+
+        crate::info!(
+            "Writing manifest file with files: {}",
+            manifest
+                .files
+                .iter()
+                .map(|f| f.designator.to_string())
+                .collect::<Vec<String>>()
+                .join(", "),
+        );
+
         self.file_system
             .write_file(Self::GLOBAL_MANIFEST_FILE, serialized)
             .context("write manifest.json")?;

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -73,7 +73,9 @@ impl BackupManager {
         factor_secret: String,
         factor_type: FactorType,
     ) -> Result<CreatedBackup, BackupError> {
-        log::info!("[BackupManager] creating sealed backup for new user with factor: {factor_type:?}");
+        crate::info!(
+            "Creating sealed backup for new user with factor: {factor_type:?}"
+        );
 
         // 1: Decode the root secret from multiple formats
         let root_secret = RootKey::from_json(root_secret)
@@ -173,9 +175,7 @@ impl BackupManager {
         factor_type: FactorType,
         current_manifest_hash: String,
     ) -> Result<DecryptedBackup, BackupError> {
-        log::info!(
-            "[BackupManager] decrypting sealed backup with factor: {factor_type:?}"
-        );
+        crate::info!("Decrypting sealed backup with factor: {factor_type:?}");
 
         if sealed_backup_data.is_empty() {
             return Err(BackupError::InvalidSealedBackupError);
@@ -205,6 +205,8 @@ impl BackupManager {
             .map_err(|_| BackupError::DecryptBackupError)?;
 
         let unsealed_backup = BackupFormat::from_bytes(&unsealed_backup)?;
+
+        crate::info!("Backup successfully decrypted, initiating unpacking.");
 
         Self::unpack_backup_to_filesystem(&unsealed_backup, current_manifest_hash)?;
 
@@ -251,7 +253,7 @@ impl BackupManager {
         existing_factor_type: FactorType,
         new_factor_type: FactorType,
     ) -> Result<AddNewFactorResult, BackupError> {
-        log::info!("[BackupManager] creating new encrypted backup key: existing - {existing_factor_type:?}, new - {new_factor_type:?}");
+        crate::info!("Creating new encrypted backup key: existing - {existing_factor_type:?}, new - {new_factor_type:?}");
 
         // 1: Decode the backup keypair that was encrypted with the existing factor secret
         let encrypted_backup_keypair_bytes =
@@ -314,6 +316,7 @@ impl BackupManager {
     /// # Errors
     /// - Returns an error if the post-processing fails.
     pub fn post_delete_backup(&self) -> Result<(), BackupError> {
+        crate::info!("Cleaning up backup system... Deleting manifest file after backup is disabled/deleted.");
         let manifest = ManifestManager::new();
         manifest.danger_delete_manifest()?;
         Ok(())
@@ -333,6 +336,8 @@ impl BackupManager {
         let fs = get_filesystem_raw()?;
         let mut manifest_entries: Vec<V0BackupManifestEntry> =
             Vec::with_capacity(backup.files.len());
+
+        crate::info!("Processing {} files for unpacking.", backup.files.len());
 
         for file in &backup.files {
             let rel_path = file.path.trim_start_matches('/');
@@ -384,10 +389,16 @@ impl BackupManager {
         // See: `test_decrypt_and_unpack_default_manifest_hash`
         let previous_manifest_hash =
             if current_manifest_hash_hex == BackupManifest::DEFAULT_HASH {
+                crate::info!("Manifest hash is the default hash, setting to None");
                 None
             } else {
                 Some(current_manifest_hash_hex)
             };
+
+        crate::info!(
+            "Saving manifest file with hash: {previous_manifest_hash:?} and {} files",
+            manifest_entries.len()
+        );
 
         let manifest = BackupManifest::V0(V0BackupManifest {
             previous_manifest_hash,


### PR DESCRIPTION
The logging will help us determine why the manifest is not being properly constructed after restore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise info logs across backup restore/unpack flows and manifest writes, replacing prior log calls and improving visibility into processed files and hashes.
> 
> - **Backup**:
>   - **Restore/Unpack Flow**:
>     - Log decryption start, success, and unpack initiation in `decrypt_and_unpack_sealed_backup`.
>     - Log file processing counts, checksum discrepancies, and write outcomes in `unpack_backup_to_filesystem`.
>     - Log manifest hash handling (default vs previous) and final save details (hash, file count).
>   - **Factor Ops**:
>     - Log creation of new encrypted backup key during `add_new_factor`.
>   - **Lifecycle**:
>     - Log cleanup during `post_delete_backup`.
>   - **New User Flow**:
>     - Log sealed backup creation in `create_sealed_backup_for_new_user`.
>   - Replace `log::info!` with `crate::info!` for uniform logging.
> - **Manifest**:
>   - Log files included when writing the manifest in `write_manifest` (destructures `BackupManifest::V0` to access entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e128d4bfcf2009e1fad789059009450fcd8472. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->