### PR TITLE
feat: add canonical manifest hashing

### DIFF
--- a/bedrock/src/backup/backup_format/v0.rs
+++ b/bedrock/src/backup/backup_format/v0.rs
@@ -15,10 +15,6 @@ const ROOT_SECRET_FILE: &str = "root_secret.json";
 /// NOTE: Important not to incorporate types with undefined iteration order into this struct (e.g. `HashMap`)
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct V0BackupManifest {
-    /// Hash of the immediately previous manifest state (hex, 32-byte blake3), if any.
-    ///
-    /// Used to provide a lightweight chain of states for conflict detection and auditing.
-    pub previous_manifest_hash: Option<String>,
     /// Entries describing each file to be backed up.
     pub files: Vec<V0BackupManifestEntry>,
 }

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use bedrock_macros::bedrock_export;
 use chrono::Utc;
 use crypto_box::PublicKey;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use crate::backup::backup_format::v0::{V0BackupManifest, V0BackupManifestEntry};
@@ -26,6 +27,8 @@ use crate::{
     primitives::filesystem::get_filesystem_raw,
 };
 
+static DEFAULT_DIGEST_HEX: OnceCell<String> = OnceCell::new();
+
 /// A single, global manifest that describes the backup content.
 ///
 /// All operations on the backup use this as a source.
@@ -37,7 +40,7 @@ pub enum BackupManifest {
 
 impl BackupManifest {
     /// Returns the canonical bytes used for manifest hashing, independent of JSON formatting.
-    fn hash_material(&self) -> Result<Vec<u8>, BackupError> {
+    fn to_digest(&self) -> Result<Vec<u8>, BackupError> {
         let mut out = Vec::with_capacity(64);
         out.extend_from_slice(b"BEDROCK_MANIFEST");
         match self {
@@ -45,33 +48,19 @@ impl BackupManifest {
                 // Version tag for V0
                 out.push(0x00);
 
-                // Previous manifest hash: 0x00 for None, 0x01 + 32 bytes for Some
-                match &m.previous_manifest_hash {
-                    None => out.push(0x00),
-                    Some(prev_hex) => {
-                        out.push(0x01);
-                        let prev_bytes = hex::decode(prev_hex).map_err(|_| {
-                            BackupError::InvalidFileForBackup(
-                                "Invalid previous manifest hash encoding".to_string(),
-                            )
-                        })?;
-                        let prev_arr: [u8; 32] =
-                            prev_bytes.try_into().map_err(|_| {
-                                BackupError::InvalidFileForBackup(
-                                    "Invalid previous manifest hash length".to_string(),
-                                )
-                            })?;
-                        out.extend_from_slice(&prev_arr);
-                    }
-                }
-
                 // Files length (u32 LE)
                 #[allow(clippy::cast_possible_truncation)]
                 let count = m.files.len() as u32;
-                out.extend_from_slice(&count.to_le_bytes());
+                out.extend_from_slice(&count.to_be_bytes());
+
+                let mut sorted_files: Vec<&V0BackupManifestEntry> =
+                    m.files.iter().collect();
+                sorted_files.sort_by(|a, b| {
+                    a.file_path.to_lowercase().cmp(&b.file_path.to_lowercase())
+                });
 
                 // Files in-order
-                for entry in &m.files {
+                for entry in sorted_files {
                     // Designator (snake_case) + 0x00 separator
                     out.extend_from_slice(entry.designator.to_string().as_bytes());
                     out.push(0x00);
@@ -109,29 +98,35 @@ impl BackupManifest {
     }
 
     /// Computes the BLAKE3 hash of the canonical manifest bytes.
-    pub fn calculate_hash(&self) -> Result<[u8; 32], BackupError> {
-        let material = self.hash_material()?;
-        Ok(blake3::hash(&material).into())
+    pub fn to_hash(&self) -> Result<[u8; 32], BackupError> {
+        let pre_image = self.to_digest()?;
+        Ok(blake3::hash(&pre_image).into())
     }
 
     /// Returns the hex-encoded hash of the default (empty) manifest.
     #[must_use]
-    pub fn default_hash_hex() -> String {
-        // This cannot fail: no previous hash, no files to decode.
-        hex::encode(
-            Self::default()
-                .calculate_hash()
-                .expect("default manifest hash is infallible"),
-        )
+    pub fn default_hash_hex() -> &'static str {
+        DEFAULT_DIGEST_HEX.get_or_init(|| {
+            // This cannot fail: no previous hash, no files to decode.
+            hex::encode(
+                Self::default()
+                    .to_hash()
+                    .expect("default manifest hash is infallible"),
+            )
+        })
+    }
+
+    /// The number of file entries in the manifest.
+    pub const fn entries_length(&self) -> usize {
+        match self {
+            Self::V0(m) => m.files.len(),
+        }
     }
 }
 
 impl Default for BackupManifest {
     fn default() -> Self {
-        Self::V0(V0BackupManifest {
-            previous_manifest_hash: None,
-            files: vec![],
-        })
+        Self::V0(V0BackupManifest { files: vec![] })
     }
 }
 
@@ -452,7 +447,7 @@ impl ManifestManager {
             Ok(bytes) => {
                 let manifest: BackupManifest =
                     serde_json::from_slice(&bytes).context("parse BackupManifest")?;
-                let checksum = manifest.calculate_hash()?;
+                let checksum = manifest.to_hash()?;
                 Ok((manifest, checksum))
             }
             Err(FileSystemError::FileDoesNotExist) => {
@@ -504,15 +499,13 @@ impl ManifestManager {
             ManifestMutation::Changed => (),
         }
 
-        manifest.previous_manifest_hash = Some(hex::encode(local_hash));
-
         let files = self.build_unsealed_backup_files_from_manifest(&manifest)?;
         let unsealed_backup = V0Backup::new(root, files).to_bytes()?;
         let sealed_backup =
             BackupManager::seal_backup_with_public_key(&unsealed_backup, &pk)?;
 
         let updated_manifest = BackupManifest::V0(manifest);
-        let new_manifest_hash = updated_manifest.calculate_hash()?;
+        let new_manifest_hash = updated_manifest.to_hash()?;
 
         BackupServiceClient::sync(
             hex::encode(local_hash),
@@ -559,4 +552,22 @@ impl Default for ManifestManager {
 enum ManifestMutation {
     NoChange,
     Changed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_hash() {
+        let manifest = BackupManifest::V0(V0BackupManifest { files: vec![] });
+        let digest = manifest.to_digest().unwrap();
+        // 0u8 = version tag; 4x 0u8 = u32 length of files
+        assert_eq!(digest, b"BEDROCK_MANIFEST\x00\x00\x00\x00\x00");
+        let hash = manifest.to_hash().unwrap();
+        assert_eq!(
+            hex::encode(hash),
+            "85c9d3437fbd13e892674f14603650fff5cb32db314d375722f39f84f501036f"
+        );
+    }
 }

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -393,7 +393,7 @@ impl BackupManager {
         // this must be set as `None`, otherwise the remote will appear ahead when it's not.
         // See: `test_decrypt_and_unpack_default_manifest_hash`
         let previous_manifest_hash =
-            if current_manifest_hash_hex == BackupManifest::DEFAULT_HASH {
+            if current_manifest_hash_hex == BackupManifest::default_hash_hex() {
                 crate::info!("Manifest hash is the default hash, setting to None");
                 None
             } else {

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -93,7 +93,7 @@ impl BackupServiceApi for FakeBackupServiceApi {
             manifest_hash: s
                 .remote_manifest_hash_hex
                 .clone()
-                .unwrap_or_else(|| hex::encode(blake3::hash(b"").as_bytes())),
+                .unwrap_or_else(BackupManifest::default_hash_hex),
             encryption_keys: None,
             sync_factor_count: None,
             main_factors: None,
@@ -153,7 +153,7 @@ fn test_backup_manifest_default_hash() {
         files: vec![],
     });
     let hash = hex::encode(manifest.calculate_hash().unwrap());
-    assert_eq!(hash, BackupManifest::DEFAULT_HASH);
+    assert_eq!(hash, BackupManifest::default_hash_hex());
 }
 
 #[tokio::test]
@@ -235,7 +235,7 @@ async fn test_list_files_corrupted_manifest() {
     mw.write_file("manifest.json", b"not-json".to_vec())
         .unwrap();
 
-    api.set_remote_hash(hex::encode(blake3::hash(b"").as_bytes()));
+    api.set_remote_hash(BackupManifest::default_hash_hex());
 
     let mgr = ManifestManager::new_with_prefix("backup_test_list_corrupted");
     let err = mgr
@@ -866,7 +866,7 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             prf_result.clone(),
             FactorType::Prf,
-            hex::encode(blake3::hash(b"").as_bytes()),
+            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 
@@ -893,7 +893,7 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             incorrect_factor_secret,
             FactorType::Prf,
-            hex::encode(blake3::hash(b"").as_bytes()),
+            BackupManifest::default_hash_hex(),
         )
         .expect_err("Expected decryption to fail with incorrect factor secret");
     assert_eq!(
@@ -914,7 +914,7 @@ fn test_decrypt_sealed_backup_with_prf() {
             incorrect_encrypted_backup_keypair,
             prf_result,
             FactorType::Prf,
-            hex::encode(blake3::hash(b"").as_bytes()),
+            BackupManifest::default_hash_hex(),
         )
         .expect_err(
             "Expected decryption to fail with incorrect encrypted backup keypair",
@@ -1019,7 +1019,7 @@ fn test_unpack_writes_files_and_manifest() {
             hex::encode(encrypted_backup_keypair),
             hex::encode(factor_sk.to_bytes()),
             FactorType::Prf,
-            hex::encode(blake3::hash(b"").as_bytes()),
+            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -93,7 +93,7 @@ impl BackupServiceApi for FakeBackupServiceApi {
             manifest_hash: s
                 .remote_manifest_hash_hex
                 .clone()
-                .unwrap_or_else(BackupManifest::default_hash_hex),
+                .unwrap_or_else(|| BackupManifest::default_hash_hex().to_string()),
             encryption_keys: None,
             sync_factor_count: None,
             main_factors: None,
@@ -131,14 +131,14 @@ fn get_manifest_from_disk(prefix: &str) -> BackupManifest {
 }
 
 fn compute_manifest_hash(manifest: &BackupManifest) -> String {
-    hex::encode(manifest.calculate_hash().unwrap())
+    hex::encode(manifest.to_hash().unwrap())
 }
 
 fn compute_manifest_hash_from_disk(prefix: &str) -> String {
     let fs: Arc<dyn FileSystem> = get_filesystem_raw().unwrap().clone();
     let bytes = fs.read_file(format!("{prefix}/manifest.json")).unwrap();
     let manifest: BackupManifest = serde_json::from_slice(&bytes).unwrap();
-    hex::encode(manifest.calculate_hash().unwrap())
+    hex::encode(manifest.to_hash().unwrap())
 }
 
 fn write_global_file(path: &str, contents: &[u8]) {
@@ -148,11 +148,8 @@ fn write_global_file(path: &str, contents: &[u8]) {
 
 #[test]
 fn test_backup_manifest_default_hash() {
-    let manifest = BackupManifest::V0(V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
-    let hash = hex::encode(manifest.calculate_hash().unwrap());
+    let manifest = BackupManifest::V0(V0BackupManifest { files: vec![] });
+    let hash = hex::encode(manifest.to_hash().unwrap());
     assert_eq!(hash, BackupManifest::default_hash_hex());
 }
 
@@ -164,7 +161,6 @@ async fn test_list_files_happy_path() {
 
     // Prepare manifest with two files
     let m = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
         files: vec![
             V0BackupManifestEntry {
                 designator: BackupFileDesignator::OrbPkg,
@@ -193,10 +189,7 @@ async fn test_list_files_stale_remote() {
     api.reset();
 
     // Local manifest
-    let m = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
+    let m = BackupManifest::V0(V0BackupManifest { files: vec![] });
     write_manifest_with_prefix(&m, "backup_test_list_2");
     // Remote is different
     api.set_remote_hash(hex::encode(blake3::hash(b"different").as_bytes()));
@@ -235,7 +228,7 @@ async fn test_list_files_corrupted_manifest() {
     mw.write_file("manifest.json", b"not-json".to_vec())
         .unwrap();
 
-    api.set_remote_hash(BackupManifest::default_hash_hex());
+    api.set_remote_hash(BackupManifest::default_hash_hex().to_string());
 
     let mgr = ManifestManager::new_with_prefix("backup_test_list_corrupted");
     let err = mgr
@@ -256,10 +249,7 @@ async fn test_store_file_happy_path_and_commit() {
     api.reset();
 
     // Local empty manifest and matching remote
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
+    let m0 = BackupManifest::V0(V0BackupManifest { files: vec![] });
     write_manifest_with_prefix(&m0, "backup_test_store_1");
     api.set_remote_hash(compute_manifest_hash_from_disk("backup_test_store_1"));
 
@@ -280,7 +270,7 @@ async fn test_store_file_happy_path_and_commit() {
     .await
     .unwrap();
 
-    // Manifest committed with previous hash == m0 and one entry
+    // Manifest committed with one entry
     let fs = get_filesystem_raw().unwrap().clone();
     let committed = fs
         .read_file("backup_test_store_1/manifest.json".to_string())
@@ -288,10 +278,6 @@ async fn test_store_file_happy_path_and_commit() {
     let committed: serde_json::Value = serde_json::from_slice(&committed).unwrap();
     assert_eq!(committed["version"], "V0");
     assert_eq!(committed["manifest"]["files"].as_array().unwrap().len(), 1);
-    assert_eq!(
-        committed["manifest"]["previous_manifest_hash"],
-        serde_json::Value::String(compute_manifest_hash(&m0))
-    );
 }
 
 #[tokio::test]
@@ -302,7 +288,6 @@ async fn test_store_file_accepts_dot_slash_path() {
 
     // Local empty manifest and matching remote
     let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
         files: vec![],
     });
     write_manifest_with_prefix(&m0, "backup_test_store_dot_path");
@@ -346,10 +331,7 @@ async fn test_store_file_propagates_sync_failure() {
     api.reset();
 
     // Local empty manifest and matching remote
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
+    let m0 = BackupManifest::V0(V0BackupManifest { files: vec![] });
     write_manifest_with_prefix(&m0, "backup_test_store_sync_failure");
     api.set_remote_hash(compute_manifest_hash_from_disk(
         "backup_test_store_sync_failure",
@@ -387,10 +369,7 @@ async fn test_store_file_fails_when_remote_ahead() {
     let api = init_test_globals();
     api.reset();
 
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
+    let m0 = BackupManifest::V0(V0BackupManifest { files: vec![] });
     write_manifest_with_prefix(&m0, "backup_test_store_2");
     api.set_remote_hash(hex::encode(blake3::hash(b"different").as_bytes()));
 
@@ -416,10 +395,7 @@ async fn test_store_file_invalid_source_path() {
     let api = init_test_globals();
     api.reset();
 
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
-        files: vec![],
-    });
+    let m0 = BackupManifest::V0(V0BackupManifest { files: vec![] });
     write_manifest_with_prefix(&m0, "backup_test_store_3");
     api.set_remote_hash(compute_manifest_hash_from_disk("backup_test_store_3"));
 
@@ -448,8 +424,7 @@ async fn test_store_file_checksum_mismatch_existing_entry() {
     // Prepare manifest with one entry that has wrong checksum vs actual file
     write_global_file("orb_pkg/existing.bin", b"ACTUAL");
     let wrong_checksum = hex::encode(blake3::hash(b"DIFFERENT").as_bytes());
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
+    let m0 = BackupManifest::V0(V0BackupManifest {
         files: vec![V0BackupManifestEntry {
             designator: BackupFileDesignator::OrbPkg,
             file_path: "orb_pkg/existing.bin".to_string(),
@@ -487,8 +462,7 @@ async fn test_store_file_checksum_mismatch_when_file_modified() {
     // Prepare manifest with one entry that matches the original file contents
     write_global_file("pcp/changed.bin", b"ORIGINAL");
     let correct_checksum = hex::encode(blake3::hash(b"ORIGINAL").as_bytes());
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
+    let m0 = BackupManifest::V0(V0BackupManifest {
         files: vec![V0BackupManifestEntry {
             designator: BackupFileDesignator::OrbPkg,
             file_path: "pcp/changed.bin".to_string(),
@@ -532,8 +506,7 @@ async fn test_store_file_fails_when_manifest_references_missing_file() {
 
     // Prepare manifest with an entry pointing to a non-existent file
     let bogus_checksum = hex::encode(blake3::hash(b"ANY").as_bytes());
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
+    let m0 = BackupManifest::V0(V0BackupManifest {
         files: vec![V0BackupManifestEntry {
             designator: BackupFileDesignator::OrbPkg,
             file_path: "pcp/missing.bin".to_string(),
@@ -577,8 +550,7 @@ async fn test_replace_all_files_for_designator_happy_path() {
     write_global_file("docs/keep.bin", b"KEEP");
 
     // Initial manifest with two Orb entries and one Document entry
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
+    let m0 = BackupManifest::V0(V0BackupManifest {
         files: vec![
             V0BackupManifestEntry {
                 designator: BackupFileDesignator::OrbPkg,
@@ -625,11 +597,6 @@ async fn test_replace_all_files_for_designator_happy_path() {
         .unwrap();
     let committed: serde_json::Value = serde_json::from_slice(&committed).unwrap();
     assert_eq!(committed["version"], "V0");
-    let prev_hash = committed["manifest"]["previous_manifest_hash"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    assert_eq!(prev_hash, compute_manifest_hash(&m0));
     let files = committed["manifest"]["files"].as_array().unwrap();
     // 1 (new orb) + 1 (existing document)
     assert_eq!(files.len(), 2);
@@ -660,8 +627,7 @@ async fn test_remove_file_happy_and_not_found() {
     write_global_file("docs/keep.bin", b"KEEP");
 
     // Initial manifest with two entries (one to be removed)
-    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
-        previous_manifest_hash: None,
+    let m0 = BackupManifest::V0(V0BackupManifest {
         files: vec![
             V0BackupManifestEntry {
                 designator: BackupFileDesignator::OrbPkg,
@@ -866,7 +832,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             prf_result.clone(),
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 
@@ -893,7 +858,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             incorrect_factor_secret,
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .expect_err("Expected decryption to fail with incorrect factor secret");
     assert_eq!(
@@ -914,7 +878,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             incorrect_encrypted_backup_keypair,
             prf_result,
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .expect_err(
             "Expected decryption to fail with incorrect encrypted backup keypair",
@@ -954,7 +917,6 @@ async fn test_decrypt_and_unpack_default_manifest_hash() {
             create_result.encrypted_backup_keypair.clone(),
             prf_result,
             FactorType::Prf,
-            create_result.manifest_hash.clone(),
         )
         .unwrap();
 
@@ -965,9 +927,6 @@ async fn test_decrypt_and_unpack_default_manifest_hash() {
 
     let manifest = get_manifest_from_disk("backup_manager");
     let unpacked_manifest_hash = compute_manifest_hash(&manifest);
-    let BackupManifest::V0(manifest) = manifest;
-
-    assert_eq!(manifest.previous_manifest_hash, None);
     assert_eq!(unpacked_manifest_hash, create_result.manifest_hash);
 }
 
@@ -1019,7 +978,6 @@ fn test_unpack_writes_files_and_manifest() {
             hex::encode(encrypted_backup_keypair),
             hex::encode(factor_sk.to_bytes()),
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce canonical, order-independent manifest hashing and drop `previous_manifest_hash`, updating APIs, sync logic, and tests.
> 
> - **Manifest hashing**:
>   - Add canonical digest via `BackupManifest::to_digest` and `to_hash` (prefix `BEDROCK_MANIFEST`, version tag, file count, sorted `files`, and raw checksum bytes) independent of JSON formatting.
>   - Replace `calculate_hash` and hardcoded `DEFAULT_HASH` with `default_hash_hex()` (cached with `OnceCell`) and `entries_length()`.
>   - Update reads/sync to use `to_hash`.
> - **Manifest format/flow**:
>   - Remove `previous_manifest_hash` from `V0BackupManifest` and stop setting/propagating it during store/replace/remove and unpack.
>   - `BackupManager::unpack_backup_to_filesystem` no longer accepts or logs previous hash; logs current computed hash instead.
> - **API changes**:
>   - `BackupManager::decrypt_and_unpack_sealed_backup` signature drops `current_manifest_hash` arg.
> - **Tests/mocks**:
>   - Update helpers to use `to_hash` and `default_hash_hex()`; adjust expected default hash to `85c9d3...036f`.
>   - Remove assertions referencing `previous_manifest_hash`; adapt fake service default remote hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d200bb7117a1dcd95b0d0ad2c4ac01ceb9a0c324. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->