### PR TITLE
feat: add WLD vault migration to re7WLD Morpho vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +869,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -877,6 +907,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +941,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +967,16 @@ name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -2315,6 +2380,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2444,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,7 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3247,6 +3344,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4093,7 +4199,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4325,13 +4431,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.16.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -4345,7 +4452,7 @@ dependencies = [
  "rand 0.9.2",
  "rlp",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -4412,7 +4519,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5115,7 +5222,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -40,6 +40,8 @@ pub enum TransactionTypeId {
     MorphoDeposit = 136,
     /// Morpho-specific vault withdraw
     MorphoWithdraw = 137,
+    /// Morpho vault migration (withdraw from old vault, approve, deposit to new vault)
+    MorphoMigrate = 138,
 }
 
 impl TransactionTypeId {

--- a/bedrock/src/transactions/contracts/mod.rs
+++ b/bedrock/src/transactions/contracts/mod.rs
@@ -3,9 +3,9 @@
 pub mod erc20;
 /// Generic ERC-4626 vault contract interface and implementation.
 pub mod erc4626;
-/// WLD vault operations including migration to re7WLD.
-pub mod wld_vault;
 /// Utilities for batching multiple transactions via the Safe `MultiSend` contract.
 pub mod multisend;
+/// WLD vault operations including migration to re7WLD.
+pub mod wld_vault;
 pub mod world_campaign_manager;
 pub mod world_gift_manager;

--- a/bedrock/src/transactions/contracts/mod.rs
+++ b/bedrock/src/transactions/contracts/mod.rs
@@ -3,6 +3,8 @@
 pub mod erc20;
 /// Generic ERC-4626 vault contract interface and implementation.
 pub mod erc4626;
+/// WLD vault operations including migration to re7WLD.
+pub mod wld_vault;
 /// Utilities for batching multiple transactions via the Safe `MultiSend` contract.
 pub mod multisend;
 pub mod world_campaign_manager;

--- a/bedrock/src/transactions/contracts/wld_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_vault.rs
@@ -11,7 +11,9 @@ use crate::smart_account::{
 };
 use crate::transactions::contracts::erc20::{Erc20, IErc20};
 use crate::transactions::contracts::erc4626::IERC4626;
-use crate::transactions::contracts::multisend::{MultiSend, MultiSendTx, MULTISEND_ADDRESS};
+use crate::transactions::contracts::multisend::{
+    MultiSend, MultiSendTx, MULTISEND_ADDRESS,
+};
 use crate::transactions::rpc::{RpcClient, RpcError};
 
 /// The WLD token address on World Chain.
@@ -122,7 +124,8 @@ impl WldVault {
         // 2. Validate that the user has funds to migrate
         if wld_amount.is_zero() {
             return Err(RpcError::InvalidResponse {
-                error_message: "Cannot migrate - user has no funds in the old vault".to_string(),
+                error_message: "Cannot migrate - user has no funds in the old vault"
+                    .to_string(),
             });
         }
 
@@ -262,11 +265,8 @@ mod tests {
 
         let wld_balance = U256::from(10u128.pow(18)); // 1 WLD
 
-        let test_rpc_client = setup_test_rpc_client(
-            old_vault_address,
-            user_address,
-            wld_balance,
-        );
+        let test_rpc_client =
+            setup_test_rpc_client(old_vault_address, user_address, wld_balance);
 
         let migration = WldVault::migrate_to_re7wld(
             &test_rpc_client,
@@ -297,11 +297,8 @@ mod tests {
 
         let wld_balance = U256::from(0); // No funds
 
-        let test_rpc_client = setup_test_rpc_client(
-            old_vault_address,
-            user_address,
-            wld_balance,
-        );
+        let test_rpc_client =
+            setup_test_rpc_client(old_vault_address, user_address, wld_balance);
 
         let result = WldVault::migrate_to_re7wld(
             &test_rpc_client,
@@ -334,11 +331,8 @@ mod tests {
 
         let wld_balance = U256::from(10u128.pow(18));
 
-        let test_rpc_client = setup_test_rpc_client(
-            old_vault_address,
-            user_address,
-            wld_balance,
-        );
+        let test_rpc_client =
+            setup_test_rpc_client(old_vault_address, user_address, wld_balance);
 
         let migration = WldVault::migrate_to_re7wld(
             &test_rpc_client,

--- a/bedrock/src/transactions/contracts/wld_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_vault.rs
@@ -1,0 +1,362 @@
+use alloy::{
+    primitives::{address, Address, Bytes, U256},
+    sol,
+    sol_types::SolCall,
+};
+
+use crate::primitives::{Network, PrimitiveError};
+use crate::smart_account::{
+    ISafe4337Module, InstructionFlag, Is4337Encodable, NonceKeyV1, SafeOperation,
+    TransactionTypeId, UserOperation,
+};
+use crate::transactions::contracts::erc20::{Erc20, IErc20};
+use crate::transactions::contracts::erc4626::IERC4626;
+use crate::transactions::contracts::multisend::{MultiSend, MultiSendTx, MULTISEND_ADDRESS};
+use crate::transactions::rpc::{RpcClient, RpcError};
+
+/// The WLD token address on World Chain.
+pub const WLD_TOKEN_ADDRESS: Address =
+    address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003");
+
+sol! {
+    /// Interface for the WLD vault contract.
+    #[derive(serde::Serialize)]
+    interface IWldVault {
+        /// Withdraws all of the caller's shares from the vault.
+        function withdrawAll() external;
+    }
+}
+
+// =============================================================================
+// WLD Vault Migration Transaction Type
+// =============================================================================
+
+/// Represents a WLD vault migration operation.
+///
+/// This transaction bundles three operations:
+/// 1. Withdraw all from the old WLD vault
+/// 2. Approve the new vault to spend the asset
+/// 3. Deposit into the new re7WLD Morpho vault
+#[derive(Debug)]
+pub struct WldVault {
+    /// The encoded MultiSend call data for the operation.
+    pub call_data: Vec<u8>,
+    /// The target address for the operation (MultiSend contract).
+    to: Address,
+    /// The Safe operation type for the operation.
+    operation: SafeOperation,
+    /// Metadata for nonce generation.
+    metadata: [u8; 10],
+}
+
+impl WldVault {
+    /// Helper function to fetch and decode a U256 value from an RPC call.
+    async fn fetch_u256(
+        rpc_client: &RpcClient,
+        network: Network,
+        contract_address: Address,
+        call_data: Vec<u8>,
+        function_name: &str,
+    ) -> Result<U256, RpcError> {
+        let result = rpc_client
+            .eth_call(network, contract_address, call_data.into())
+            .await?;
+
+        if result.len() != 32 {
+            return Err(RpcError::InvalidResponse {
+                error_message: format!(
+                    "Invalid {}() response: expected exactly 32 bytes, got {} bytes",
+                    function_name,
+                    result.len()
+                ),
+            });
+        }
+
+        Ok(U256::from_be_slice(&result[..32]))
+    }
+
+    /// Creates a new migration operation to move funds from the old WLD vault to the re7WLD Morpho vault.
+    ///
+    /// This operation:
+    /// 1. Withdraws all from the old vault using `withdrawAll()`
+    /// 2. Approves the new vault to spend the asset tokens
+    /// 3. Deposits into the new re7WLD Morpho vault
+    ///
+    /// # Arguments
+    /// * `rpc_client` - The RPC client for making blockchain queries.
+    /// * `network` - The blockchain network to use.
+    /// * `old_vault_address` - The address of the old WLD vault to withdraw from.
+    /// * `new_vault_address` - The address of the new re7WLD Morpho vault to deposit into.
+    /// * `user_address` - The address of the user performing the migration.
+    /// * `metadata` - Protocol-specific metadata for nonce generation.
+    ///
+    /// # Returns
+    /// A `WldVault` struct configured for the migration operation.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The user has no shares in the old vault
+    /// - The RPC calls fail
+    pub async fn migrate_to_re7wld(
+        rpc_client: &RpcClient,
+        network: Network,
+        old_vault_address: Address,
+        new_vault_address: Address,
+        user_address: Address,
+        metadata: [u8; 10],
+    ) -> Result<Self, RpcError> {
+        // 1. Query the user's WLD balance in the old vault (includes accrued interest)
+        let balance_call_data = IErc20::balanceOfCall {
+            account: user_address,
+        }
+        .abi_encode();
+        let wld_amount = Self::fetch_u256(
+            rpc_client,
+            network,
+            old_vault_address,
+            balance_call_data,
+            "balanceOf",
+        )
+        .await?;
+
+        // 2. Validate that the user has funds to migrate
+        if wld_amount.is_zero() {
+            return Err(RpcError::InvalidResponse {
+                error_message: "Cannot migrate - user has no funds in the old vault".to_string(),
+            });
+        }
+
+        // 3. Encode the withdrawAll call for the old vault
+        let withdraw_all_data = IWldVault::withdrawAllCall {}.abi_encode();
+
+        // 4. Encode the approve call (approve new vault to spend WLD)
+        let approve_data = Erc20::encode_approve(new_vault_address, wld_amount);
+
+        // 5. Encode the deposit call for the new vault
+        let deposit_data = IERC4626::depositCall {
+            assets: wld_amount,
+            receiver: user_address,
+        }
+        .abi_encode();
+
+        // 6. Build the MultiSend bundle (withdrawAll + approve + deposit)
+        let entries = vec![
+            MultiSendTx {
+                operation: SafeOperation::Call as u8,
+                to: old_vault_address,
+                value: U256::ZERO,
+                data_length: U256::from(withdraw_all_data.len()),
+                data: withdraw_all_data.into(),
+            },
+            MultiSendTx {
+                operation: SafeOperation::Call as u8,
+                to: WLD_TOKEN_ADDRESS,
+                value: U256::ZERO,
+                data_length: U256::from(approve_data.len()),
+                data: approve_data.into(),
+            },
+            MultiSendTx {
+                operation: SafeOperation::Call as u8,
+                to: new_vault_address,
+                value: U256::ZERO,
+                data_length: U256::from(deposit_data.len()),
+                data: deposit_data.into(),
+            },
+        ];
+
+        let bundle = MultiSend::build_bundle(&entries);
+
+        Ok(Self {
+            call_data: bundle.data,
+            to: MULTISEND_ADDRESS,
+            operation: SafeOperation::DelegateCall,
+            metadata,
+        })
+    }
+}
+
+impl Is4337Encodable for WldVault {
+    type MetadataArg = ();
+
+    fn as_execute_user_op_call_data(&self) -> Bytes {
+        ISafe4337Module::executeUserOpCall {
+            to: self.to,
+            value: U256::ZERO,
+            data: self.call_data.clone().into(),
+            operation: self.operation as u8,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn as_preflight_user_operation(
+        &self,
+        wallet_address: Address,
+        _metadata: Option<Self::MetadataArg>,
+    ) -> Result<UserOperation, PrimitiveError> {
+        let call_data = self.as_execute_user_op_call_data();
+
+        let key = NonceKeyV1::new(
+            TransactionTypeId::MorphoMigrate,
+            InstructionFlag::Default,
+            self.metadata,
+        );
+        let nonce = key.encode_with_sequence(0);
+
+        Ok(UserOperation::new_with_defaults(
+            wallet_address,
+            nonce,
+            call_data,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::{node_bindings::Anvil, providers::ProviderBuilder};
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use crate::primitives::Network;
+    use crate::transactions::rpc::RpcClient;
+
+    use super::*;
+
+    /// Creates a test RPC client with mocked responses for migration queries
+    fn setup_test_rpc_client(
+        old_vault_address: Address,
+        user_address: Address,
+        wld_balance: U256,
+    ) -> RpcClient {
+        let anvil = Anvil::new().spawn();
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
+
+        let mut http_client = crate::test_utils::AnvilBackedHttpClient::new(provider);
+
+        // Set response for balanceOf() call (user's WLD balance in old vault)
+        let balance_call_data = IErc20::balanceOfCall {
+            account: user_address,
+        }
+        .abi_encode();
+        let mut padded_balance = [0u8; 32];
+        padded_balance[..32].copy_from_slice(&wld_balance.to_be_bytes::<32>());
+        let balance_response = format!("0x{}", hex::encode(padded_balance));
+        http_client.set_response_for_address_and_data(
+            old_vault_address,
+            format!("0x{}", hex::encode(balance_call_data)),
+            balance_response,
+        );
+
+        RpcClient::new(Arc::new(http_client))
+    }
+
+    #[tokio::test]
+    async fn test_wld_vault_migrate_to_re7wld() {
+        let old_vault_address =
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let new_vault_address =
+            Address::from_str("0x348831b46876d3dF2Db98BdEc5E3B4083329Ab9f").unwrap();
+        let user_address =
+            Address::from_str("0x9bB365324EDeF7A608c316abBf1d88460c556AB0").unwrap();
+        let metadata = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        let wld_balance = U256::from(10u128.pow(18)); // 1 WLD
+
+        let test_rpc_client = setup_test_rpc_client(
+            old_vault_address,
+            user_address,
+            wld_balance,
+        );
+
+        let migration = WldVault::migrate_to_re7wld(
+            &test_rpc_client,
+            Network::WorldChain,
+            old_vault_address,
+            new_vault_address,
+            user_address,
+            metadata,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(migration.operation as u8, SafeOperation::DelegateCall as u8);
+        assert_eq!(migration.to, MULTISEND_ADDRESS);
+        // Verify the call data is not empty (MultiSend bundle was created)
+        assert!(!migration.call_data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_wld_vault_migrate_with_zero_balance_error() {
+        let old_vault_address =
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let new_vault_address =
+            Address::from_str("0x348831b46876d3dF2Db98BdEc5E3B4083329Ab9f").unwrap();
+        let user_address =
+            Address::from_str("0x9bB365324EDeF7A608c316abBf1d88460c556AB0").unwrap();
+        let metadata = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        let wld_balance = U256::from(0); // No funds
+
+        let test_rpc_client = setup_test_rpc_client(
+            old_vault_address,
+            user_address,
+            wld_balance,
+        );
+
+        let result = WldVault::migrate_to_re7wld(
+            &test_rpc_client,
+            Network::WorldChain,
+            old_vault_address,
+            new_vault_address,
+            user_address,
+            metadata,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Cannot migrate - user has no funds in the old vault"));
+    }
+
+    #[tokio::test]
+    async fn test_wld_vault_preflight_user_operation() {
+        let old_vault_address =
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let new_vault_address =
+            Address::from_str("0x348831b46876d3dF2Db98BdEc5E3B4083329Ab9f").unwrap();
+        let user_address =
+            Address::from_str("0x9bB365324EDeF7A608c316abBf1d88460c556AB0").unwrap();
+        let wallet_address =
+            Address::from_str("0x545c97c6664e6f9c37b0e6e2b80e68954413f70b").unwrap();
+        let metadata = [0u8; 10];
+
+        let wld_balance = U256::from(10u128.pow(18));
+
+        let test_rpc_client = setup_test_rpc_client(
+            old_vault_address,
+            user_address,
+            wld_balance,
+        );
+
+        let migration = WldVault::migrate_to_re7wld(
+            &test_rpc_client,
+            Network::WorldChain,
+            old_vault_address,
+            new_vault_address,
+            user_address,
+            metadata,
+        )
+        .await
+        .unwrap();
+
+        let user_op = migration
+            .as_preflight_user_operation(wallet_address, None)
+            .unwrap();
+
+        // Check the nonce contains the correct transaction type
+        let be: [u8; 32] = user_op.nonce.to_be_bytes();
+        assert_eq!(be[5], TransactionTypeId::MorphoMigrate as u8);
+    }
+}


### PR DESCRIPTION
## Summary

- Add new `MorphoMigrate` transaction type for migrating funds from the old WLD vault to the new re7WLD Morpho vault
- New `wld_vault` module in `transactions/contracts` with `WldVault::migrate_to_re7wld()` function
- Bundles three operations into a single MultiSend transaction:
  1. `withdrawAll()` from the old WLD vault
  2. `approve()` the new vault to spend WLD
  3. `deposit()` into the new re7WLD Morpho vault

For:

```
Old vault: 0x1111111111111111111111111111111111111111
New vault: 0x348831b46876d3dF2Db98BdEc5E3B4083329Ab9f
User: 0x9bB365324EDeF7A608c316abBf1d88460c556AB0
WLD amount: 1000000000000000000
MultiSend target: 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526
```

Generates calldata:

```
0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000018b00111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004853828b6002cfc85d8e48f8eab294be644d9e25c303086300300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000348831b46876d3df2db98bdec5e3b4083329ab9f0000000000000000000000000000000000000000000000000de0b6b3a764000000348831b46876d3df2db98bdec5e3b4083329ab9f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000446e553f650000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000009bb365324edef7a608c316abbf1d88460c556ab0000000000000000000000000000000000000000000
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a migration path from the old WLD vault to the re7WLD Morpho vault.
> 
> - New `MorphoMigrate` in `TransactionTypeId` and nonce wiring
> - New `transactions/contracts/wld_vault` with `WldVault::migrate_to_re7wld()` that:
>   - Queries user balance, errors on zero
>   - Builds MultiSend bundle: `withdrawAll` (old vault) -> `approve` (WLD token) -> `deposit` (new vault)
>   - Encodes 4337 `executeUserOp` with `DelegateCall` to `MultiSend`
> - Unit tests for success, zero-balance error, and nonce encoding
> - Cargo.lock updates (e.g., `ruint` bump, new `ark-ff 0.5.x`, `windows-sys` alignment)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f9940ded3cf903936e36c4082b5eff78a9c195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->