### PR TITLE
Copy verbatim `migration` from oxide

### DIFF
--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -40,7 +40,7 @@ aws-nitro-enclaves-nsm-api = "0.4.0"
 base64 = "0.22.1"
 bedrock-macros = { path = "../bedrock-macros" }
 blake3 = "1.5.5"
-chrono = { version = "0.4.42", default-features = false, features = ["now", "std"] }
+chrono = { version = "0.4.42", default-features = false, features = ["now", "std", "serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"
 crypto_box = { version = "0.9.1", features = ["seal"] }

--- a/bedrock/src/lib.rs
+++ b/bedrock/src/lib.rs
@@ -43,6 +43,9 @@ pub use primitives::{AuthenticatedHttpClient, HttpError, HttpMethod};
 /// Key management for World App.
 mod root_key;
 
+/// Migration system for running idempotent, resumable migrations
+pub mod migration;
+
 /// Test utilities for unit and integration tests
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -1,7 +1,7 @@
 use crate::device::{DeviceKeyValueStore, KeyValueStoreError};
+use crate::migration::error::MigrationResult;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};
 use crate::migration::state::{MigrationRecord, MigrationStatus};
-use crate::OxideResult;
 use chrono::{Duration, Utc};
 use log::{error, info, warn};
 use once_cell::sync::Lazy;
@@ -26,11 +26,17 @@ static MIGRATION_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 /// Summary of a migration run
 #[derive(Debug, uniffi::Record)]
 pub struct MigrationRunSummary {
+    /// Total number of migrations
     pub total: i32,
+    /// Number of migrations that succeeded
     pub succeeded: i32,
+    /// Number of migrations that failed but are retryable
     pub failed_retryable: i32,
+    /// Number of migrations that failed with terminal errors
     pub failed_terminal: i32,
+    /// Number of migrations blocked waiting for user action
     pub blocked: i32,
+    /// Number of migrations skipped
     pub skipped: i32,
 }
 
@@ -84,12 +90,12 @@ impl MigrationController {
     ///
     /// # Errors
     ///
-    /// Returns `OxideError::InvalidOperation` if another migration run is already in progress.
+    /// Returns `MigrationError::InvalidOperation` if another migration run is already in progress.
     /// Returns other errors for migration execution failures (see `MigrationRunSummary` for details).
-    pub async fn run_migrations(&self) -> OxideResult<MigrationRunSummary> {
+    pub async fn run_migrations(&self) -> MigrationResult<MigrationRunSummary> {
         // Try to acquire the global lock. If another migration is running, fail immediately.
         let _guard = MIGRATION_LOCK.try_lock().map_err(|_| {
-            crate::OxideError::InvalidOperation(
+            crate::migration::MigrationError::InvalidOperation(
                 "Migration is already in progress. Please wait for the current migration to complete.".to_string(),
             )
         })?;
@@ -121,7 +127,7 @@ impl MigrationController {
     }
 
     /// Internal async implementation of run_migrations
-    async fn run_migrations_async(&self) -> OxideResult<MigrationRunSummary> {
+    async fn run_migrations_async(&self) -> MigrationResult<MigrationRunSummary> {
         info!("Migration run started");
 
         // Summary of this migration run for analytics. Not stored.
@@ -280,7 +286,7 @@ impl MigrationController {
     /// If the stored JSON is corrupted or invalid, this method treats it as a reset
     /// and returns a new `MigrationRecord`. This prevents one corrupted record from
     /// blocking all migrations permanently.
-    fn load_record(&self, migration_id: &str) -> OxideResult<MigrationRecord> {
+    fn load_record(&self, migration_id: &str) -> MigrationResult<MigrationRecord> {
         let key = format!("{MIGRATION_KEY_PREFIX}{migration_id}");
         match self.kv_store.get(key) {
             Ok(json) => {
@@ -308,7 +314,7 @@ impl MigrationController {
 
     /// Save a single migration record to persistent storage
     /// Each migration is stored under its own key: "migration:{migration_id}"
-    fn save_record(&self, migration_id: &str, record: &MigrationRecord) -> OxideResult<()> {
+    fn save_record(&self, migration_id: &str, record: &MigrationRecord) -> MigrationResult<()> {
         let key = format!("{MIGRATION_KEY_PREFIX}{migration_id}");
         let json = serde_json::to_string(record)?;
         self.kv_store.set(key, json)?;
@@ -372,11 +378,11 @@ mod tests {
             &self.id
         }
 
-        async fn is_applicable(&self) -> OxideResult<bool> {
+        async fn is_applicable(&self) -> MigrationResult<bool> {
             Ok(true)
         }
 
-        async fn execute(&self) -> OxideResult<ProcessorResult> {
+        async fn execute(&self) -> MigrationResult<ProcessorResult> {
             self.execution_count.fetch_add(1, Ordering::SeqCst);
             if self.delay_ms > 0 {
                 sleep(Duration::from_millis(self.delay_ms)).await;
@@ -441,7 +447,7 @@ mod tests {
         // Second should fail with InvalidOperation
         assert!(result2.is_err());
         match result2.unwrap_err() {
-            crate::OxideError::InvalidOperation(msg) => {
+            crate::migration::MigrationError::InvalidOperation(msg) => {
                 assert!(msg.contains("already in progress"));
             }
             e => panic!("Expected InvalidOperation error, got: {:?}", e),
@@ -542,7 +548,7 @@ mod tests {
         // Second should fail with InvalidOperation (same global lock)
         assert!(result2.is_err());
         match result2.unwrap_err() {
-            crate::OxideError::InvalidOperation(msg) => {
+            crate::migration::MigrationError::InvalidOperation(msg) => {
                 assert!(msg.contains("already in progress"));
             }
             e => panic!("Expected InvalidOperation error, got: {:?}", e),
@@ -661,7 +667,7 @@ mod tests {
             let result = handle.await.unwrap();
             match result {
                 Ok(_) => success_count += 1,
-                Err(crate::OxideError::InvalidOperation(_)) => failure_count += 1,
+                Err(crate::migration::MigrationError::InvalidOperation(_)) => failure_count += 1,
                 Err(e) => panic!("Unexpected error: {:?}", e),
             }
         }

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -1,0 +1,676 @@
+use crate::device::{DeviceKeyValueStore, KeyValueStoreError};
+use crate::migration::processor::{MigrationProcessor, ProcessorResult};
+use crate::migration::state::{MigrationRecord, MigrationStatus};
+use crate::OxideResult;
+use chrono::{Duration, Utc};
+use log::{error, info, warn};
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const MIGRATION_KEY_PREFIX: &str = "migration:";
+const DEFAULT_RETRY_DELAY_MS: i64 = 60_000; // 1 minute
+const MAX_RETRY_DELAY_MS: i64 = 86_400_000; // 1 day
+
+/// Global lock to prevent concurrent migration runs across all controller instances.
+/// This is a process-wide coordination mechanism that ensures only one migration
+/// can execute at a time, regardless of how many MigrationController instances exist.
+///
+/// **Application-level Requirements:**
+/// The calling application should ensure only one `MigrationController` instance is
+/// instantiated at a time. While this process-wide lock provides thread-safety within
+/// a single process, applications should use app-level constructs (singletons, dependency
+/// injection, etc.) to prevent multiple controller instances as an additional safeguard.
+static MIGRATION_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+/// Summary of a migration run
+#[derive(Debug, uniffi::Record)]
+pub struct MigrationRunSummary {
+    pub total: i32,
+    pub succeeded: i32,
+    pub failed_retryable: i32,
+    pub failed_terminal: i32,
+    pub blocked: i32,
+    pub skipped: i32,
+}
+
+/// Controller that orchestrates migration execution
+///
+/// ## Storage Architecture
+///
+/// Each migration's state is stored independently in the DeviceKeyValueStore using
+/// a namespaced key pattern: `migration:{migration_id}`.
+///
+/// For example:
+/// - `migration:worldId.credentials.poh.refresh.v1`
+/// - `migration:worldId.credentials.nfc.refresh.v1`
+///
+/// This approach ensures:
+/// - **Scalability**: No size limits on the total number of migrations
+/// - **Isolation**: Each migration's state is independent and can be managed separately
+/// - **Platform compatibility**: Avoids hitting single-key size limits in SharedPreferences (Android) and UserDefaults (iOS)
+///
+/// Each key stores a JSON-serialized `MigrationRecord` containing execution state,
+/// timestamps, and error information.
+#[derive(uniffi::Object)]
+pub struct MigrationController {
+    kv_store: Arc<dyn DeviceKeyValueStore>,
+    processors: Vec<Arc<dyn MigrationProcessor>>,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl MigrationController {
+    /// Create a new MigrationController
+    /// Processors are registered internally
+    #[uniffi::constructor]
+    pub fn new(kv_store: Arc<dyn DeviceKeyValueStore>) -> Arc<Self> {
+        Self::with_processors(kv_store, Self::default_processors())
+    }
+
+    /// Run all registered migrations
+    ///
+    /// This is an async call that may take several seconds depending on network
+    /// conditions and the number of migrations to process.
+    ///
+    /// UniFFI handles the async runtime automatically via the `async_runtime = "tokio"` attribute.
+    ///
+    /// # Concurrency
+    ///
+    /// This method is **thread-safe** with fail-fast behavior. A global lock ensures only one
+    /// migration run can execute at a time across all `MigrationController` instances in the process.
+    ///
+    /// If another migration is already in progress when this method is called, it will return
+    /// immediately with an `InvalidOperation` error rather than waiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxideError::InvalidOperation` if another migration run is already in progress.
+    /// Returns other errors for migration execution failures (see `MigrationRunSummary` for details).
+    pub async fn run_migrations(&self) -> OxideResult<MigrationRunSummary> {
+        // Try to acquire the global lock. If another migration is running, fail immediately.
+        let _guard = MIGRATION_LOCK.try_lock().map_err(|_| {
+            crate::OxideError::InvalidOperation(
+                "Migration is already in progress. Please wait for the current migration to complete.".to_string(),
+            )
+        })?;
+
+        // Lock acquired - we have exclusive access to run migrations
+        self.run_migrations_async().await
+        // Lock automatically released when _guard is dropped
+    }
+}
+
+impl MigrationController {
+    /// Create a controller with processors injected in
+    pub fn with_processors(
+        kv_store: Arc<dyn DeviceKeyValueStore>,
+        processors: Vec<Arc<dyn MigrationProcessor>>,
+    ) -> Arc<Self> {
+        Arc::new(Self { kv_store, processors })
+    }
+
+    /// Get the default list of processors to run
+    /// Add new processors here as they're implemented
+    fn default_processors() -> Vec<Arc<dyn MigrationProcessor>> {
+        vec![
+            // Add actual processors here as they're implemented:
+            // Arc::new(AccountBootstrapProcessor::new()),
+            // Arc::new(PoHRefreshProcessor::new()),
+            // Arc::new(NfcRefreshProcessor::new()),
+        ]
+    }
+
+    /// Internal async implementation of run_migrations
+    async fn run_migrations_async(&self) -> OxideResult<MigrationRunSummary> {
+        info!("Migration run started");
+
+        // Summary of this migration run for analytics. Not stored.
+        let mut summary = MigrationRunSummary {
+            total: self.processors.len() as i32,
+            succeeded: 0,
+            failed_retryable: 0,
+            failed_terminal: 0,
+            blocked: 0,
+            skipped: 0,
+        };
+
+        // Execute each processor sequentially
+        for processor in &self.processors {
+            let migration_id = processor.migration_id();
+
+            // Load the current record for this migration (or create new one if first time)
+            let mut record = self.load_record(migration_id)?;
+
+            // Skip if already succeeded
+            if matches!(record.status, MigrationStatus::Succeeded) {
+                info!("Migration {migration_id} already succeeded, skipping");
+                summary.skipped += 1;
+                continue;
+            }
+
+            // Skip if terminal failure (non-retryable)
+            if matches!(record.status, MigrationStatus::FailedTerminal) {
+                info!("Migration {migration_id} failed terminally, skipping");
+                summary.skipped += 1;
+                continue;
+            }
+
+            // Check if we should retry (based on next_attempt_at)
+            if let Some(next_attempt) = record.next_attempt_at {
+                let now = Utc::now();
+                if now < next_attempt {
+                    info!("Migration {migration_id} scheduled for retry at {next_attempt}, skipping");
+                    summary.skipped += 1;
+                    continue;
+                }
+            }
+
+            // Check if migration is applicable and should run, based on processor defined logic.
+            // This checks actual state (e.g., "does v4 credential exist?") to ensure idempotency
+            // even if migration record is deleted (reinstall scenario).
+            match processor.is_applicable().await {
+                Ok(false) => {
+                    info!("Migration {migration_id} not applicable, skipping");
+                    summary.skipped += 1;
+                    continue;
+                }
+                Err(e) => {
+                    error!("Failed to check applicability for {migration_id}: {e:?}");
+                    summary.skipped += 1;
+                    continue;
+                }
+                Ok(true) => {
+                    // Continue with execution. Fall through to the execution block below.
+                }
+            }
+
+            // Execute the migration
+            info!("Starting migration: {} (attempt {})", migration_id, record.attempts + 1);
+
+            // Update record for execution
+            if record.started_at.is_none() {
+                record.started_at = Some(Utc::now());
+            }
+            record.status = MigrationStatus::InProgress;
+            record.attempts += 1;
+            record.last_attempted_at = Some(Utc::now());
+
+            // Save record before execution so we don't lose progress if the app crashes mid-migration
+            self.save_record(migration_id, &record)?;
+
+            // Execute
+            match processor.execute().await {
+                Ok(ProcessorResult::Success) => {
+                    info!("Migration {migration_id} succeeded");
+                    record.status = MigrationStatus::Succeeded;
+                    record.completed_at = Some(Utc::now());
+                    record.last_error_code = None;
+                    record.last_error_message = None;
+                    record.next_attempt_at = None; // Clear retry time
+                    summary.succeeded += 1;
+                }
+                Ok(ProcessorResult::Retryable {
+                    error_code,
+                    error_message,
+                    retry_after_ms,
+                }) => {
+                    warn!("Migration {migration_id} failed (retryable): {error_code} - {error_message}");
+                    record.status = MigrationStatus::FailedRetryable;
+                    record.last_error_code = Some(error_code);
+                    record.last_error_message = Some(error_message);
+
+                    // Retry time is calculated according to exponential backoff and set on the
+                    // record.next_attempt_at field. When the app is next opened and the
+                    // migration is run again; the controller will check whether to run the
+                    // migration again based on the record.next_attempt_at field.
+                    let retry_delay_ms = retry_after_ms.unwrap_or_else(|| calculate_backoff_delay(record.attempts));
+                    record.next_attempt_at = Some(Utc::now() + Duration::milliseconds(retry_delay_ms));
+
+                    summary.failed_retryable += 1;
+                }
+                Ok(ProcessorResult::Terminal {
+                    error_code,
+                    error_message,
+                }) => {
+                    error!("Migration {migration_id} failed (terminal): {error_code} - {error_message}");
+                    record.status = MigrationStatus::FailedTerminal;
+                    record.last_error_code = Some(error_code);
+                    record.last_error_message = Some(error_message);
+                    record.next_attempt_at = None; // Clear retry time
+                    summary.failed_terminal += 1;
+                }
+                Ok(ProcessorResult::BlockedUserAction { reason }) => {
+                    warn!("Migration {migration_id} blocked: {reason}");
+                    record.status = MigrationStatus::BlockedUserAction;
+                    record.last_error_message = Some(reason);
+                    record.next_attempt_at = None; // Clear retry time
+                    summary.blocked += 1;
+                }
+                Err(e) => {
+                    error!("Migration {migration_id} threw error: {e:?}");
+                    record.status = MigrationStatus::FailedRetryable;
+                    record.last_error_code = Some("UNEXPECTED_ERROR".to_string());
+                    record.last_error_message = Some(format!("{e:?}"));
+
+                    // Schedule retry with backoff
+                    let retry_delay_ms = calculate_backoff_delay(record.attempts);
+                    record.next_attempt_at = Some(Utc::now() + Duration::milliseconds(retry_delay_ms));
+
+                    summary.failed_retryable += 1;
+                }
+            }
+
+            // Save the final result (success/failure) to storage
+            self.save_record(migration_id, &record)?;
+        }
+
+        info!(
+            "Migration run completed: {} succeeded, {} retryable, {} terminal, {} blocked, {} skipped",
+            summary.succeeded, summary.failed_retryable, summary.failed_terminal, summary.blocked, summary.skipped
+        );
+
+        Ok(summary)
+    }
+
+    /// Load a single migration record from the DeviceKeyValueStore
+    /// Each migration is stored under its own key: "migration:{migration_id}"
+    ///
+    /// # Corruption Handling
+    ///
+    /// If the stored JSON is corrupted or invalid, this method treats it as a reset
+    /// and returns a new `MigrationRecord`. This prevents one corrupted record from
+    /// blocking all migrations permanently.
+    fn load_record(&self, migration_id: &str) -> OxideResult<MigrationRecord> {
+        let key = format!("{MIGRATION_KEY_PREFIX}{migration_id}");
+        match self.kv_store.get(key) {
+            Ok(json) => {
+                match serde_json::from_str(&json) {
+                    Ok(record) => Ok(record),
+                    Err(e) => {
+                        // JSON is corrupted - treat as reset and let migration re-run
+                        warn!("Migration {migration_id} has corrupted JSON data, resetting: {e:?}");
+                        Ok(MigrationRecord::new())
+                    }
+                }
+            }
+            Err(KeyValueStoreError::KeyNotFound) => {
+                // First time running this migration, return new record
+                Ok(MigrationRecord::new())
+            }
+            Err(KeyValueStoreError::ParsingFailure) => {
+                // Storage layer couldn't parse the value - treat as reset
+                warn!("Migration {migration_id} has corrupted storage data, resetting");
+                Ok(MigrationRecord::new())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Save a single migration record to persistent storage
+    /// Each migration is stored under its own key: "migration:{migration_id}"
+    fn save_record(&self, migration_id: &str, record: &MigrationRecord) -> OxideResult<()> {
+        let key = format!("{MIGRATION_KEY_PREFIX}{migration_id}");
+        let json = serde_json::to_string(record)?;
+        self.kv_store.set(key, json)?;
+        Ok(())
+    }
+}
+
+/// Calculate exponential backoff delay based on number of attempts
+fn calculate_backoff_delay(attempts: i32) -> i64 {
+    // attempts: 1 => base, 2 => 2x, 3 => 4x, ...
+    let exp = (attempts.saturating_sub(1)).clamp(0, 16) as u32; // cap exponent
+    let factor = 1_i64.checked_shl(exp).unwrap_or(i64::MAX);
+    (DEFAULT_RETRY_DELAY_MS.saturating_mul(factor)).min(MAX_RETRY_DELAY_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the migration controller's locking behavior.
+    //!
+    //! **Note:** These tests share a global `MIGRATION_LOCK` and must run serially.
+    //! The `#[serial]` attribute ensures they don't interfere with each other.
+
+    use super::*;
+    use crate::device::test::InMemoryDeviceKeyValueStore;
+    use async_trait::async_trait;
+    use serial_test::serial;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tokio::time::{sleep, Duration};
+
+    /// Test processor that can be controlled for timing tests
+    struct TestProcessor {
+        id: String,
+        delay_ms: u64,
+        should_fail: bool,
+        execution_count: Arc<AtomicU32>,
+    }
+
+    impl TestProcessor {
+        fn new(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                delay_ms: 0,
+                should_fail: false,
+                execution_count: Arc::new(AtomicU32::new(0)),
+            }
+        }
+
+        fn with_delay(mut self, delay_ms: u64) -> Self {
+            self.delay_ms = delay_ms;
+            self
+        }
+
+        fn execution_count(&self) -> u32 {
+            self.execution_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl MigrationProcessor for TestProcessor {
+        fn migration_id(&self) -> &str {
+            &self.id
+        }
+
+        async fn is_applicable(&self) -> OxideResult<bool> {
+            Ok(true)
+        }
+
+        async fn execute(&self) -> OxideResult<ProcessorResult> {
+            self.execution_count.fetch_add(1, Ordering::SeqCst);
+            if self.delay_ms > 0 {
+                sleep(Duration::from_millis(self.delay_ms)).await;
+            }
+            if self.should_fail {
+                Ok(ProcessorResult::Retryable {
+                    error_code: "TEST_ERROR".to_string(),
+                    error_message: "Test error".to_string(),
+                    retry_after_ms: None,
+                })
+            } else {
+                Ok(ProcessorResult::Success)
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_single_migration_run_succeeds() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(TestProcessor::new("test.migration.v1"));
+        let controller = MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+
+        let summary = result.unwrap();
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(processor.execution_count(), 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_concurrent_migrations_fail_fast() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+
+        // Create a processor with a delay so the first migration holds the lock
+        let processor = Arc::new(TestProcessor::new("test.migration.v1").with_delay(100));
+        let controller = MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        // Clone controller for concurrent access
+        let controller_clone = controller.clone();
+
+        // Start first migration (will hold lock for 100ms)
+        let handle1 = tokio::spawn(async move { controller.run_migrations().await });
+
+        // Give first migration time to acquire lock
+        sleep(Duration::from_millis(10)).await;
+
+        // Try to start second migration while first is running
+        let handle2 = tokio::spawn(async move { controller_clone.run_migrations().await });
+
+        // Wait for both to complete
+        let result1 = handle1.await.unwrap();
+        let result2 = handle2.await.unwrap();
+
+        // First should succeed
+        assert!(result1.is_ok());
+        assert_eq!(result1.unwrap().succeeded, 1);
+
+        // Second should fail with InvalidOperation
+        assert!(result2.is_err());
+        match result2.unwrap_err() {
+            crate::OxideError::InvalidOperation(msg) => {
+                assert!(msg.contains("already in progress"));
+            }
+            e => panic!("Expected InvalidOperation error, got: {:?}", e),
+        }
+
+        // Processor should only have executed once (first migration)
+        assert_eq!(processor.execution_count(), 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_sequential_migrations_succeed() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(TestProcessor::new("test.migration.v1"));
+        let controller = MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        // First migration
+        let result1 = controller.run_migrations().await;
+        assert!(result1.is_ok());
+
+        // Second migration should succeed (first is complete)
+        let result2 = controller.run_migrations().await;
+        assert!(result2.is_ok());
+
+        // Migration already succeeded, so second run should skip it
+        let summary2 = result2.unwrap();
+        assert_eq!(summary2.skipped, 1);
+        assert_eq!(summary2.succeeded, 0);
+
+        // Processor should only execute once (second run skipped)
+        assert_eq!(processor.execution_count(), 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_lock_released_on_error() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+
+        // Create a processor that will cause the migration to fail by using
+        // an invalid KV store that errors on save
+        struct FailingKvStore;
+        impl DeviceKeyValueStore for FailingKvStore {
+            fn get(&self, _key: String) -> Result<String, KeyValueStoreError> {
+                Err(KeyValueStoreError::KeyNotFound)
+            }
+            fn set(&self, _key: String, _value: String) -> Result<(), KeyValueStoreError> {
+                Err(KeyValueStoreError::UpdateFailure)
+            }
+            fn delete(&self, _key: String) -> Result<(), KeyValueStoreError> {
+                Err(KeyValueStoreError::UpdateFailure)
+            }
+        }
+
+        let failing_kv = Arc::new(FailingKvStore);
+        let processor = Arc::new(TestProcessor::new("test.migration.v1"));
+        let controller1 = MigrationController::with_processors(failing_kv, vec![processor.clone()]);
+
+        // First migration fails
+        let result1 = controller1.run_migrations().await;
+        assert!(result1.is_err());
+
+        // Create another controller with working KV store
+        let controller2 =
+            MigrationController::with_processors(kv_store, vec![Arc::new(TestProcessor::new("test.migration.v2"))]);
+
+        // Second migration should succeed (lock was released despite error)
+        let result2 = controller2.run_migrations().await;
+        assert!(result2.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_multiple_controller_instances_share_lock() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+
+        // Create two separate controller instances
+        let processor1 = Arc::new(TestProcessor::new("test.migration1.v1").with_delay(100));
+        let controller1 = MigrationController::with_processors(kv_store.clone(), vec![processor1.clone()]);
+
+        let processor2 = Arc::new(TestProcessor::new("test.migration2.v1"));
+        let controller2 = MigrationController::with_processors(kv_store, vec![processor2.clone()]);
+
+        // Start first controller's migration
+        let handle1 = tokio::spawn(async move { controller1.run_migrations().await });
+
+        // Give first migration time to acquire lock
+        sleep(Duration::from_millis(10)).await;
+
+        // Try second controller's migration while first is running
+        let handle2 = tokio::spawn(async move { controller2.run_migrations().await });
+
+        let result1 = handle1.await.unwrap();
+        let result2 = handle2.await.unwrap();
+
+        // First should succeed
+        assert!(result1.is_ok());
+
+        // Second should fail with InvalidOperation (same global lock)
+        assert!(result2.is_err());
+        match result2.unwrap_err() {
+            crate::OxideError::InvalidOperation(msg) => {
+                assert!(msg.contains("already in progress"));
+            }
+            e => panic!("Expected InvalidOperation error, got: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_individual_key_storage() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor1 = Arc::new(TestProcessor::new("test.migration1.v1"));
+        let processor2 = Arc::new(TestProcessor::new("test.migration2.v1"));
+
+        let controller = MigrationController::with_processors(kv_store.clone(), vec![processor1, processor2]);
+
+        // Run migrations
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().succeeded, 2);
+
+        // Verify individual keys are stored correctly
+        let key1 = format!("{MIGRATION_KEY_PREFIX}test.migration1.v1");
+        let key2 = format!("{MIGRATION_KEY_PREFIX}test.migration2.v1");
+
+        // Both keys should exist in the KV store
+        let record1_json = kv_store.get(key1).expect("Migration 1 record should exist");
+        let record2_json = kv_store.get(key2).expect("Migration 2 record should exist");
+
+        // Verify they can be deserialized
+        let record1: MigrationRecord = serde_json::from_str(&record1_json).expect("Should deserialize");
+        let record2: MigrationRecord = serde_json::from_str(&record2_json).expect("Should deserialize");
+
+        // Both should be in Succeeded status
+        assert!(matches!(record1.status, MigrationStatus::Succeeded));
+        assert!(matches!(record2.status, MigrationStatus::Succeeded));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_corrupted_record_does_not_block_migrations() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(TestProcessor::new("test.migration.v1"));
+
+        // Manually insert corrupted JSON for this migration
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        kv_store
+            .set(key.clone(), "{invalid json!!!".to_string())
+            .expect("Should store corrupted data");
+
+        let controller = MigrationController::with_processors(kv_store.clone(), vec![processor.clone()]);
+
+        // Migration should still run despite corrupted record
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+
+        let summary = result.unwrap();
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.failed_retryable, 0);
+
+        // Verify the corrupted data was overwritten with valid JSON
+        let updated_json = kv_store.get(key).expect("Record should exist");
+        let record: MigrationRecord = serde_json::from_str(&updated_json).expect("Should be valid JSON now");
+        assert!(matches!(record.status, MigrationStatus::Succeeded));
+    }
+
+    #[test]
+    fn test_load_record_handles_parsing_failure() {
+        // Test that ParsingFailure is handled gracefully like JSON corruption
+        struct ParsingFailureKvStore;
+
+        impl DeviceKeyValueStore for ParsingFailureKvStore {
+            fn get(&self, _key: String) -> Result<String, KeyValueStoreError> {
+                Err(KeyValueStoreError::ParsingFailure)
+            }
+
+            fn set(&self, _key: String, _value: String) -> Result<(), KeyValueStoreError> {
+                Ok(())
+            }
+
+            fn delete(&self, _key: String) -> Result<(), KeyValueStoreError> {
+                Ok(())
+            }
+        }
+
+        let kv_store = Arc::new(ParsingFailureKvStore);
+        let controller = MigrationController::with_processors(kv_store, vec![]);
+
+        // Should return a new record instead of erroring
+        let result = controller.load_record("test.migration.v1");
+        assert!(result.is_ok());
+
+        let record = result.unwrap();
+        assert_eq!(record.attempts, 0);
+        assert!(matches!(record.status, MigrationStatus::NotStarted));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_many_concurrent_attempts_only_one_succeeds() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(TestProcessor::new("test.migration.v1").with_delay(50));
+        let controller = MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        // Launch 10 concurrent attempts
+        let mut handles = vec![];
+        for _ in 0..10 {
+            let controller_clone = controller.clone();
+            handles.push(tokio::spawn(async move { controller_clone.run_migrations().await }));
+        }
+
+        // Collect results
+        let mut success_count = 0;
+        let mut failure_count = 0;
+
+        for handle in handles {
+            let result = handle.await.unwrap();
+            match result {
+                Ok(_) => success_count += 1,
+                Err(crate::OxideError::InvalidOperation(_)) => failure_count += 1,
+                Err(e) => panic!("Unexpected error: {:?}", e),
+            }
+        }
+
+        // Exactly one should succeed
+        assert_eq!(success_count, 1);
+        assert_eq!(failure_count, 9);
+
+        // Processor should only execute once
+        assert_eq!(processor.execution_count(), 1);
+    }
+}

--- a/bedrock/src/migration/error.rs
+++ b/bedrock/src/migration/error.rs
@@ -1,0 +1,29 @@
+/// Errors that can occur during migration operations
+#[crate::bedrock_error]
+pub enum MigrationError {
+    /// An invalid operation was attempted
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+
+    /// Key-value store operation failed
+    #[error(transparent)]
+    KeyValueStore(#[from] crate::device::KeyValueStoreError),
+
+    /// JSON serialization/deserialization failed
+    #[error("JSON error: {message}")]
+    JsonError {
+        /// The error message from serde_json
+        message: String,
+    },
+}
+
+impl From<serde_json::Error> for MigrationError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::JsonError {
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Result type for migration operations
+pub type MigrationResult<T> = std::result::Result<T, MigrationError>;

--- a/bedrock/src/migration/mod.rs
+++ b/bedrock/src/migration/mod.rs
@@ -1,0 +1,81 @@
+//! Migration System
+//!
+//! A generic, reusable framework for running idempotent, resumable migrations.
+//!
+//! # Overview
+//!
+//! The migration system consists of:
+//! - [`MigrationController`]: Orchestrates migration execution
+//! - [`MigrationProcessor`]: Trait for implementing individual migrations
+//! - [`MigrationRecord`]: Persistent state tracking individual migration progress
+//!
+//! Each migration's state is stored independently in the `DeviceKeyValueStore` using
+//! namespaced keys (`migration:{migration_id}`)
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use oxide::migration::MigrationController;
+//! use std::sync::Arc;
+//!
+//! // Create controller (processors are registered internally)
+//! let controller = MigrationController::new(kv_store);
+//!
+//! let summary = controller.run_migrations()?;
+//! ```
+//!
+//! # Adding New Processors
+//!
+//! To add a new migration processor:
+//! 1. Implement the `MigrationProcessor` trait in `processors/`
+//! 2. Add it to `MigrationController::default_processors()`
+//!
+//! ## Versioning
+//!
+//! Include the version in the migration ID itself (e.g., `worldid.credentials.nfc.refresh.v1`).
+//! If you need to update a migration, create a new processor with a new ID:
+//!
+//! ```rust,ignore
+//! // Old migration
+//! worldid.credentials.nfc.refresh.v1
+//!
+//! // Updated migration
+//! worldid.credentials.nfc.refresh.v2
+//! ```
+//!
+//! Both processors can coexist in `default_processors()`. The v1 will already be succeeded
+//! for existing users, and v2 will run for those who need it. This keeps the system simple
+//! with one unique identifier per migration.
+//!
+//! # Handling App Reinstalls
+//!
+//! **On app uninstall:** Both migration records (in `DeviceKeyValueStore`) and actual data are cleared.
+//!
+//! **On app reinstall with account recovery:** Actual data (credentials, etc.) is restored from
+//! backup, but migration records remain empty since `DeviceKeyValueStore` is not backed up.
+//!
+//! **Why this works:** Each processor's `is_applicable()` method checks **actual restored state**
+//! first, not just migration records. Example:
+//!
+//! ```rust,ignore
+//! async fn is_applicable(&self, record: Option<&MigrationRecord>) -> OxideResult<bool> {
+//!     // 1. Check if migration outcome already exists (e.g., v4 credential restored from backup)
+//!     if self.credential_store.has_v4_credential().await? {
+//!         return Ok(false);  // Skip - already have what this migration creates
+//!     }
+//!
+//!     Ok(true)  // Run migration
+//! }
+//! ```
+
+mod controller;
+mod processor;
+mod state;
+
+// Example processors
+pub mod processors;
+
+// Public API exports
+pub use controller::{MigrationController, MigrationRunSummary};
+pub use processor::{MigrationProcessor, ProcessorResult};
+pub use state::{MigrationRecord, MigrationStatus};

--- a/bedrock/src/migration/mod.rs
+++ b/bedrock/src/migration/mod.rs
@@ -58,7 +58,7 @@
 //! first, not just migration records. Example:
 //!
 //! ```rust,ignore
-//! async fn is_applicable(&self, record: Option<&MigrationRecord>) -> OxideResult<bool> {
+//! async fn is_applicable(&self, record: Option<&MigrationRecord>) -> MigrationResult<bool> {
 //!     // 1. Check if migration outcome already exists (e.g., v4 credential restored from backup)
 //!     if self.credential_store.has_v4_credential().await? {
 //!         return Ok(false);  // Skip - already have what this migration creates
@@ -69,13 +69,15 @@
 //! ```
 
 mod controller;
+mod error;
 mod processor;
 mod state;
 
-// Example processors
+/// Migration processor implementations
 pub mod processors;
 
 // Public API exports
 pub use controller::{MigrationController, MigrationRunSummary};
+pub use error::{MigrationError, MigrationResult};
 pub use processor::{MigrationProcessor, ProcessorResult};
 pub use state::{MigrationRecord, MigrationStatus};

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -1,0 +1,46 @@
+use crate::OxideResult;
+use async_trait::async_trait;
+
+/// Result of executing a migration processor
+pub enum ProcessorResult {
+    /// Migration succeeded
+    Success,
+
+    /// Migration failed but can be retried
+    Retryable {
+        error_code: String,
+        error_message: String,
+        retry_after_ms: Option<i64>,
+    },
+
+    /// Migration failed with terminal error (won't retry)
+    Terminal { error_code: String, error_message: String },
+
+    /// Migration blocked pending user action
+    BlockedUserAction { reason: String },
+}
+
+/// Trait that all migration processors must implement
+#[async_trait]
+pub trait MigrationProcessor: Send + Sync {
+    /// Unique identifier for this migration (e.g., "worldid.account.bootstrap.v1")
+    /// The version should be included in the ID itself (e.g., ".v1", ".v2")
+    fn migration_id(&self) -> &str;
+
+    /// Check if this migration is applicable
+    ///
+    /// This method should check **actual state** (e.g., does v4 credential exist?)
+    /// to determine if the migration needs to run. This ensures the system is
+    /// truly idempotent and handles edge cases gracefully.
+    ///
+    ///
+    /// # Returns
+    /// - `Ok(true)` if the migration should run
+    /// - `Ok(false)` if the migration should be skipped
+    /// - `Err(_)` if unable to determine (migration will be skipped with error logged)
+    async fn is_applicable(&self) -> OxideResult<bool>;
+
+    /// Execute the migration
+    /// Called by the controller when the migration is ready to run
+    async fn execute(&self) -> OxideResult<ProcessorResult>;
+}

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -1,4 +1,4 @@
-use crate::OxideResult;
+use crate::migration::MigrationResult;
 use async_trait::async_trait;
 
 /// Result of executing a migration processor
@@ -8,16 +8,27 @@ pub enum ProcessorResult {
 
     /// Migration failed but can be retried
     Retryable {
+        /// Error code for this failure
         error_code: String,
+        /// Human-readable error message
         error_message: String,
+        /// Optional suggestion for when to retry (in milliseconds)
         retry_after_ms: Option<i64>,
     },
 
     /// Migration failed with terminal error (won't retry)
-    Terminal { error_code: String, error_message: String },
+    Terminal {
+        /// Error code for this terminal failure
+        error_code: String,
+        /// Human-readable error message
+        error_message: String,
+    },
 
     /// Migration blocked pending user action
-    BlockedUserAction { reason: String },
+    BlockedUserAction {
+        /// Reason why the migration is blocked
+        reason: String,
+    },
 }
 
 /// Trait that all migration processors must implement
@@ -38,9 +49,9 @@ pub trait MigrationProcessor: Send + Sync {
     /// - `Ok(true)` if the migration should run
     /// - `Ok(false)` if the migration should be skipped
     /// - `Err(_)` if unable to determine (migration will be skipped with error logged)
-    async fn is_applicable(&self) -> OxideResult<bool>;
+    async fn is_applicable(&self) -> MigrationResult<bool>;
 
     /// Execute the migration
     /// Called by the controller when the migration is ready to run
-    async fn execute(&self) -> OxideResult<ProcessorResult>;
+    async fn execute(&self) -> MigrationResult<ProcessorResult>;
 }

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -1,0 +1,118 @@
+use crate::migration::processor::{MigrationProcessor, ProcessorResult};
+use crate::OxideResult;
+use async_trait::async_trait;
+use log::info;
+
+/// Example processor skeleton showing how to implement a migration
+///
+/// This is a **template** - copy this file and customize it for your actual migration.
+/// Replace `ExampleProcessor` with your processor name and update the migration_id.
+///
+/// For actual implementations, see the migration spec and implement processors like:
+/// - `AccountBootstrapProcessor` for "worldid.account.bootstrap.v1"
+/// - `PoHRefreshProcessor` for "worldid.credentials.poh.refresh.v1"
+/// - `NfcRefreshProcessor` for "worldid.credentials.nfc.refresh.v1"
+pub struct ExampleProcessor {
+    // Add dependencies here (e.g., authenticator, config, API clients, credential store, etc.)
+    // For example:
+    // authenticator: Arc<Authenticator>,
+    // config: Arc<Config>,
+    // credential_store: Arc<CredentialStore>,
+}
+
+impl ExampleProcessor {
+    #[allow(dead_code)]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            // Initialize dependencies
+        }
+    }
+}
+
+impl Default for ExampleProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MigrationProcessor for ExampleProcessor {
+    fn migration_id(&self) -> &'static str {
+        // TODO: Replace with your actual migration ID
+        // Format: "namespace.category.action.v1"
+        // Examples:
+        //   - "worldid.account.bootstrap.v1"
+        //   - "worldid.credentials.poh.refresh.v1"
+        //   - "worldid.credentials.nfc.refresh.v1"
+        "example.migration.v1"
+    }
+
+    async fn is_applicable(&self) -> OxideResult<bool> {
+        // IMPORTANT: Check actual state, not migration records
+        // This ensures idempotency and handles reinstalls gracefully.
+
+        // Example implementation pattern:
+
+        // 1. Check if the migration outcome already exists (e.g., v4 credential exists)
+        // if self.credential_store.has_v4_credential().await? {
+        //     info!("v4 credential already exists, migration not needed");
+        //     return Ok(false);
+        // }
+
+        // 2. Check if the migration source exists (e.g., v3 credential to migrate from)
+        // if !self.credential_store.has_v3_credential().await? {
+        //     info!("No v3 credential to migrate, skipping");
+        //     return Ok(false);
+        // }
+
+        // 3. Check feature flags if applicable
+        // if !self.config.is_migration_enabled() {
+        //     return Ok(false);
+        // }
+
+        // 4. All checks passed - migration is needed
+        // Ok(true)
+
+        // Placeholder: skip this example processor
+        Ok(false)
+    }
+
+    async fn execute(&self) -> OxideResult<ProcessorResult> {
+        info!("Executing example migration");
+
+        // TODO: Implement your migration logic here
+        //
+        // Example patterns:
+
+        // SUCCESS CASE:
+        // let result = self.do_migration().await?;
+        // return Ok(ProcessorResult::Success);
+
+        // RETRYABLE ERROR (network issues, temporary failures):
+        // if let Err(e) = self.api_call().await {
+        //     return Ok(ProcessorResult::Retryable {
+        //         error_code: "NETWORK_ERROR".to_string(),
+        //         error_message: format!("Failed to connect: {}", e),
+        //         retry_after_ms: Some(30_000), // Optional: suggest retry delay
+        //     });
+        // }
+
+        // TERMINAL ERROR (can't recover, don't retry):
+        // if account_not_found {
+        //     return Ok(ProcessorResult::Terminal {
+        //         error_code: "ACCOUNT_NOT_FOUND".to_string(),
+        //         error_message: "No account exists for this user".to_string(),
+        //     });
+        // }
+
+        // BLOCKED (waiting for user action):
+        // if needs_user_consent {
+        //     return Ok(ProcessorResult::BlockedUserAction {
+        //         reason: "User must grant permission in settings".to_string(),
+        //     });
+        // }
+
+        Ok(ProcessorResult::Success)
+    }
+}

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -1,5 +1,5 @@
+use crate::migration::error::MigrationResult;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};
-use crate::OxideResult;
 use async_trait::async_trait;
 use log::info;
 
@@ -21,6 +21,7 @@ pub struct ExampleProcessor {
 }
 
 impl ExampleProcessor {
+    /// Create a new example processor
     #[allow(dead_code)]
     #[must_use]
     pub const fn new() -> Self {
@@ -48,7 +49,7 @@ impl MigrationProcessor for ExampleProcessor {
         "example.migration.v1"
     }
 
-    async fn is_applicable(&self) -> OxideResult<bool> {
+    async fn is_applicable(&self) -> MigrationResult<bool> {
         // IMPORTANT: Check actual state, not migration records
         // This ensures idempotency and handles reinstalls gracefully.
 
@@ -78,7 +79,7 @@ impl MigrationProcessor for ExampleProcessor {
         Ok(false)
     }
 
-    async fn execute(&self) -> OxideResult<ProcessorResult> {
+    async fn execute(&self) -> MigrationResult<ProcessorResult> {
         info!("Executing example migration");
 
         // TODO: Implement your migration logic here

--- a/bedrock/src/migration/processors/mod.rs
+++ b/bedrock/src/migration/processors/mod.rs
@@ -1,0 +1,8 @@
+/// Example migration processors
+///
+/// This module contains skeleton implementations of migration processors
+/// that can be used as templates for actual migrations.
+pub mod example_processor;
+
+// Re-export for convenience
+pub use example_processor::ExampleProcessor;

--- a/bedrock/src/migration/state.rs
+++ b/bedrock/src/migration/state.rs
@@ -1,0 +1,65 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Status of a single migration
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum MigrationStatus {
+    NotStarted,
+    InProgress,
+    Succeeded,
+    FailedRetryable,
+    FailedTerminal,
+    BlockedUserAction,
+}
+
+/// Record of a single migration's execution state
+/// e.g. this could be the PoH refresh migration stage.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MigrationRecord {
+    /// Current status
+    pub status: MigrationStatus,
+
+    /// Number of attempts
+    pub attempts: i32,
+
+    /// Timestamp when migration was first started
+    pub started_at: Option<DateTime<Utc>>,
+
+    /// Timestamp of last attempt
+    pub last_attempted_at: Option<DateTime<Utc>>,
+
+    /// Timestamp when to retry next
+    /// Included so migrations are not spammed on each app open.
+    pub next_attempt_at: Option<DateTime<Utc>>,
+
+    /// Last error code (if any)
+    pub last_error_code: Option<String>,
+
+    /// Last error message (if any)
+    pub last_error_message: Option<String>,
+
+    /// Timestamp when migration completed successfully
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl MigrationRecord {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            status: MigrationStatus::NotStarted,
+            attempts: 0,
+            started_at: None,
+            last_attempted_at: None,
+            next_attempt_at: None,
+            last_error_code: None,
+            last_error_message: None,
+            completed_at: None,
+        }
+    }
+}
+
+impl Default for MigrationRecord {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/bedrock/src/migration/state.rs
+++ b/bedrock/src/migration/state.rs
@@ -4,11 +4,17 @@ use serde::{Deserialize, Serialize};
 /// Status of a single migration
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum MigrationStatus {
+    /// Migration has not been started yet
     NotStarted,
+    /// Migration is currently in progress
     InProgress,
+    /// Migration completed successfully
     Succeeded,
+    /// Migration failed but can be retried
     FailedRetryable,
+    /// Migration failed with a terminal error (cannot retry)
     FailedTerminal,
+    /// Migration is blocked waiting for user action
     BlockedUserAction,
 }
 
@@ -43,6 +49,7 @@ pub struct MigrationRecord {
 }
 
 impl MigrationRecord {
+    /// Create a new migration record with default values
     #[must_use]
     pub const fn new() -> Self {
         Self {


### PR DESCRIPTION
Moving the `MigrationController` over from Oxide to Bedrock: https://github.com/worldcoin/oxide/pull/879

------------------------------------------------------------------
## Implement general Migration abstraction for the app
As part of the World ID 3.0 -> 4.0 migration we need to re-issue all user credentials, PoH and NFC, in the background. There are numerous other upcoming migrations, such as issuing an Allowance module onto user's Safes. Given that, we introduce a general Migration abstraction which will be a permanent artifact of the app; rather than building multiple independent ad hoc background migration tasks. The job of the Migration artifact is to bring a user's app to the expected state.

This PR introduces the general abstraction. There is a concept of a MigrationController who's job it is to orchestrate the migration flow on app start. It has a series of MigrationProcessors in a "registry", where each Processor implements a specific migration and encapsulates all related logic.

For example, for the World ID 4.0 migration there are two processors:

- `worldid.credentials.poh.refresh.v1`
- `worldid.credentials.nfc.refresh.v1`
Processors implement two main methods:
```
pub trait MigrationProcessor: {
    async fn is_applicable() -> determine if the migration should be run, based on conditions defined by the specific migration
    
    async fn execute() - > execute the specific migration
}
```
The MigrationController essentially iterates through all processors, calls `processor.is_applicable()` and if true, then calls `execute()`. This should run in a background thread so we don't block the main UI.

### Migration state
There is a concept of MigrationRecords which stores a record of the migration in a key:value store in the device storage.

Importantly, it is okay if the app is deleted and MigrationState is wiped. If the user does that and uses backup and recovery to restore their WorldID and credentials; the Migration will still work. is_applicable() is expected to check the raw existence of a WorldID, credential in CredentialStorage engine etc.

This is implemented in Oxide so that we don't have two dual implementations across Swift and Kotlin.

### Full spec
https://docs.google.com/document/d/1WEGZk6F6Y8RDfkSRrpgr4OkDOJKeakhvI22VQaMDEe4/edit?usp=sharing

