### PR TITLE
feat: add timeout protections to migration controller

### DIFF
--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -14,7 +14,6 @@ const MAX_RETRY_DELAY_MS: i64 = 86_400_000; // 1 day
 
 #[cfg(not(test))]
 const MIGRATION_TIMEOUT_SECS: u64 = 20; // 20 seconds in production
-                                        // Use a shorter timeout in tests to speed up test ex
 #[cfg(test)]
 const MIGRATION_TIMEOUT_SECS: u64 = 1; // 1 second in tests
 

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -12,9 +12,9 @@ const MIGRATION_KEY_PREFIX: &str = "migration:";
 const DEFAULT_RETRY_DELAY_MS: i64 = 60_000; // 1 minute
 const MAX_RETRY_DELAY_MS: i64 = 86_400_000; // 1 day
 
-// Use a shorter timeout in tests to speed up test execution
 #[cfg(not(test))]
 const MIGRATION_TIMEOUT_SECS: u64 = 20; // 20 seconds in production
+// Use a shorter timeout in tests to speed up test ex
 #[cfg(test)]
 const MIGRATION_TIMEOUT_SECS: u64 = 1; // 1 second in tests
 
@@ -796,7 +796,7 @@ mod tests {
         }
     }
 
-    /// Test processor that hangs indefinitely during is_applicable check
+    /// Test processor that hangs indefinitely during `is_applicable` check
     struct HangingApplicabilityProcessor {
         id: String,
     }

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -14,7 +14,7 @@ const MAX_RETRY_DELAY_MS: i64 = 86_400_000; // 1 day
 
 #[cfg(not(test))]
 const MIGRATION_TIMEOUT_SECS: u64 = 20; // 20 seconds in production
-// Use a shorter timeout in tests to speed up test ex
+                                        // Use a shorter timeout in tests to speed up test ex
 #[cfg(test)]
 const MIGRATION_TIMEOUT_SECS: u64 = 1; // 1 second in tests
 

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -11,7 +11,12 @@ use tokio::sync::Mutex;
 const MIGRATION_KEY_PREFIX: &str = "migration:";
 const DEFAULT_RETRY_DELAY_MS: i64 = 60_000; // 1 minute
 const MAX_RETRY_DELAY_MS: i64 = 86_400_000; // 1 day
-const MIGRATION_TIMEOUT_SECS: u64 = 20; // 20 seconds
+
+// Use a shorter timeout in tests to speed up test execution
+#[cfg(not(test))]
+const MIGRATION_TIMEOUT_SECS: u64 = 20; // 20 seconds in production
+#[cfg(test)]
+const MIGRATION_TIMEOUT_SECS: u64 = 1; // 1 second in tests
 
 /// Global lock to prevent concurrent migration runs across all controller instances.
 /// This is a process-wide coordination mechanism that ensures only one migration

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -97,6 +97,16 @@ impl MigrationController {
     /// If another migration is already in progress when this method is called, it will return
     /// immediately with an `InvalidOperation` error rather than waiting.
     ///
+    /// # Timeouts
+    ///
+    /// Each migration is subject to a 20-second timeout for both applicability checks and execution.
+    /// If a migration times out:
+    /// - During `is_applicable()`: The migration is skipped
+    /// - During `execute()`: The migration is marked as retryable and scheduled for retry with exponential backoff
+    ///
+    /// Subsequent migrations will continue regardless of timeouts, ensuring one slow migration
+    /// doesn't block the entire migration system.
+    ///
     /// # Errors
     ///
     /// Returns `MigrationError::InvalidOperation` if another migration run is already in progress.

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -33,6 +33,21 @@ pub enum ProcessorResult {
 }
 
 /// Trait that all migration processors must implement
+///
+/// # Timeouts and Cancellation Safety
+///
+/// Both [`is_applicable`](Self::is_applicable) and [`execute`](Self::execute) are subject to timeouts
+/// (20 seconds in production). When a timeout occurs, the future is dropped and the migration
+/// is marked as failed (for `execute`) or skipped (for `is_applicable`).
+///
+/// **IMPORTANT**: Implementations MUST be cancellation-safe:
+///
+/// - **DO NOT** spawn background tasks using `tokio::spawn`, `std::thread::spawn`, or similar
+///   that will continue running after the timeout
+/// - **DO NOT** use blocking operations or FFI calls without proper cleanup
+/// - **ENSURE** all work stops when the future is dropped (cooperative cancellation)
+/// - **MAKE** migrations idempotent so partial execution can be safely retried
+///
 #[uniffi::export(with_foreign)]
 #[async_trait]
 pub trait MigrationProcessor: Send + Sync {
@@ -46,7 +61,6 @@ pub trait MigrationProcessor: Send + Sync {
     /// to determine if the migration needs to run. This ensures the system is
     /// truly idempotent and handles edge cases gracefully.
     ///
-    ///
     /// # Returns
     /// - `Ok(true)` if the migration should run
     /// - `Ok(false)` if the migration should be skipped
@@ -54,6 +68,5 @@ pub trait MigrationProcessor: Send + Sync {
     async fn is_applicable(&self) -> Result<bool, MigrationError>;
 
     /// Execute the migration
-    /// Called by the controller when the migration is ready to run
     async fn execute(&self) -> Result<ProcessorResult, MigrationError>;
 }


### PR DESCRIPTION
## Add timeout protections to migration controller
The Migration `controller.rs` does not currently have timeout protections in case a migration hangs indefinitely. This PR adds them, and enforces a limit of 20seconds per migration.

If the migration takes longer than 20seconds, it is failed and marked retryable. Exponential backoff is used to determine the next time it can be retried.