### PR TITLE
feat: add permit2 allowance signing support

### DIFF
--- a/bedrock-macros/src/lib.rs
+++ b/bedrock-macros/src/lib.rs
@@ -743,6 +743,8 @@ fn generate_unparsed_struct(struct_info: &StructInfo) -> String {
 
         // 6.3: Use nested unparsed struct for complex types, String for primitives
         let field_type = if is_sol_struct_type(&field.ty) {
+            // 6.4: Add Solidity type comment for nested struct types
+            code.push_str(&format!("    /// Nested struct type: `{}`\n", field.ty));
             format!("Unparsed{}", field.ty)
         } else {
             // 6.4: Add Solidity type comment for primitive types
@@ -808,7 +810,7 @@ fn generate_try_from_impl(
                     field.name, field.name, field.name
                 ),
                 _ => format!(
-                    "            {}: value.{}.parse().map_err(|e| crate::primitives::PrimitiveError::InvalidInput {{ attribute: \"{}\", error_message: format!(\"failed to parse: {{}}\", e) }})?",
+                    "            {}: value.{}.parse().map_err(|e| crate::primitives::PrimitiveError::InvalidInput {{ attribute: \"{}\".to_string(), error_message: format!(\"failed to parse: {{}}\", e) }})?",
                     field.name, field.name, field.name
                 ),
             }
@@ -834,8 +836,10 @@ fn is_sol_struct_type(ty: &str) -> bool {
         ty,
         "address"
             | "uint256"
+            | "uint160"
             | "uint128"
             | "uint64"
+            | "uint48"
             | "uint32"
             | "uint16"
             | "uint8"

--- a/bedrock/src/smart_account/permit2.rs
+++ b/bedrock/src/smart_account/permit2.rs
@@ -42,8 +42,54 @@ bedrock_sol! {
     }
 }
 
+bedrock_sol! {
+    /// The approval details for a single token allowance.
+    ///
+    /// Reference: <https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/interfaces/IAllowanceTransfer.sol#L41>
+    #[derive(serde::Serialize)]
+    #[unparsed]
+    struct PermitDetails {
+        // ERC20 token address
+        address token;
+        // Maximum amount allowed to transfer
+        uint160 amount;
+        // Timestamp at which the allowance expires
+        uint48 expiration;
+        // An incrementing value indexed per owner, token, and spender for each signature
+        uint48 nonce;
+    }
+
+    /// The permit message for a single token allowance.
+    ///
+    /// Reference: <https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/interfaces/IAllowanceTransfer.sol#L51>
+    #[derive(serde::Serialize)]
+    #[unparsed]
+    struct PermitSingle {
+        // The permit data for a single token allowance
+        PermitDetails details;
+        // Address permissioned on the allowed tokens
+        address spender;
+        // Deadline on the permit signature
+        uint256 sigDeadline;
+    }
+}
+
 impl PermitTransferFrom {
     /// Converts the `PermitTransferFrom` struct into an EIP-712 `TypedData` struct with its relevant domain.
+    #[must_use]
+    pub fn as_typed_data(&self, chain_id: u32) -> TypedData {
+        let domain: Eip712Domain = eip712_domain!(
+            name: "Permit2",
+            chain_id: chain_id.into(),
+            verifying_contract: PERMIT2_ADDRESS,
+        );
+
+        TypedData::from_struct(self, Some(domain))
+    }
+}
+
+impl PermitSingle {
+    /// Converts the `PermitSingle` struct into an EIP-712 `TypedData` struct with its relevant domain.
     #[must_use]
     pub fn as_typed_data(&self, chain_id: u32) -> TypedData {
         let domain: Eip712Domain = eip712_domain!(
@@ -87,5 +133,94 @@ mod tests {
                 "0x22c2b928cf818940122abf8f5e7e04158c38653b9a985006e295e90f32abd351"
             )
         );
+    }
+
+    #[test]
+    fn test_permit2_allowance_typed_data_produces_valid_hash() {
+        let details = PermitDetails {
+            token: address!("0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1"),
+            amount: uint!(1000000000000000000_U160),
+            expiration: uint!(1704067200_U48),
+            nonce: uint!(0_U48),
+        };
+
+        let permit_single = PermitSingle {
+            details,
+            spender: address!("0x3f1480266afef1ba51834cfef0a5d61841d57572"),
+            sigDeadline: uint!(1704067200_U256),
+        };
+
+        let signing_hash = permit_single
+            .as_typed_data(Network::WorldChain as u32)
+            .eip712_signing_hash();
+
+        // Verify the hash can be computed without error
+        assert!(signing_hash.is_ok());
+        // The hash should be 32 bytes (B256)
+        let hash = signing_hash.unwrap();
+        assert_ne!(
+            hash,
+            fixed_bytes!(
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            )
+        );
+    }
+
+    #[test]
+    fn test_permit2_allowance_typed_data_is_deterministic() {
+        let make_permit_single = || {
+            let details = PermitDetails {
+                token: address!("0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1"),
+                amount: uint!(500000000000000000_U160),
+                expiration: uint!(1704153600_U48),
+                nonce: uint!(1_U48),
+            };
+
+            PermitSingle {
+                details,
+                spender: address!("0x3f1480266afef1ba51834cfef0a5d61841d57572"),
+                sigDeadline: uint!(1704067200_U256),
+            }
+        };
+
+        let hash1 = make_permit_single()
+            .as_typed_data(Network::WorldChain as u32)
+            .eip712_signing_hash()
+            .unwrap();
+
+        let hash2 = make_permit_single()
+            .as_typed_data(Network::WorldChain as u32)
+            .eip712_signing_hash()
+            .unwrap();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_permit2_allowance_different_chain_id_produces_different_hash() {
+        let details = PermitDetails {
+            token: address!("0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1"),
+            amount: uint!(1000000000000000000_U160),
+            expiration: uint!(1704067200_U48),
+            nonce: uint!(0_U48),
+        };
+
+        let permit_single = PermitSingle {
+            details,
+            spender: address!("0x3f1480266afef1ba51834cfef0a5d61841d57572"),
+            sigDeadline: uint!(1704067200_U256),
+        };
+
+        let hash_worldchain = permit_single
+            .as_typed_data(Network::WorldChain as u32)
+            .eip712_signing_hash()
+            .unwrap();
+
+        let hash_ethereum = permit_single
+            .as_typed_data(Network::Ethereum as u32)
+            .eip712_signing_hash()
+            .unwrap();
+
+        assert_ne!(hash_worldchain, hash_ethereum);
     }
 }

--- a/bedrock/tests/test_smart_account_permit2_allowance.rs
+++ b/bedrock/tests/test_smart_account_permit2_allowance.rs
@@ -1,0 +1,246 @@
+use alloy::{
+    primitives::{address, Address, U160, U256},
+    providers::{ext::AnvilApi, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::SolCall,
+};
+use bedrock::primitives::Network;
+use bedrock::smart_account::{
+    SafeOperation, SafeSmartAccount, SafeTransaction, UnparsedPermitDetails,
+    UnparsedPermitSingle, PERMIT2_ADDRESS,
+};
+use chrono::Utc;
+
+mod common;
+use common::{deploy_safe, set_erc20_balance_for_safe, setup_anvil, ISafe, IERC20};
+
+sol!(
+    // NOTE: This is defined in the `permit2` module, but it cannot be easily re-used here.
+    struct PermitDetails {
+        address token;
+        uint160 amount;
+        uint48 expiration;
+        uint48 nonce;
+    }
+
+    /// The permit message for a single token allowance.
+    struct PermitSingle {
+        PermitDetails details;
+        address spender;
+        uint256 sigDeadline;
+    }
+
+    /// Reference: <https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/interfaces/IAllowanceTransfer.sol>
+    #[sol(rpc)]
+    interface IAllowanceTransfer {
+        function permit(
+            address owner,
+            PermitSingle memory permitSingle,
+            bytes calldata signature
+        ) external;
+
+        function transferFrom(
+            address from,
+            address to,
+            uint160 amount,
+            address token
+        ) external;
+
+        function allowance(
+            address user,
+            address token,
+            address spender
+        ) external view returns (uint160 amount, uint48 expiration, uint48 nonce);
+    }
+);
+
+/// This integration test encompasses multiple key functionality of the `SafeSmartAccount`.
+/// In particular it tests both `sign_transaction` & `sign_permit2_allowance`.
+///
+/// The high level flow is as follows:
+/// 1. General set-up
+/// 2. Deploy a Safe (World App User)
+/// 3. Give the Safe some simulated WLD balance
+/// 4. Approve the Permit2 contract to transfer WLD tokens from the Safe on the ERC-20 WLD contract (this tests `sign_transaction` works properly on-chain).
+/// 5. Initialize a "Mini App" Wallet which will get approved via allowance
+/// 6. Sign a Permit2 allowance to grant the Mini App an allowance on behalf of the Safe
+/// 7. Execute the `permit` call on the Permit2 contract to set the allowance
+/// 8. Execute a `transferFrom` call on the Permit2 contract using the allowance
+/// 9. Verify the tokens were transferred
+#[tokio::test]
+async fn test_integration_permit2_allowance() -> anyhow::Result<()> {
+    // Step 1: Initial setup
+    let anvil = setup_anvil();
+    let owner_signer = PrivateKeySigner::random();
+    let owner_key_hex = hex::encode(owner_signer.to_bytes());
+    let owner = owner_signer.address();
+
+    let provider = ProviderBuilder::new()
+        .wallet(owner_signer.clone())
+        .connect_http(anvil.endpoint_url());
+
+    provider.anvil_set_balance(owner, U256::from(1e18)).await?;
+
+    // Step 2: Deploy a Safe (World App User)
+    let safe_address = deploy_safe(&provider, owner, U256::ZERO).await?;
+    let chain_id = Network::WorldChain as u32;
+    let safe_account = SafeSmartAccount::new(owner_key_hex, &safe_address.to_string())?;
+
+    // Step 3: Give the Safe some simulated WLD balance
+    let wld_token_address = address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003");
+    let wld_contract = IERC20::new(wld_token_address, &provider);
+    let balance = U256::from(10e18); // 10 WLD
+
+    set_erc20_balance_for_safe(&provider, wld_token_address, safe_address, balance)
+        .await?;
+
+    assert_eq!(wld_contract.balanceOf(safe_address).call().await?, balance);
+
+    // Step 4: Approve the Permit2 contract to transfer WLD tokens from the Safe
+    let calldata = IERC20::approveCall {
+        spender: PERMIT2_ADDRESS,
+        amount: U256::MAX,
+    }
+    .abi_encode();
+
+    let tx = SafeTransaction {
+        to: wld_token_address.to_string(),
+        value: "0".to_string(),
+        data: format!("0x{}", hex::encode(&calldata)),
+        operation: SafeOperation::Call,
+        safe_tx_gas: "33000".to_string(),
+        base_gas: "30000".to_string(),
+        gas_price: "0".to_string(),
+        gas_token: "0x0000000000000000000000000000000000000000".to_string(),
+        refund_receiver: "0x0000000000000000000000000000000000000000".to_string(),
+        nonce: "0".to_string(),
+    };
+    let signature = safe_account.sign_transaction(chain_id, tx)?;
+
+    let safe_contract = ISafe::new(safe_address, &provider);
+    let approve_result = safe_contract
+        .execTransaction(
+            wld_token_address,
+            U256::ZERO, // value
+            calldata.into(),
+            0u8, // `Call`
+            U256::from(33_000u64),
+            U256::from(30_000u64), // base_gas
+            U256::ZERO,            // gas_price (no refund)
+            Address::ZERO,         // ETH token
+            Address::ZERO,         // refund_receiver
+            signature.to_vec()?.into(),
+        )
+        .from(owner)
+        .send()
+        .await?;
+
+    approve_result.get_receipt().await?;
+
+    // Step 5: Initialize a "Mini App" Wallet which will get approved via allowance
+    let mini_app_signer = PrivateKeySigner::random();
+    let mini_app_provider = ProviderBuilder::new()
+        .wallet(mini_app_signer.clone())
+        .connect_http(anvil.endpoint_url());
+
+    mini_app_provider
+        .anvil_set_balance(mini_app_signer.address(), U256::from(1e18))
+        .await?;
+
+    // Step 6: Sign a Permit2 allowance to grant the Mini App an allowance
+    let allowance_amount: u128 = 5_000_000_000_000_000_000; // 5 WLD
+    let expiration = (Utc::now().timestamp() + 3600) as u64; // 1 hour from now
+    let sig_deadline = Utc::now().timestamp() + 180; // 3 minutes from now
+
+    let details = UnparsedPermitDetails {
+        token: wld_token_address.to_string(),
+        amount: allowance_amount.to_string(),
+        expiration: expiration.to_string(),
+        nonce: "0".to_string(),
+    };
+
+    let permit_single = UnparsedPermitSingle {
+        details,
+        spender: mini_app_signer.address().to_string(),
+        sigDeadline: sig_deadline.to_string(),
+    };
+
+    let signature = safe_account
+        .sign_permit2_allowance(chain_id, permit_single)
+        .expect("Failed to sign permit2 allowance");
+
+    // Step 7: Execute the `permit` call on the Permit2 contract to set the allowance
+    let permit_struct = PermitSingle {
+        details: PermitDetails {
+            token: wld_token_address,
+            amount: U160::from(allowance_amount),
+            expiration: alloy::primitives::aliases::U48::from(expiration),
+            nonce: alloy::primitives::aliases::U48::from(0u64),
+        },
+        spender: mini_app_signer.address(),
+        sigDeadline: U256::from(sig_deadline),
+    };
+
+    let signature_bytes = signature.to_vec()?;
+
+    let permit2_contract = IAllowanceTransfer::new(PERMIT2_ADDRESS, &mini_app_provider);
+
+    let result = permit2_contract
+        .permit(safe_address, permit_struct, signature_bytes.into())
+        .from(mini_app_signer.address())
+        .gas(500_000)
+        .send()
+        .await?;
+
+    result.get_receipt().await?;
+
+    // Verify the allowance was set
+    let allowance = permit2_contract
+        .allowance(safe_address, wld_token_address, mini_app_signer.address())
+        .call()
+        .await?;
+
+    assert_eq!(allowance.amount, U160::from(allowance_amount));
+
+    // Step 8: Execute a `transferFrom` call using the allowance
+    let transfer_amount: u128 = 1_000_000_000_000_000_000; // 1 WLD
+
+    let transfer_result = permit2_contract
+        .transferFrom(
+            safe_address,
+            mini_app_signer.address(),
+            U160::from(transfer_amount),
+            wld_token_address,
+        )
+        .from(mini_app_signer.address())
+        .gas(500_000)
+        .send()
+        .await?;
+
+    transfer_result.get_receipt().await?;
+
+    // Step 9: Verify the tokens were indeed transferred
+    let wld_contract = IERC20::new(wld_token_address, &mini_app_provider);
+    let mini_app_balance = wld_contract
+        .balanceOf(mini_app_signer.address())
+        .call()
+        .await?;
+    let safe_balance_after = wld_contract.balanceOf(safe_address).call().await?;
+
+    assert_eq!(mini_app_balance, U256::from(1e18));
+    assert_eq!(safe_balance_after, U256::from(9e18));
+
+    // Verify the remaining allowance was decremented
+    let remaining_allowance = permit2_contract
+        .allowance(safe_address, wld_token_address, mini_app_signer.address())
+        .call()
+        .await?;
+
+    assert_eq!(
+        remaining_allowance.amount,
+        U160::from(allowance_amount - transfer_amount)
+    );
+
+    Ok(())
+}

--- a/kotlin/bedrock-tests/src/test/kotlin/bedrock/BedrockSolMacroTests.kt
+++ b/kotlin/bedrock-tests/src/test/kotlin/bedrock/BedrockSolMacroTests.kt
@@ -90,4 +90,76 @@ class BedrockSolMacroTests {
         assertEquals("1000000000000000000", modifiedPermissions.amount)
         assertEquals(tokenPermissions.token, modifiedPermissions.token)
     }
+
+    @Test
+    fun `test UnparsedPermitDetails creation`() {
+        // Test creating an UnparsedPermitDetails struct
+        val unparsed = UnparsedPermitDetails(
+            token = "0x1234567890123456789012345678901234567890",
+            amount = "1000000000000000000",
+            expiration = "1704067200",
+            nonce = "0"
+        )
+
+        assertEquals("0x1234567890123456789012345678901234567890", unparsed.token)
+        assertEquals("1000000000000000000", unparsed.amount)
+        assertEquals("1704067200", unparsed.expiration)
+        assertEquals("0", unparsed.nonce)
+    }
+
+    @Test
+    fun `test UnparsedPermitSingle with nesting`() {
+        // Test creating nested structures for allowance
+        val permitDetails = UnparsedPermitDetails(
+            token = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            amount = "1000000",
+            expiration = "1704067200",
+            nonce = "0"
+        )
+
+        val permitSingle = UnparsedPermitSingle(
+            details = permitDetails,
+            spender = "0x0000000000000000000000000000000000000001",
+            sigDeadline = "1704067200"
+        )
+
+        assertEquals("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", permitSingle.details.token)
+        assertEquals("1000000", permitSingle.details.amount)
+        assertEquals("1704067200", permitSingle.details.expiration)
+        assertEquals("0", permitSingle.details.nonce)
+        assertEquals("0x0000000000000000000000000000000000000001", permitSingle.spender)
+        assertEquals("1704067200", permitSingle.sigDeadline)
+    }
+
+    @Test
+    fun `test sign Permit2 allowance integration`() {
+        // Test that the unparsed types work with the signing function
+        val safeAccount = SafeSmartAccount(
+            privateKey = "4142710b9b4caaeb000b8e5de271bbebac7f509aab2f5e61d1ed1958bfe6d583",
+            walletAddress = "0x4564420674EA68fcc61b463C0494807C759d47e6"
+        )
+
+        val permitDetails = UnparsedPermitDetails(
+            token = "0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1",
+            amount = "1000000000000000000",
+            expiration = "1704067200",
+            nonce = "0"
+        )
+
+        val permitSingle = UnparsedPermitSingle(
+            details = permitDetails,
+            spender = "0x3f1480266afef1ba51834cfef0a5d61841d57572",
+            sigDeadline = "1704067200"
+        )
+
+        // This should successfully sign the permit allowance
+        val signature = safeAccount.signPermit2Allowance(
+            chainId = 480u,
+            permit = permitSingle
+        )
+
+        // Verify we got a valid signature back (should be 65 bytes hex = 130 chars + 0x)
+        assertEquals(132, signature.toHexString().length)
+        assertTrue(signature.toHexString().startsWith("0x"))
+    }
 } 

--- a/swift/tests/BedrockTests/BedrockSolMacroTests.swift
+++ b/swift/tests/BedrockTests/BedrockSolMacroTests.swift
@@ -65,4 +65,73 @@ final class BedrockSolMacroTests: XCTestCase {
         XCTAssertEqual(signature.toHexString().count, 132)
         XCTAssertTrue(signature.toHexString().hasPrefix("0x"))
     }
+
+    func testUnparsedPermitDetailsCreation() throws {
+        // Test creating an UnparsedPermitDetails struct
+        let unparsed = UnparsedPermitDetails(
+            token: "0x1234567890123456789012345678901234567890",
+            amount: "1000000000000000000",
+            expiration: "1704067200",
+            nonce: "0"
+        )
+
+        XCTAssertEqual(unparsed.token, "0x1234567890123456789012345678901234567890")
+        XCTAssertEqual(unparsed.amount, "1000000000000000000")
+        XCTAssertEqual(unparsed.expiration, "1704067200")
+        XCTAssertEqual(unparsed.nonce, "0")
+    }
+
+    func testUnparsedPermitSingleWithNesting() throws {
+        // Test creating nested structures for allowance
+        let permitDetails = UnparsedPermitDetails(
+            token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            amount: "1000000",
+            expiration: "1704067200",
+            nonce: "0"
+        )
+
+        let permitSingle = UnparsedPermitSingle(
+            details: permitDetails,
+            spender: "0x0000000000000000000000000000000000000001",
+            sigDeadline: "1704067200"
+        )
+
+        XCTAssertEqual(permitSingle.details.token, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+        XCTAssertEqual(permitSingle.details.amount, "1000000")
+        XCTAssertEqual(permitSingle.details.expiration, "1704067200")
+        XCTAssertEqual(permitSingle.details.nonce, "0")
+        XCTAssertEqual(permitSingle.spender, "0x0000000000000000000000000000000000000001")
+        XCTAssertEqual(permitSingle.sigDeadline, "1704067200")
+    }
+
+    func testSignPermit2AllowanceIntegration() throws {
+        // Test that the unparsed types work with the signing function
+        let safeAccount = try SafeSmartAccount(
+            privateKey: "4142710b9b4caaeb000b8e5de271bbebac7f509aab2f5e61d1ed1958bfe6d583",
+            walletAddress: "0x4564420674EA68fcc61b463C0494807C759d47e6"
+        )
+
+        let permitDetails = UnparsedPermitDetails(
+            token: "0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1",
+            amount: "1000000000000000000",
+            expiration: "1704067200",
+            nonce: "0"
+        )
+
+        let permitSingle = UnparsedPermitSingle(
+            details: permitDetails,
+            spender: "0x3f1480266afef1ba51834cfef0a5d61841d57572",
+            sigDeadline: "1704067200"
+        )
+
+        // This should successfully sign the permit allowance
+        let signature = try safeAccount.signPermit2Allowance(
+            chainId: 480,
+            permit: permitSingle
+        )
+
+        // Verify we got a valid signature back (should be 65 bytes hex = 130 chars + 0x)
+        XCTAssertEqual(signature.toHexString().count, 132)
+        XCTAssertTrue(signature.toHexString().hasPrefix("0x"))
+    }
 } 


### PR DESCRIPTION
This PR adds `sign_permit2_allowance` support to `SafeSmartAccount`, enabling World Card to request token allowances (via Permit2's `IAllowanceTransfer`).

## Problem

Permit2 has two distinct mechanisms: **SignatureTransfer** (one-time transfers, already supported via `sign_permit2_transfer`) and **AllowanceTransfer** (recurring allowances with expiration). We only supported the former, but allowance-based approvals are needed for Mini App use cases where a spender draws from an allowance over time.

## Changes

- **`permit2.rs`**: Added `PermitDetails` (token, uint160 amount, uint48 expiration, uint48 nonce) and `PermitSingle` (details, spender, sigDeadline) structs with `#[unparsed]` for FFI, plus `PermitSingle::as_typed_data()` for EIP-712 hashing
- **`mod.rs`**: Added `sign_permit2_allowance` method on `SafeSmartAccount`, exported `UnparsedPermitDetails` and `UnparsedPermitSingle`
- **`bedrock-macros`**: Extended `is_sol_struct_type` to handle `uint160`/`uint48`, fixed `&str` vs `String` in the catch-all `TryFrom` codegen, added doc comments for nested struct fields to satisfy `missing_docs` lint
- **Integration test**: Full on-chain test (Anvil fork) covering Safe deploy → ERC-20 approve → sign allowance → `permit()` → `transferFrom()` → balance verification
- **Swift & Kotlin tests**: Matching FFI tests for `UnparsedPermitDetails`, `UnparsedPermitSingle`, and `signPermit2Allowance`

## Test plan

- [x] `cargo test --lib smart_account` — all 35 unit tests pass
- [x] `cargo check --test test_smart_account_permit2_allowance` — integration test compiles
- [x] CI runs full test suite with `--features test_utils`
- [x] Swift and Kotlin FFI tests run in CI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crypto-signing and EIP-712 typed-data hashing paths and expands codegen for FFI structs/types; while scoped and well-tested, mistakes could produce invalid signatures or parsing errors across languages.
> 
> **Overview**
> Adds Permit2 *allowance* ("AllowanceTransfer") signing support by introducing `PermitDetails`/`PermitSingle` EIP-712 types and a new `SafeSmartAccount::sign_permit2_allowance` API, plus exports of the corresponding `Unparsed*` FFI records.
> 
> Updates the `bedrock_sol` macro codegen to better support nested unparsed structs and additional Solidity primitive widths (`uint160`, `uint48`), and fixes error construction to use owned `String` attributes. Adds unit tests for allowance typed-data hashing and restriction behavior, a full Anvil integration test that executes `permit()` + `transferFrom()` on-chain, and Swift/Kotlin FFI tests covering the new unparsed types and signing method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0569ab42dcd5de38101b10c0c380539e6fa838f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->