### PR TITLE
feat: use sync interfaces for controller to avoid UniFFI Android bug

### DIFF
--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -96,5 +96,5 @@ alloy = { version = "1.1.2", default-features = false, features = [
 dotenvy = "0.15.7"
 k256 = { version = "0.13.4", default-features = false, features = ["std", "ecdsa"] }
 serial_test = "3.2.0"
-tokio = { version = "1.47.1", features = ["time", "rt-multi-thread"] }
+tokio = { version = "1.47.1", features = ["time", "rt"] }
 tokio-test = "0.4.4"

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -96,5 +96,5 @@ alloy = { version = "1.1.2", default-features = false, features = [
 dotenvy = "0.15.7"
 k256 = { version = "0.13.4", default-features = false, features = ["std", "ecdsa"] }
 serial_test = "3.2.0"
-tokio = { version = "1.47.1", features = ["time"] }
+tokio = { version = "1.47.1", features = ["time", "rt-multi-thread"] }
 tokio-test = "0.4.4"

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -87,8 +87,6 @@ impl MigrationController {
     ///
     /// **Caller requirement:** This method blocks the calling thread for the duration
     /// of each migration. It must be called from a background thread/context.
-    /// On Kotlin, use `withContext(Dispatchers.IO) { controller.runMigrations() }`.
-    /// On Swift, dispatch to a background queue.
     ///
     /// # Concurrency
     ///

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -172,7 +172,7 @@ impl MigrationController {
             // Check if migration is applicable and should run, based on processor defined logic.
             // This checks actual state (e.g., "does v4 credential exist?") to ensure idempotency
             // even if migration record is deleted (reinstall scenario).
-            match processor.is_applicable().await {
+            match processor.is_applicable() {
                 Ok(false) => {
                     info!("Migration {migration_id} not applicable, skipping");
                     summary.skipped += 1;
@@ -207,7 +207,7 @@ impl MigrationController {
             self.save_record(&migration_id, &record)?;
 
             // Execute
-            match processor.execute().await {
+            match processor.execute() {
                 Ok(ProcessorResult::Success) => {
                     info!("Migration {migration_id} succeeded");
                     record.status = MigrationStatus::Succeeded;

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -505,15 +505,13 @@ mod tests {
         let controller_clone = controller.clone();
 
         // Start first migration on a separate thread (will hold lock for 100ms)
-        let handle1 =
-            std::thread::spawn(move || controller.run_migrations());
+        let handle1 = std::thread::spawn(move || controller.run_migrations());
 
         // Give first migration time to acquire lock
         std::thread::sleep(Duration::from_millis(10));
 
         // Try to start second migration while first is running
-        let handle2 =
-            std::thread::spawn(move || controller_clone.run_migrations());
+        let handle2 = std::thread::spawn(move || controller_clone.run_migrations());
 
         // Wait for both to complete
         let result1 = handle1.join().unwrap();
@@ -606,15 +604,13 @@ mod tests {
             MigrationController::with_processors(kv_store, vec![processor2.clone()]);
 
         // Start first controller's migration on a separate thread
-        let handle1 =
-            std::thread::spawn(move || controller1.run_migrations());
+        let handle1 = std::thread::spawn(move || controller1.run_migrations());
 
         // Give first migration time to acquire lock
         std::thread::sleep(Duration::from_millis(10));
 
         // Try second controller's migration while first is running
-        let handle2 =
-            std::thread::spawn(move || controller2.run_migrations());
+        let handle2 = std::thread::spawn(move || controller2.run_migrations());
 
         let result1 = handle1.join().unwrap();
         let result2 = handle2.join().unwrap();

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -567,7 +567,7 @@ mod tests {
         let failing_kv = Arc::new(FailingKvStore);
         let processor = Arc::new(TestProcessor::new("test.migration.v1"));
         let controller1 =
-            MigrationController::with_processors(failing_kv, vec![processor.clone()]);
+            MigrationController::with_processors(failing_kv, vec![processor]);
 
         // First migration fails
         let result1 = controller1.run_migrations();
@@ -592,14 +592,12 @@ mod tests {
         // Create two separate controller instances
         let processor1 =
             Arc::new(TestProcessor::new("test.migration1.v1").with_delay(100));
-        let controller1 = MigrationController::with_processors(
-            kv_store.clone(),
-            vec![processor1.clone()],
-        );
+        let controller1 =
+            MigrationController::with_processors(kv_store.clone(), vec![processor1]);
 
         let processor2 = Arc::new(TestProcessor::new("test.migration2.v1"));
         let controller2 =
-            MigrationController::with_processors(kv_store, vec![processor2.clone()]);
+            MigrationController::with_processors(kv_store, vec![processor2]);
 
         // Start first controller's migration on a separate thread
         let handle1 = std::thread::spawn(move || controller1.run_migrations());
@@ -674,10 +672,8 @@ mod tests {
             .set(key.clone(), "{invalid json!!!".to_string())
             .expect("Should store corrupted data");
 
-        let controller = MigrationController::with_processors(
-            kv_store.clone(),
-            vec![processor.clone()],
-        );
+        let controller =
+            MigrationController::with_processors(kv_store.clone(), vec![processor]);
 
         // Migration should still run despite corrupted record
         let result = controller.run_migrations();
@@ -826,12 +822,10 @@ mod tests {
 
         let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
         let json = serde_json::to_string(&record).unwrap();
-        kv_store.set(key.clone(), json).unwrap();
+        kv_store.set(key, json).unwrap();
 
-        let controller = MigrationController::with_processors(
-            kv_store.clone(),
-            vec![processor.clone()],
-        );
+        let controller =
+            MigrationController::with_processors(kv_store, vec![processor.clone()]);
 
         // Run migrations - should treat as normal InProgress and retry
         let result = controller.run_migrations();
@@ -1176,7 +1170,7 @@ mod tests {
         // NotStarted doesn't need setup - it's the default
 
         let controller = MigrationController::with_processors(
-            kv_store.clone(),
+            kv_store,
             vec![
                 processor1.clone(),
                 processor2.clone(),

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -351,7 +351,6 @@ mod tests {
 
     use super::*;
     use crate::primitives::key_value_store::InMemoryDeviceKeyValueStore;
-    use async_trait::async_trait;
     use serial_test::serial;
     use std::sync::atomic::{AtomicU32, Ordering};
     use tokio::time::{sleep, Duration};
@@ -384,17 +383,16 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl MigrationProcessor for TestProcessor {
         fn migration_id(&self) -> String {
             self.id.clone()
         }
 
-        async fn is_applicable(&self) -> Result<bool, MigrationError> {
+        fn is_applicable(&self) -> Result<bool, MigrationError> {
             Ok(true)
         }
 
-        async fn execute(&self) -> Result<ProcessorResult, MigrationError> {
+        fn execute(&self) -> Result<ProcessorResult, MigrationError> {
             self.execution_count.fetch_add(1, Ordering::SeqCst);
             if self.delay_ms > 0 {
                 sleep(Duration::from_millis(self.delay_ms)).await;

--- a/bedrock/src/migration/mod.rs
+++ b/bedrock/src/migration/mod.rs
@@ -58,15 +58,24 @@
 //! first, not just migration records. Example:
 //!
 //! ```rust,ignore
-//! async fn is_applicable(&self, record: Option<&MigrationRecord>) -> OxideResult<bool> {
+//! fn is_applicable(&self) -> Result<bool, MigrationError> {
 //!     // 1. Check if migration outcome already exists (e.g., v4 credential restored from backup)
-//!     if self.credential_store.has_v4_credential().await? {
+//!     if self.credential_store.has_v4_credential()? {
 //!         return Ok(false);  // Skip - already have what this migration creates
 //!     }
 //!
 //!     Ok(true)  // Run migration
 //! }
 //! ```
+//!
+//! # Synchronous Processor Interface
+//!
+//! `is_applicable()` and `execute()` are intentionally **synchronous** to work around a
+//! known UniFFI bug with async foreign callbacks on Android/Kotlin
+//! ([uniffi-rs#2624](https://github.com/mozilla/uniffi-rs/issues/2624)).
+//!
+//! Foreign (Kotlin/Swift) implementations that need async operations should block
+//! internally (e.g., `runBlocking` in Kotlin, semaphore in Swift).
 
 mod controller;
 mod error;

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -41,8 +41,8 @@ pub enum ProcessorResult {
 ///
 /// **For foreign (Kotlin/Swift) implementors:** If your migration logic requires async
 /// operations (network calls, database access, etc.), use a blocking wrapper internally.
-/// 
-/// **Caller requirement:** `run_migrations()` must be called from a background context. 
+///
+/// **Caller requirement:** `run_migrations()` must be called from a background context.
 /// These sync callbacks will block the calling thread for the duration of each migration.
 /// Calling from the main/UI thread will cause UI freezes.
 #[uniffi::export(with_foreign)]
@@ -67,6 +67,9 @@ pub trait MigrationProcessor: Send + Sync {
     /// - `Ok(true)` if the migration should run
     /// - `Ok(false)` if the migration should be skipped
     /// - `Err(_)` if unable to determine (migration will be skipped with error logged)
+    ///
+    /// # Errors
+    /// Returns `MigrationError` if the applicability check fails (e.g., unable to read state).
     fn is_applicable(&self) -> Result<bool, MigrationError>;
 
     /// Execute the migration
@@ -78,5 +81,8 @@ pub trait MigrationProcessor: Send + Sync {
     /// This method is sync to work around a UniFFI async callback bug on Android.
     /// Foreign implementations needing async work should block internally
     /// (e.g., `runBlocking` in Kotlin).
+    ///
+    /// # Errors
+    /// Returns `MigrationError` if the migration encounters an unexpected failure.
     fn execute(&self) -> Result<ProcessorResult, MigrationError>;
 }

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -1,5 +1,4 @@
 use crate::migration::MigrationError;
-use async_trait::async_trait;
 
 /// Result of executing a migration processor
 #[derive(uniffi::Enum)]
@@ -32,9 +31,21 @@ pub enum ProcessorResult {
     },
 }
 
-/// Trait that all migration processors must implement
+/// Trait that all migration processors must implement.
+///
+/// # Synchronous Interface
+///
+/// These methods are intentionally **synchronous** to avoid a known UniFFI bug with
+/// async foreign callbacks on Android/Kotlin
+/// ([uniffi-rs#2624](https://github.com/mozilla/uniffi-rs/issues/2624)).
+///
+/// **For foreign (Kotlin/Swift) implementors:** If your migration logic requires async
+/// operations (network calls, database access, etc.), use a blocking wrapper internally.
+/// 
+/// **Caller requirement:** `run_migrations()` must be called from a background context. 
+/// These sync callbacks will block the calling thread for the duration of each migration.
+/// Calling from the main/UI thread will cause UI freezes.
 #[uniffi::export(with_foreign)]
-#[async_trait]
 pub trait MigrationProcessor: Send + Sync {
     /// Unique identifier for this migration (e.g., "worldid.account.bootstrap.v1")
     /// The version should be included in the ID itself (e.g., ".v1", ".v2")
@@ -46,14 +57,26 @@ pub trait MigrationProcessor: Send + Sync {
     /// to determine if the migration needs to run. This ensures the system is
     /// truly idempotent and handles edge cases gracefully.
     ///
+    /// # Synchronous
+    ///
+    /// This method is sync to work around a UniFFI async callback bug on Android.
+    /// Foreign implementations needing async work should block internally
+    /// (e.g., `runBlocking` in Kotlin).
     ///
     /// # Returns
     /// - `Ok(true)` if the migration should run
     /// - `Ok(false)` if the migration should be skipped
     /// - `Err(_)` if unable to determine (migration will be skipped with error logged)
-    async fn is_applicable(&self) -> Result<bool, MigrationError>;
+    fn is_applicable(&self) -> Result<bool, MigrationError>;
 
     /// Execute the migration
-    /// Called by the controller when the migration is ready to run
-    async fn execute(&self) -> Result<ProcessorResult, MigrationError>;
+    ///
+    /// Called by the controller when the migration is ready to run.
+    ///
+    /// # Synchronous
+    ///
+    /// This method is sync to work around a UniFFI async callback bug on Android.
+    /// Foreign implementations needing async work should block internally
+    /// (e.g., `runBlocking` in Kotlin).
+    fn execute(&self) -> Result<ProcessorResult, MigrationError>;
 }


### PR DESCRIPTION
## Use sync interfaces for controller to avoid UniFFI Android bug
There is a bug in UniFFI where Kotlin bindings will sometimes throw an error when calling an async Rust function: https://github.com/mozilla/uniffi-rs/issues/2624

This PR updates the migration processor interfaces to use `sync` rather `async` as a work around. It has been documented that the calling mobile clients will need to take care of the call being blocking.