### PR TITLE
fix: Change panic strategy from unwind to abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ uniffi = { version = "0.31.0", features = ["build", "tokio"] }
 debug = false
 lto = true       # Enable Link Time Optimization.
 opt-level = 'z'  # Optimize for size.
-panic = "unwind"
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ uniffi = { version = "0.31.0", features = ["build", "tokio"] }
 
 [profile.release]
 debug = false
-lto = true       # Enable Link Time Optimization.
-opt-level = 'z'  # Optimize for size.
+lto = true      # Enable Link Time Optimization.
+opt-level = 'z' # Optimize for size.
 panic = "abort"


### PR DESCRIPTION
Unwinding stack frames across language boundaries is a source of undefined behavior when inter-oping between Swift and Rust (and more broadly). Rust has a different personality routine than Swift, and neither language's personality routine considers the other. 

To address this, we should change the panic behavior in Bedrock to abort the process, rather than unwind a call stack into Swift (or Kotlin) in the event of `panic!` throwing an error.

I suspect this change will also enable us to use the thread sanitizer in LLDB, which we currently can't use as we have too many personality routines in the compiled Mach-O executable due to the presence of the Swift, C++, Objective-C, _and_ Rust personality routines. 

If you're interested in more detailed information, here's a [breakdown of a custom personality routine](https://nicolasbrailo.github.io/blog/2013/0319_Cexceptionsunderthehood7anicepersonality.html) for C++.