### PR TITLE
feat: allow multiple authorized host options for SIWE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1",
  "serde",
  "serde_json",
@@ -366,7 +366,7 @@ dependencies = [
  "alloy-signer-local",
  "k256",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -393,7 +393,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ruint",
  "rustc-hash",
  "serde",
@@ -628,7 +628,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
 ]
 
@@ -976,7 +976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -986,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -996,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1557,7 +1557,7 @@ dependencies = [
  "once_cell",
  "p256 0.13.2",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "ruint",
  "secrecy",
@@ -2591,7 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -4123,7 +4123,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -4231,7 +4231,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4280,9 +4280,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4292,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4518,8 +4518,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -4631,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4782,7 +4782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -391,17 +391,11 @@ impl SiweMessage {
     pub fn from_str_with_account(
         s: &str,
         smart_account: &SafeSmartAccount,
-        authorized_url: &str,
+        authorized_urls: &Vec<String>,
         querying_url: &str,
     ) -> Result<Self, SiweError> {
         let s = s.replacen("{address}", &Address::ZERO.to_checksum(None), 1);
 
-        let (expected_authority, _) = parse_authority(authorized_url).map_err(|e| {
-            PrimitiveError::InvalidInput {
-                attribute: "authorized_url".to_string(),
-                error_message: e.to_string(),
-            }
-        })?;
         let (current_authority, _) = parse_authority(querying_url).map_err(|e| {
             PrimitiveError::InvalidInput {
                 attribute: "querying_url".to_string(),
@@ -409,9 +403,23 @@ impl SiweMessage {
             }
         })?;
 
-        if expected_authority != current_authority {
-            return Err(SiweError::UnauthorizedHost);
-        }
+        let expected_authority: Authority =
+            {
+                let mut found = None;
+                for authorized_url in authorized_urls {
+                    let (expected_authority, _) = parse_authority(authorized_url)
+                        .map_err(|e| PrimitiveError::InvalidInput {
+                            attribute: "authorized_url".to_string(),
+                            error_message: e.to_string(),
+                        })?;
+
+                    if expected_authority == current_authority {
+                        found = Some(expected_authority);
+                        break;
+                    }
+                }
+                found.ok_or(SiweError::UnauthorizedHost)?
+            };
 
         let mut msg = Self::from_str(&s)?;
         msg.address = smart_account.wallet_address;

--- a/bedrock/src/siwe/test.rs
+++ b/bedrock/src/siwe/test.rs
@@ -334,7 +334,7 @@ fn address_placeholder_replaced_in_address_line() {
     let msg = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://example.com",
+        &vec!["https://example.com".to_string()],
         "https://example.com",
     )
     .unwrap();
@@ -367,7 +367,7 @@ fn address_placeholder_only_first_occurrence() {
     let msg = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://example.com",
+        &vec!["https://example.com".to_string()],
         "https://example.com",
     )
     .unwrap();
@@ -392,7 +392,7 @@ fn no_placeholder_still_parses() {
     let msg = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://example.com",
+        &vec!["https://example.com".to_string()],
         "https://example.com",
     )
     .unwrap();
@@ -681,7 +681,29 @@ fn authorized_host_matches_domain_and_uri() {
     let msg = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com/registered",
+        &vec!["https://app.example.com/registered".to_string()],
+        "https://app.example.com/current",
+    )
+    .unwrap();
+    assert_eq!(msg.domain, "app.example.com");
+}
+
+#[test]
+fn authorized_host_matches_from_list_of_authorized_urls() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "app.example.com",
+        "https://app.example.com/callback",
+        &now_rfc3339(),
+    );
+    let msg = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec![
+            "https://anotherdomain.com".to_string(),
+            "https://example.com".to_string(),
+            "https://app.example.com/registered".to_string(),
+        ],
         "https://app.example.com/current",
     )
     .unwrap();
@@ -696,7 +718,7 @@ fn rejects_mismatched_authorized_and_querying_hosts() {
     let err = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com",
+        &vec!["https://example.com".to_string()],
         "https://evil.com",
     )
     .unwrap_err();
@@ -710,7 +732,7 @@ fn rejects_message_domain_not_matching_authorized_host() {
     let err = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com",
+        &vec!["https://app.example.com".to_string()],
         "https://app.example.com",
     )
     .unwrap_err();
@@ -725,7 +747,7 @@ fn rejects_message_uri_not_matching_authorized_host() {
     let err = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com",
+        &vec!["https://app.example.com".to_string()],
         "https://app.example.com",
     )
     .unwrap_err();
@@ -743,7 +765,7 @@ fn domain_with_port_matches_authorized_authority() {
     let msg = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com:8080",
+        &vec!["https://app.example.com:8080".to_string()],
         "https://app.example.com:8080",
     )
     .unwrap();
@@ -761,7 +783,7 @@ fn rejects_different_port_on_same_host() {
     let err = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com:8080",
+        &vec!["https://app.example.com:8080".to_string()],
         "https://app.example.com:8080",
     )
     .unwrap_err();
@@ -779,7 +801,7 @@ fn rejects_querying_url_with_different_port() {
     let err = SiweMessage::from_str_with_account(
         &raw_msg,
         &account,
-        "https://app.example.com:8080",
+        &vec!["https://app.example.com:8080".to_string()],
         "https://app.example.com:9090",
     )
     .unwrap_err();


### PR DESCRIPTION
SIWE apps may have multiple authorized domains. This allows handling the different options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIWE host-authorization logic; incorrect matching could allow or block authentication for unintended domains. Scope is small but security-sensitive, so test coverage and edge cases (ports/schemes) matter.
> 
> **Overview**
> SIWE message parsing now accepts **multiple authorized URL options**: `SiweMessage::from_str_with_account` takes `authorized_urls: Vec<String>` and selects an `expected_authority` by matching the `querying_url` host/port against any provided authorized URL, rejecting if none match.
> 
> Tests are updated to pass URL lists and add coverage for matching from a mixed list of authorized domains, and `Cargo.lock` is refreshed (notably `rand` and `rustls-webpki` version bumps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1aa14f1356607454d8932caf2efc250902671e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->