### PR TITLE
refactor(smart_account): idiomatic Rust cleanup on Is4337Encodable

### DIFF
--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -149,6 +149,12 @@ impl NonceKeyV1 {
         out
     }
 
+    /// Encodes the nonceKey with a sequence of 0, the standard for Bedrock-crafted transactions.
+    #[must_use]
+    pub fn encode(&self) -> U256 {
+        self.encode_with_sequence(0)
+    }
+
     /// Encodes the 24-byte nonceKey together with a provided 8-byte sequence into a U256 integer
     /// for use with the 4337 `EntryPoint` contract.
     #[must_use]
@@ -196,7 +202,7 @@ mod tests {
             [0u8; 10],
             [0u8; 7],
         );
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode_with_sequence(0); // explicit 0 to test encode_with_sequence directly
         let lower_64 = nonce & U256::from(u64::MAX);
         assert!(lower_64.is_zero(), "sequence must be zero"); // checks the lower 64 bits of the nonce (i.e. the sequence) are zero
     }

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -77,28 +77,24 @@ pub trait Is4337Encodable {
     /// constructing a preflight `UserOperation`.
     type MetadataArg;
 
-    /// Converts the object into a `callData` for the `executeUserOp` method. This is the inner-most `calldata`.
-    ///
-    /// # Errors
-    /// - Will throw a parsing error if any of the provided attributes are invalid.
-    fn as_execute_user_op_call_data(&self) -> Bytes;
+    /// Builds the `callData` for the `executeUserOp` method. This is the inner-most calldata.
+    fn build_execute_user_op_call_data(&self) -> Bytes;
 
-    /// Converts the object into a preflight `UserOperation` for use with the `Safe4337Module`.
+    /// Builds a preflight `UserOperation` for use with the `Safe4337Module`.
     ///
-    /// A preflight operation is defined as having empty gas & paymaster data and a dummy signature.
-    ///
-    /// The preflight operation is sent to the RPC to request sponsorship.
+    /// A preflight operation has zeroed gas fields and a dummy signature.
+    /// It is sent to the sponsor endpoint to request gas estimation and paymaster data.
     ///
     /// # Errors
-    /// - Will throw a parsing error if any of the provided attributes are invalid.
-    fn as_preflight_user_operation(
+    /// - Returns an error if any of the provided attributes are invalid.
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError>;
 
     /// Signs and executes a 4337 `UserOperation` by:
-    /// 1. Creating a preflight `UserOperation`
+    /// 1. Building a preflight `UserOperation`
     /// 2. Requesting sponsorship via `wa_sponsorUserOperation`
     /// 3. Merging paymaster data into the `UserOperation`
     /// 4. Signing the `UserOperation`
@@ -126,7 +122,7 @@ pub trait Is4337Encodable {
 
         // 1. Create preflight UserOperation using default metadata for this implementation
         let mut user_operation =
-            self.as_preflight_user_operation(safe_account.wallet_address, metadata)?;
+            self.build_preflight_user_operation(safe_account.wallet_address, metadata)?;
 
         // 2. Request sponsorship
         let sponsor_response = rpc_client

--- a/bedrock/src/transactions/contracts/erc20.rs
+++ b/bedrock/src/transactions/contracts/erc20.rs
@@ -158,7 +158,7 @@ pub struct MetadataArg {
 impl Is4337Encodable for Erc20 {
     type MetadataArg = MetadataArg;
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             // The token address
             to: self.token_address,
@@ -170,12 +170,12 @@ impl Is4337Encodable for Erc20 {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let mut metadata_bytes: [u8; 10] = [0u8; 10];
         if let Some(metadata) = metadata {
@@ -216,7 +216,7 @@ mod tests {
             U256::from(1),
         );
 
-        let execute_user_op_call_data = erc20.as_execute_user_op_call_data();
+        let execute_user_op_call_data = erc20.build_execute_user_op_call_data();
 
         // generated with `chisel`
         let expected_call_data = bytes!("0x7bb374280000000000000000000000002cfc85d8e48f8eab294be644d9e25c30308630030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044a9059cbb0000000000000000000000001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000");
@@ -234,7 +234,7 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = erc20.as_preflight_user_operation(wallet, None).unwrap();
+        let user_op = erc20.build_preflight_user_operation(wallet, None).unwrap();
 
         // Check nonce layout
         let be: [u8; 32] = user_op.nonce.to_be_bytes();
@@ -265,7 +265,7 @@ mod tests {
         };
 
         let user_op = erc20
-            .as_preflight_user_operation(wallet, Some(metadata))
+            .build_preflight_user_operation(wallet, Some(metadata))
             .unwrap();
 
         // Check nonce layout

--- a/bedrock/src/transactions/contracts/erc20.rs
+++ b/bedrock/src/transactions/contracts/erc20.rs
@@ -189,7 +189,7 @@ impl Is4337Encodable for Erc20 {
             InstructionFlag::Default,
             metadata_bytes,
         );
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/contracts/erc20.rs
+++ b/bedrock/src/transactions/contracts/erc20.rs
@@ -32,7 +32,7 @@ sol! {
 /// Enables operations with the ERC-20 token contract.
 pub struct Erc20 {
     /// The inner call data for the ERC-20 `transferCall` function.
-    call_data: Vec<u8>,
+    call_data: Bytes,
     /// The address of the ERC-20 token contract.
     token_address: Address,
 }
@@ -46,7 +46,7 @@ impl Erc20 {
     /// * `value` - The amount of tokens to transfer.
     #[must_use]
     pub fn new(token_address: Address, to: Address, value: U256) -> Self {
-        let call_data = IErc20::transferCall { to, value }.abi_encode();
+        let call_data = IErc20::transferCall { to, value }.abi_encode().into();
 
         Self {
             call_data,
@@ -163,7 +163,7 @@ impl Is4337Encodable for Erc20 {
             // The token address
             to: self.token_address,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: SafeOperation::Call as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/erc4626.rs
+++ b/bedrock/src/transactions/contracts/erc4626.rs
@@ -387,7 +387,7 @@ impl Erc4626Vault {
 impl Is4337Encodable for Erc4626Vault {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
@@ -398,12 +398,12 @@ impl Is4337Encodable for Erc4626Vault {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, self.metadata);
         let nonce = key.encode_with_sequence(0);

--- a/bedrock/src/transactions/contracts/erc4626.rs
+++ b/bedrock/src/transactions/contracts/erc4626.rs
@@ -44,7 +44,7 @@ sol! {
 #[derive(Debug)]
 pub struct Erc4626Vault {
     /// The encoded call data for the operation.
-    pub call_data: Vec<u8>,
+    pub call_data: Bytes,
     /// The action type.
     action: TransactionTypeId,
     /// The target address for the operation.
@@ -204,7 +204,7 @@ impl Erc4626Vault {
         let bundle = MultiSend::build_bundle(&entries);
 
         Ok(Self {
-            call_data: bundle.data,
+            call_data: bundle.data.into(),
             action: TransactionTypeId::ERC4626Deposit,
             to: crate::transactions::contracts::multisend::MULTISEND_ADDRESS,
             operation: SafeOperation::DelegateCall,
@@ -291,7 +291,7 @@ impl Erc4626Vault {
             .abi_encode();
 
             return Ok(Self {
-                call_data: redeem_data,
+                call_data: redeem_data.into(),
                 action: TransactionTypeId::ERC4626Redeem,
                 to: vault_address,
                 operation: SafeOperation::Call,
@@ -308,7 +308,7 @@ impl Erc4626Vault {
         .abi_encode();
 
         Ok(Self {
-            call_data: withdraw_data,
+            call_data: withdraw_data.into(),
             action: TransactionTypeId::ERC4626Withdraw,
             to: vault_address,
             operation: SafeOperation::Call,
@@ -375,7 +375,7 @@ impl Erc4626Vault {
         .abi_encode();
 
         Ok(Self {
-            call_data: redeem_data,
+            call_data: redeem_data.into(),
             action: TransactionTypeId::ERC4626Redeem,
             to: vault_address,
             operation: SafeOperation::Call,
@@ -391,7 +391,7 @@ impl Is4337Encodable for Erc4626Vault {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: self.operation as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/erc4626.rs
+++ b/bedrock/src/transactions/contracts/erc4626.rs
@@ -406,7 +406,7 @@ impl Is4337Encodable for Erc4626Vault {
         let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, self.metadata);
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/contracts/permit2.rs
+++ b/bedrock/src/transactions/contracts/permit2.rs
@@ -131,7 +131,9 @@ impl Permit2Approve {
         }
         .abi_encode();
 
-        Self { call_data: call_data.into() }
+        Self {
+            call_data: call_data.into(),
+        }
     }
 }
 
@@ -343,7 +345,9 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = approve.build_preflight_user_operation(wallet, None).unwrap();
+        let user_op = approve
+            .build_preflight_user_operation(wallet, None)
+            .unwrap();
 
         let be: [u8; 32] = user_op.nonce.to_be_bytes();
 

--- a/bedrock/src/transactions/contracts/permit2.rs
+++ b/bedrock/src/transactions/contracts/permit2.rs
@@ -105,7 +105,7 @@ sol! {
 /// Reference: <https://docs.uniswap.org/contracts/permit2/reference/allowance-transfer#approve>
 pub struct Permit2Approve {
     /// The ABI-encoded calldata for `IAllowanceTransfer.approve(token, spender, amount, expiration)`.
-    call_data: Vec<u8>,
+    call_data: Bytes,
 }
 
 impl Permit2Approve {
@@ -131,7 +131,7 @@ impl Permit2Approve {
         }
         .abi_encode();
 
-        Self { call_data }
+        Self { call_data: call_data.into() }
     }
 }
 
@@ -142,7 +142,7 @@ impl Is4337Encodable for Permit2Approve {
         ISafe4337Module::executeUserOpCall {
             to: PERMIT2_ADDRESS,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: SafeOperation::Call as u8,
         }
         .abi_encode()
@@ -180,7 +180,7 @@ impl Is4337Encodable for Permit2Approve {
 /// Builds a single 4337 `UserOperation` that grants a spender contract max allowance
 /// on each of the given token contracts.
 pub struct BatchPermit2Approval {
-    call_data: Vec<u8>,
+    call_data: Bytes,
     to: Address,
     operation: SafeOperation,
 }
@@ -208,7 +208,7 @@ impl BatchPermit2Approval {
         let bundle = MultiSend::build_bundle(&entries);
 
         Self {
-            call_data: bundle.data,
+            call_data: bundle.data.into(),
             to: bundle.to,
             operation: bundle.operation,
         }
@@ -222,7 +222,7 @@ impl Is4337Encodable for BatchPermit2Approval {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: self.operation as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/permit2.rs
+++ b/bedrock/src/transactions/contracts/permit2.rs
@@ -138,7 +138,7 @@ impl Permit2Approve {
 impl Is4337Encodable for Permit2Approve {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: PERMIT2_ADDRESS,
             value: U256::ZERO,
@@ -149,12 +149,12 @@ impl Is4337Encodable for Permit2Approve {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(
             TransactionTypeId::Permit2Approve,
@@ -218,7 +218,7 @@ impl BatchPermit2Approval {
 impl Is4337Encodable for BatchPermit2Approval {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
@@ -229,12 +229,12 @@ impl Is4337Encodable for BatchPermit2Approval {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(
             TransactionTypeId::Permit2Approve,
@@ -299,7 +299,7 @@ mod tests {
         let expiration = U48::from(1_704_067_200u64);
 
         let approve = Permit2Approve::new(token, spender, amount, expiration);
-        let execute_user_op_call_data = approve.as_execute_user_op_call_data();
+        let execute_user_op_call_data = approve.build_execute_user_op_call_data();
 
         let call_data_bytes: &[u8] = &execute_user_op_call_data;
 
@@ -343,7 +343,7 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = approve.as_preflight_user_operation(wallet, None).unwrap();
+        let user_op = approve.build_preflight_user_operation(wallet, None).unwrap();
 
         let be: [u8; 32] = user_op.nonce.to_be_bytes();
 
@@ -362,7 +362,7 @@ mod tests {
         let tokens = vec![usdc, weth];
         let batch = BatchPermit2Approval::new(&tokens);
 
-        let call_data = batch.as_execute_user_op_call_data();
+        let call_data = batch.build_execute_user_op_call_data();
         let call_data_bytes: &[u8] = &call_data;
 
         let decoded =

--- a/bedrock/src/transactions/contracts/permit2.rs
+++ b/bedrock/src/transactions/contracts/permit2.rs
@@ -161,7 +161,7 @@ impl Is4337Encodable for Permit2Approve {
             InstructionFlag::Default,
             [0u8; 10],
         );
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,
@@ -241,7 +241,7 @@ impl Is4337Encodable for BatchPermit2Approval {
             InstructionFlag::Default,
             [0u8; 10],
         );
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/contracts/usd_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/usd_legacy_vault.rs
@@ -71,7 +71,7 @@ sol! {
 #[derive(Debug)]
 pub struct UsdLegacyVault {
     /// The encoded call data for the operation.
-    pub call_data: Vec<u8>,
+    pub call_data: Bytes,
     /// The action type.
     action: TransactionTypeId,
     /// The target address for the operation.
@@ -316,7 +316,7 @@ impl UsdLegacyVault {
         let bundle = MultiSend::build_bundle(&entries);
 
         Ok(Self {
-            call_data: bundle.data,
+            call_data: bundle.data.into(),
             action: TransactionTypeId::USDVaultMigration,
             to: crate::transactions::contracts::multisend::MULTISEND_ADDRESS,
             operation: SafeOperation::DelegateCall,
@@ -331,7 +331,7 @@ impl Is4337Encodable for UsdLegacyVault {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: self.operation as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/usd_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/usd_legacy_vault.rs
@@ -327,7 +327,7 @@ impl UsdLegacyVault {
 impl Is4337Encodable for UsdLegacyVault {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
@@ -338,12 +338,12 @@ impl Is4337Encodable for UsdLegacyVault {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, [0u8; 10]);
         let nonce = key.encode_with_sequence(0);

--- a/bedrock/src/transactions/contracts/usd_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/usd_legacy_vault.rs
@@ -346,7 +346,7 @@ impl Is4337Encodable for UsdLegacyVault {
         let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, [0u8; 10]);
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/contracts/wld_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_legacy_vault.rs
@@ -44,7 +44,7 @@ sol! {
 #[derive(Debug)]
 pub struct WldLegacyVault {
     /// The encoded call data for the operation.
-    pub call_data: Vec<u8>,
+    pub call_data: Bytes,
     /// The action type.
     action: TransactionTypeId,
     /// The target address for the operation.
@@ -143,7 +143,7 @@ impl WldLegacyVault {
         let bundle = MultiSend::build_bundle(&entries);
 
         Ok(Self {
-            call_data: bundle.data,
+            call_data: bundle.data.into(),
             action: TransactionTypeId::WLDVaultMigration,
             to: crate::transactions::contracts::multisend::MULTISEND_ADDRESS,
             operation: SafeOperation::DelegateCall,
@@ -158,7 +158,7 @@ impl Is4337Encodable for WldLegacyVault {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: self.operation as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/wld_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_legacy_vault.rs
@@ -173,7 +173,7 @@ impl Is4337Encodable for WldLegacyVault {
         let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, [0u8; 10]);
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/contracts/wld_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_legacy_vault.rs
@@ -154,7 +154,7 @@ impl WldLegacyVault {
 impl Is4337Encodable for WldLegacyVault {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: U256::ZERO,
@@ -165,12 +165,12 @@ impl Is4337Encodable for WldLegacyVault {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let key = NonceKeyV1::new(self.action, InstructionFlag::Default, [0u8; 10]);
         let nonce = key.encode_with_sequence(0);

--- a/bedrock/src/transactions/contracts/world_gift_manager.rs
+++ b/bedrock/src/transactions/contracts/world_gift_manager.rs
@@ -50,7 +50,7 @@ pub struct WorldGiftManager {
     gift_id: [u8; 14],
     tx_type_id: TransactionTypeId,
     /// The inner call data for the function.
-    call_data: Vec<u8>,
+    call_data: Bytes,
     operation: SafeOperation,
     to: Address,
     value: U256,
@@ -97,7 +97,7 @@ impl WorldGiftManager {
         Self {
             gift_id,
             tx_type_id: TransactionTypeId::WorldGiftManagerGift,
-            call_data: bundle.data,
+            call_data: bundle.data.into(),
             operation: bundle.operation,
             to: bundle.to,
             value: bundle.value,
@@ -107,7 +107,7 @@ impl WorldGiftManager {
     /// Creates a redeem operation.
     #[must_use]
     pub fn redeem(gift_id: U256) -> Self {
-        let call_data = IWorldGiftManager::redeemCall { giftId: gift_id }.abi_encode();
+        let call_data = IWorldGiftManager::redeemCall { giftId: gift_id }.abi_encode().into();
         Self {
             gift_id: u256_to_gift_id(gift_id),
             tx_type_id: TransactionTypeId::WorldGiftManagerRedeem,
@@ -121,7 +121,7 @@ impl WorldGiftManager {
     /// Creates a cancel operation.
     #[must_use]
     pub fn cancel(gift_id: U256) -> Self {
-        let call_data = IWorldGiftManager::cancelCall { giftId: gift_id }.abi_encode();
+        let call_data = IWorldGiftManager::cancelCall { giftId: gift_id }.abi_encode().into();
         Self {
             gift_id: u256_to_gift_id(gift_id),
             tx_type_id: TransactionTypeId::WorldGiftManagerCancel,
@@ -140,7 +140,7 @@ impl Is4337Encodable for WorldGiftManager {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: self.value,
-            data: self.call_data.clone().into(),
+            data: self.call_data.clone(),
             operation: self.operation as u8,
         }
         .abi_encode()

--- a/bedrock/src/transactions/contracts/world_gift_manager.rs
+++ b/bedrock/src/transactions/contracts/world_gift_manager.rs
@@ -107,7 +107,9 @@ impl WorldGiftManager {
     /// Creates a redeem operation.
     #[must_use]
     pub fn redeem(gift_id: U256) -> Self {
-        let call_data = IWorldGiftManager::redeemCall { giftId: gift_id }.abi_encode().into();
+        let call_data = IWorldGiftManager::redeemCall { giftId: gift_id }
+            .abi_encode()
+            .into();
         Self {
             gift_id: u256_to_gift_id(gift_id),
             tx_type_id: TransactionTypeId::WorldGiftManagerRedeem,
@@ -121,7 +123,9 @@ impl WorldGiftManager {
     /// Creates a cancel operation.
     #[must_use]
     pub fn cancel(gift_id: U256) -> Self {
-        let call_data = IWorldGiftManager::cancelCall { giftId: gift_id }.abi_encode().into();
+        let call_data = IWorldGiftManager::cancelCall { giftId: gift_id }
+            .abi_encode()
+            .into();
         Self {
             gift_id: u256_to_gift_id(gift_id),
             tx_type_id: TransactionTypeId::WorldGiftManagerCancel,

--- a/bedrock/src/transactions/contracts/world_gift_manager.rs
+++ b/bedrock/src/transactions/contracts/world_gift_manager.rs
@@ -136,7 +136,7 @@ impl WorldGiftManager {
 impl Is4337Encodable for WorldGiftManager {
     type MetadataArg = ();
 
-    fn as_execute_user_op_call_data(&self) -> Bytes {
+    fn build_execute_user_op_call_data(&self) -> Bytes {
         ISafe4337Module::executeUserOpCall {
             to: self.to,
             value: self.value,
@@ -147,12 +147,12 @@ impl Is4337Encodable for WorldGiftManager {
         .into()
     }
 
-    fn as_preflight_user_operation(
+    fn build_preflight_user_operation(
         &self,
         wallet_address: Address,
         _metadata: Option<Self::MetadataArg>,
     ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.as_execute_user_op_call_data();
+        let call_data = self.build_execute_user_op_call_data();
 
         let mut metadata_bytes = [0u8; 10];
         metadata_bytes.copy_from_slice(&self.gift_id[0..10]);
@@ -215,7 +215,7 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = gift.as_preflight_user_operation(wallet, None).unwrap();
+        let user_op = gift.build_preflight_user_operation(wallet, None).unwrap();
 
         // Check nonce layout
         let be: [u8; 32] = user_op.nonce.to_be_bytes();
@@ -241,7 +241,7 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = gift.as_preflight_user_operation(wallet, None).unwrap();
+        let user_op = gift.build_preflight_user_operation(wallet, None).unwrap();
 
         // Check nonce layout
         let be: [u8; 32] = user_op.nonce.to_be_bytes();
@@ -263,7 +263,7 @@ mod tests {
 
         let wallet =
             Address::from_str("0x4564420674EA68fcc61b463C0494807C759d47e6").unwrap();
-        let user_op = gift.as_preflight_user_operation(wallet, None).unwrap();
+        let user_op = gift.build_preflight_user_operation(wallet, None).unwrap();
 
         // Check nonce layout
         let be: [u8; 32] = user_op.nonce.to_be_bytes();

--- a/bedrock/src/transactions/contracts/world_gift_manager.rs
+++ b/bedrock/src/transactions/contracts/world_gift_manager.rs
@@ -168,7 +168,7 @@ impl Is4337Encodable for WorldGiftManager {
             metadata_bytes,
             random_tail,
         );
-        let nonce = key.encode_with_sequence(0);
+        let nonce = key.encode();
 
         Ok(UserOperation::new_with_defaults(
             wallet_address,

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     transactions::{
         contracts::{
-            erc20::{Erc20, TransferAssociation},
+            erc20::{Erc20, MetadataArg, TransferAssociation},
             usd_legacy_vault::Permit2Data,
             world_gift_manager::WorldGiftManager,
         },
@@ -103,7 +103,7 @@ impl SafeSmartAccount {
 
         let transaction = Erc20::new(token_address, to_address, amount);
 
-        let metadata = crate::transactions::contracts::erc20::MetadataArg {
+        let metadata = MetadataArg {
             association: transfer_association,
         };
 


### PR DESCRIPTION
smart_account: idiomatic Rust cleanup on Is4337Encodable

Four improvements across the Is4337Encodable trait and its 
implementations:

- Rename trait methods to use the build_ prefix:
  as_execute_user_op_call_data → build_execute_user_op_call_data
  as_preflight_user_operation  → build_preflight_user_operation
  as_ conventionally signals a cheap, infallible borrow or cast; these
  methods allocate, construct values from parts, and can return errors.

- Add NonceKeyV1::encode() as a zero-argument convenience over
  encode_with_sequence(0). The sequence field is documented as unused
  and hardcoded to 0 in both constructors.

- Import MetadataArg alongside Erc20 and TransferAssociation in
  transactions/mod.rs rather than constructing it via a full crate path.

- Store call_data as Bytes instead of Vec<u8> in all implementations.
  The Vec<u8> -> Bytes conversion now happens once at construction;
  the clone in build_execute_user_op_call_data is cheap since Bytes
  is reference-counted.

No behaviour change; UniFFI-exported surfaces are unaffected.
