### PR TITLE
feat(rpc): add V2 RPC primitives, on-device prepare/sign doc

### DIFF
--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -214,7 +214,7 @@ pub struct SponsorUserOperationResponse {
 /// `paymaster_verification_gas_limit`, `paymaster_post_op_gas_limit`) are
 /// absent from the bundler-sponsored response shape and present on the
 /// self-sponsored (token) response — see
-/// `bedrock/src/transactions/contracts/prepare_sign_tx.md`. They are modelled as
+/// `bedrock/src/transactions/transaction.md`. They are modelled as
 /// `Option<T>` so both shapes deserialize.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -244,7 +244,7 @@ pub struct PmSponsorUserOperationResponse {
 /// V2 sponsorship is a two-mode protocol: an initial protocol-sponsored
 /// attempt with empty context, followed (on a structured decline) by a
 /// self-sponsored retry that names the ERC-20 token paying for gas. See
-/// `bedrock/src/transactions/contracts/prepare_sign_tx.md`.
+/// `bedrock/src/transactions/transaction.md`.
 #[derive(Debug, Clone)]
 pub enum SponsorshipContext {
     /// Empty context — request protocol sponsorship (the wallet provider

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -39,15 +39,21 @@ pub enum Id {
 /// Supported RPC methods in Bedrock
 #[derive(Debug, Clone, Serialize)]
 pub enum RpcMethod {
-    /// Request sponsorship for a `UserOperation`
+    /// Request sponsorship for a `UserOperation` (V1)
     #[serde(rename = "wa_sponsorUserOperation")]
     SponsorUserOperation,
+    /// Request sponsorship for a `UserOperation` (V2)
+    #[serde(rename = "pm_sponsorUserOperation")]
+    PmSponsorUserOperation,
     /// Queries the status of a `UserOperation`
     #[serde(rename = "wa_getUserOperationReceipt")]
     WaGetUserOperationReceipt,
-    /// Submit a signed `UserOperation`
+    /// Submit a signed `UserOperation` (V1)
     #[serde(rename = "eth_sendUserOperation")]
     SendUserOperation,
+    /// Submit a signed `UserOperation` (V2)
+    #[serde(rename = "eth_sendUserOperation")]
+    SendUserOperationV2,
     /// Make a read call to a smart contract
     #[serde(rename = "eth_call")]
     EthCall,
@@ -76,20 +82,6 @@ impl RpcProviderName {
             Self::Any => "any",
             Self::Alchemy => "alchemy",
             Self::Pimlico => "pimlico",
-        }
-    }
-}
-
-impl RpcMethod {
-    /// Get the string representation of the RPC method
-    #[must_use]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::SponsorUserOperation => "wa_sponsorUserOperation",
-            Self::WaGetUserOperationReceipt => "wa_getUserOperationReceipt",
-            Self::SendUserOperation => "eth_sendUserOperation",
-            Self::EthCall => "eth_call",
-            Self::SupportedEntryPoints => "eth_supportedEntryPoints",
         }
     }
 }
@@ -216,6 +208,64 @@ pub struct SponsorUserOperationResponse {
     pub provider_name: RpcProviderName,
 }
 
+/// Response from `pm_sponsorUserOperation` (V2)
+///
+/// Paymaster fields (`paymaster`, `paymaster_data`,
+/// `paymaster_verification_gas_limit`, `paymaster_post_op_gas_limit`) are
+/// absent from the bundler-sponsored response shape and present on the
+/// self-sponsored (token) response — see
+/// `bedrock/src/transactions/contracts/prepare_sign_tx.md`. They are modelled as
+/// `Option<T>` so both shapes deserialize.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmSponsorUserOperationResponse {
+    /// Call gas limit
+    pub call_gas_limit: U128,
+    /// Verification gas limit
+    pub verification_gas_limit: U128,
+    /// Pre-verification gas
+    pub pre_verification_gas: U256,
+    /// Max fee per gas
+    pub max_fee_per_gas: U128,
+    /// Max priority fee per gas
+    pub max_priority_fee_per_gas: U128,
+    /// Paymaster address (absent on the bundler-sponsored path)
+    pub paymaster: Option<Address>,
+    /// Paymaster verification gas limit (absent on the bundler-sponsored path)
+    pub paymaster_verification_gas_limit: Option<U128>,
+    /// Paymaster post-op gas limit (absent on the bundler-sponsored path)
+    pub paymaster_post_op_gas_limit: Option<U128>,
+    /// Paymaster data (absent on the bundler-sponsored path)
+    pub paymaster_data: Option<Bytes>,
+}
+
+/// Context object passed as the third parameter of `pm_sponsorUserOperation`.
+///
+/// V2 sponsorship is a two-mode protocol: an initial protocol-sponsored
+/// attempt with empty context, followed (on a structured decline) by a
+/// self-sponsored retry that names the ERC-20 token paying for gas. See
+/// `bedrock/src/transactions/contracts/prepare_sign_tx.md`.
+#[derive(Debug, Clone)]
+pub enum SponsorshipContext {
+    /// Empty context — request protocol sponsorship (the wallet provider
+    /// pays gas). Distinct from the ERC-4337 notion of bundler sponsorship,
+    /// which implies a user-appointed bundler choosing to sponsor.
+    Protocol,
+    /// Self-sponsored mode with the given ERC-20 token paying for gas.
+    SelfSponsoredToken(Address),
+}
+
+impl SponsorshipContext {
+    fn to_json_value(&self) -> serde_json::Value {
+        match self {
+            Self::Protocol => serde_json::json!({}),
+            Self::SelfSponsoredToken(token) => {
+                serde_json::json!({ "token": format!("{token:?}") })
+            }
+        }
+    }
+}
+
 /// Response from `wa_getUserOperationReceipt`
 #[derive(Debug, Deserialize, uniffi::Record, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -242,7 +292,7 @@ pub struct WaGetUserOperationReceiptResponse {
 
 /// RPC client for handling 4337 `UserOperation` requests
 ///
-/// This client communicates with the app-backend's RPC endpoint at `/v1/rpc/{network}`.
+/// This client communicates with the RPC endpoint at `/v1/rpc/{network}` and `/v2/rpc/{network}`.
 pub struct RpcClient {
     http_client: Arc<dyn AuthenticatedHttpClient>,
 }
@@ -259,7 +309,9 @@ impl RpcClient {
     /// Constructs the RPC endpoint URL for the specified network and method
     fn rpc_endpoint(network: Network, method: &RpcMethod) -> String {
         let version = match method {
-            RpcMethod::EthCall => "v2",
+            RpcMethod::EthCall
+            | RpcMethod::PmSponsorUserOperation
+            | RpcMethod::SendUserOperationV2 => "v2",
             _ => "v1",
         };
         format!("/{version}/rpc/{}", network.network_name())
@@ -367,6 +419,42 @@ impl RpcClient {
             .await
     }
 
+    /// Requests sponsorship for a `UserOperation` via `pm_sponsorUserOperation` (V2)
+    ///
+    /// Sends the three-element params vec `[userOperation, entryPoint, context]`
+    /// per the V2 contract. `context` is `SponsorshipContext::Protocol`
+    /// (serializes to `{}`) for the initial attempt and
+    /// `SponsorshipContext::SelfSponsoredToken` for the self-sponsored retry
+    /// after a decline.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The HTTP request fails
+    /// - The request serialization fails
+    /// - The response parsing fails
+    /// - The RPC returns an error response
+    pub async fn pm_sponsor_user_operation(
+        &self,
+        network: Network,
+        user_operation: &UserOperation,
+        entry_point: Address,
+        context: &SponsorshipContext,
+    ) -> Result<PmSponsorUserOperationResponse, RpcError> {
+        let params = vec![
+            serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
+            serde_json::Value::String(format!("{entry_point:?}")),
+            context.to_json_value(),
+        ];
+        self.rpc_call(
+            network,
+            RpcMethod::PmSponsorUserOperation,
+            params,
+            RpcProviderName::Any,
+        )
+        .await
+    }
+
     /// Submits a signed `UserOperation` via `eth_sendUserOperation`
     ///
     /// # Errors
@@ -391,6 +479,45 @@ impl RpcClient {
 
         let result: String = self
             .rpc_call(network, RpcMethod::SendUserOperation, params, provider)
+            .await?;
+
+        FixedBytes::from_hex(&result).map_err(|e| RpcError::InvalidResponse {
+            error_message: format!("Invalid userOpHash format: {e}"),
+        })
+    }
+
+    /// Submits a signed `UserOperation` via the V2 RPC endpoint (`/v2/rpc/{network}`).
+    ///
+    /// Identical wire format to [`send_user_operation`] but routed to the V2 path.
+    /// Use this from V2 execution flows (e.g. `sign_and_execute_v2`) so that
+    /// V1 callers remain fully on the legacy path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The HTTP request fails
+    /// - The request serialization fails
+    /// - The response parsing fails
+    /// - The RPC returns an error response
+    /// - The returned user operation hash is invalid
+    pub async fn send_user_operation_v2(
+        &self,
+        network: Network,
+        user_operation: &UserOperation,
+        entrypoint: Address,
+    ) -> Result<FixedBytes<32>, RpcError> {
+        let params = vec![
+            serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
+            serde_json::Value::String(format!("{entrypoint:?}")),
+        ];
+
+        let result: String = self
+            .rpc_call(
+                network,
+                RpcMethod::SendUserOperationV2,
+                params,
+                RpcProviderName::Any,
+            )
             .await?;
 
         FixedBytes::from_hex(&result).map_err(|e| RpcError::InvalidResponse {
@@ -705,5 +832,116 @@ mod tests {
         assert_eq!(serialized["paymasterData"], "0x");
         assert_eq!(serialized["paymasterVerificationGasLimit"], "0xa");
         assert_eq!(serialized["paymasterPostOpGasLimit"], "0x0");
+    }
+
+    #[test]
+    fn test_rpc_endpoint_v2_methods_route_to_v2() {
+        let network = Network::WorldChain;
+        for method in [
+            RpcMethod::PmSponsorUserOperation,
+            RpcMethod::SendUserOperationV2,
+            RpcMethod::EthCall,
+        ] {
+            let url = RpcClient::rpc_endpoint(network, &method);
+            assert!(
+                url.starts_with("/v2/"),
+                "{method:?} should route to /v2/, got {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rpc_endpoint_legacy_methods_stay_on_v1() {
+        let network = Network::WorldChain;
+        for method in [
+            RpcMethod::SponsorUserOperation,
+            RpcMethod::SendUserOperation,
+            RpcMethod::WaGetUserOperationReceipt,
+            RpcMethod::SupportedEntryPoints,
+        ] {
+            let url = RpcClient::rpc_endpoint(network, &method);
+            assert!(
+                url.starts_with("/v1/"),
+                "{method:?} should route to /v1/, got {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rpc_endpoint_includes_network_name() {
+        let url = RpcClient::rpc_endpoint(
+            Network::WorldChain,
+            &RpcMethod::SendUserOperationV2,
+        );
+        assert_eq!(url, "/v2/rpc/worldchain");
+
+        let url =
+            RpcClient::rpc_endpoint(Network::WorldChain, &RpcMethod::SendUserOperation);
+        assert_eq!(url, "/v1/rpc/worldchain");
+    }
+
+    #[test]
+    fn test_pm_sponsor_response_parsing() {
+        // Bundler-sponsored shape — paymaster fields are absent from the
+        // response body entirely (not present-with-zero). Modelled as
+        // Option<T>, so all four deserialize to None.
+        let no_paymaster = json!({
+            "callGasLimit": "0x0",
+            "verificationGasLimit": "0x0",
+            "preVerificationGas": "0x0",
+            "maxFeePerGas": "0x0",
+            "maxPriorityFeePerGas": "0x0",
+        });
+        let r: PmSponsorUserOperationResponse =
+            serde_json::from_value(no_paymaster).unwrap();
+        assert_eq!(r.call_gas_limit, U128::ZERO);
+        assert_eq!(r.verification_gas_limit, U128::ZERO);
+        assert_eq!(r.pre_verification_gas, U256::ZERO);
+        assert_eq!(r.max_fee_per_gas, U128::ZERO);
+        assert_eq!(r.max_priority_fee_per_gas, U128::ZERO);
+        assert!(r.paymaster.is_none());
+        assert!(r.paymaster_verification_gas_limit.is_none());
+        assert!(r.paymaster_post_op_gas_limit.is_none());
+        assert!(r.paymaster_data.is_none());
+
+        // Self-sponsored shape — all four paymaster fields present with real
+        // values from Pimlico's ERC-20 paymaster.
+        let with_paymaster = json!({
+            "callGasLimit": "0x212df",
+            "verificationGasLimit": "0x501ab",
+            "preVerificationGas": "0x350f7",
+            "maxFeePerGas": "0x7A5CF70D5",
+            "maxPriorityFeePerGas": "0x3B9ACA00",
+            "paymaster": "0x0000000000000039cd5e8aE05257CE51C473ddd1",
+            "paymasterVerificationGasLimit": "0x6dae",
+            "paymasterPostOpGasLimit": "0x706e",
+            "paymasterData": "0x01000066d1a1a4",
+        });
+        let r: PmSponsorUserOperationResponse =
+            serde_json::from_value(with_paymaster).unwrap();
+        assert_eq!(
+            r.paymaster,
+            Some(address!("0000000000000039cd5e8aE05257CE51C473ddd1"))
+        );
+        assert_eq!(
+            r.paymaster_verification_gas_limit,
+            Some(U128::from(0x6dae_u32))
+        );
+        assert_eq!(r.paymaster_post_op_gas_limit, Some(U128::from(0x706e_u32)));
+        assert!(r.paymaster_data.is_some());
+    }
+
+    #[test]
+    fn test_sponsorship_context_serialization() {
+        // Protocol-sponsored: empty object is sent as the third param.
+        assert_eq!(SponsorshipContext::Protocol.to_json_value(), json!({}));
+
+        // Self-sponsored: { "token": "0x..." } with a lowercase 0x-prefixed
+        // hex address, matching the entry_point formatting convention.
+        let token = address!("2cfc85d8e48f8eab294be644d9e25c3030863003");
+        assert_eq!(
+            SponsorshipContext::SelfSponsoredToken(token).to_json_value(),
+            json!({ "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003" })
+        );
     }
 }

--- a/bedrock/src/transactions/transaction.md
+++ b/bedrock/src/transactions/transaction.md
@@ -1,0 +1,220 @@
+# Prepare & Sign Transaction (V2 flow)
+
+This document describes the **V2** on-device flow: how Bedrock — the
+open-source, on-device SDK that powers the wallet — turns a user intent
+(e.g. "send 5 WLD to `0x…`") into a signed
+[ERC-4337 UserOperation](https://eips.ethereum.org/EIPS/eip-4337) that lands on
+chain. The earlier prepare/send flow is being phased out per transaction type;
+see [Versioning and compatibility](#versioning-and-compatibility) below.
+
+It is a living document. The wallet's sponsorship policy evolves over time;
+when it changes, this file changes with it. The on-device steps Bedrock performs
+do not depend on the server's policy — only on the wire contract described
+below.
+
+## Trust model
+
+The wallet is **self-custodial**. The user's signing key never leaves the
+device, and the user should sign only payloads they can independently verify.
+Bedrock is structured around that invariant:
+
+- **Bedrock constructs the calldata locally.** All encoding — ERC-20
+  calls, Safe `executeUserOp` wrapping, and any composition needed for a
+  given transaction — happens on device, using
+  [Alloy](https://github.com/alloy-rs/core) primitives that the user (or a
+  third-party auditor) can inspect by reading the Bedrock source.
+- **The user signs the UserOp hash** The hash is
+  derived from the fully-assembled UserOp (sender, nonce, callData, gas
+  fields, paymaster fields if any) per
+  [ERC-4337 §4.1](https://eips.ethereum.org/EIPS/eip-4337#useroperation).
+
+## High-level flow
+
+For every transaction:
+
+1. **Build callData.** Encode the contract call (ERC-20 `transfer`, ERC-4626
+   `deposit`, etc.) using Alloy.
+2. **Wrap in `executeUserOp`.** The user's wallet is a
+   [Safe smart account](https://docs.safe.global/) with the ERC-4337 module
+   installed. Bedrock wraps the inner call in a
+   `executeUserOp(to, value, data, operation)` invocation on the module so
+   the UserOp executes through the smart account when the EntryPoint
+   dispatches it.
+3. **Compute the UserOp hash locally.** Used for confirmation UI.
+4. **Ask for sponsorship.** Bedrock calls `pm_sponsorUserOperation` with an
+   empty context. The endpoint either sponsors directly (the protocol pays gas
+   on the user's behalf) or returns a structured decline with the information
+   needed to retry as a self-sponsored transaction.
+5. **(Decline branch only.) Retry as self-sponsored.** Bedrock retries the
+   request in self-sponsored mode using the token returned in the decline
+   payload; the endpoint then returns the gas estimates and paymaster
+   fields needed to finalise the UserOp.
+6. **Sign.** Bedrock merges the gas (and paymaster, if any) fields into the
+   UserOp and signs locally with the device key.
+7. **Submit.** `eth_sendUserOperation` forwards the UserOp to a bundler which calls `handleOps` on the
+   [EntryPoint](https://eips.ethereum.org/EIPS/eip-4337#entrypoint).
+8. **Poll for receipt.** Bedrock polls `eth_getUserOperationReceipt` until
+   the UserOp is mined.
+
+## Sponsored path (protocol pays gas)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Bedrock as Bedrock (on-device)
+    participant Endpoint as Sponsorship endpoint
+    participant Bundler
+    participant EP as EntryPoint contract
+
+    User->>Bedrock: Intent (send X WLD to Alice)
+    Bedrock->>Bedrock: Build callData (Alloy)
+    Bedrock->>Bedrock: Wrap in Safe executeUserOp
+    Bedrock->>Bedrock: Compute userOpHash
+
+    Bedrock->>Endpoint: pm_sponsorUserOperation(userOp, entryPoint, {})
+    Endpoint-->>Bedrock: sponsored response (gas + paymaster fields as applicable)
+
+    Bedrock->>User: Confirm: sign userOpHash = <decoded intent>
+    User-->>Bedrock: Approve
+    Bedrock->>Bedrock: Sign userOp with device key
+
+    Bedrock->>Endpoint: eth_sendUserOperation(signedUserOp, entryPoint)
+    Endpoint->>Bundler: forward
+    Bundler->>EP: handleOps([signedUserOp])
+    EP-->>Bundler: tx hash
+    Bundler-->>Endpoint: tx hash
+    Endpoint-->>Bedrock: userOpHash
+
+    Bedrock->>Endpoint: poll eth_getUserOperationReceipt
+    Endpoint-->>Bedrock: receipt
+    Bedrock-->>User: ✓ Sent
+```
+
+The sponsored response carries the gas fields and paymaster fields (when
+applicable) needed for Bedrock to finalise and sign the UserOp. Bedrock
+merges the populated fields into the UserOp and signs; fields the response
+omits are left unset on the UserOp.
+
+## Decline → self-sponsored retry (user pays gas in an ERC-20 token)
+
+When the protocol declines to sponsor, the wallet falls back to the user
+paying gas in an ERC-20 token (e.g. WLD) routed through an ERC-20 paymaster
+contract.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Bedrock as Bedrock (on-device)
+    participant Endpoint as Sponsorship endpoint
+    participant Paymaster as ERC-20 paymaster contract
+    participant Bundler
+
+    User->>Bedrock: Intent
+    Bedrock->>Bedrock: Build callData, wrap in Safe executeUserOp
+
+    Bedrock->>Endpoint: pm_sponsorUserOperation(userOp, entryPoint, {})
+    Endpoint-->>Bedrock: "sponsorship declined"<br/>data: { token, paymasterAddress, costNative, costToken }
+
+    Bedrock->>Bedrock: Prepare self-sponsored userOp
+
+    Bedrock->>Endpoint: pm_sponsorUserOperation(updatedUserOp, entryPoint, { token })
+    Endpoint-->>Bedrock: gas + paymaster + paymasterData
+
+    Bedrock->>User: Confirm: pay ~Y WLD in gas
+    User-->>Bedrock: Approve
+    Bedrock->>Bedrock: Merge gas + paymaster fields, sign userOp
+
+    Bedrock->>Endpoint: eth_sendUserOperation(signedUserOp, entryPoint)
+    Endpoint->>Bundler: forward
+    Bundler-->>Endpoint: userOpHash
+    Endpoint-->>Bedrock: userOpHash
+```
+
+**Wire shape — decline payload (`-32602`):**
+
+| Field              | Required | Meaning                                                                                      |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------- |
+| `token`            | yes      | ERC-20 token address the user should pay gas in (e.g. WLD). Bedrock uses this for the retry. |
+| `paymasterAddress` | yes      | ERC-20 paymaster contract that will pull the fee at execution time.                          |
+| `costNative`       | yes      | Estimated gas cost in native currency.                                                       |
+| `costToken`        | yes      | Estimated gas cost in ERC-20 token currency.                                                 |
+
+**Wire shape — self-sponsored response:**
+
+```json
+{
+  "callGasLimit": "0x…",
+  "verificationGasLimit": "0x…",
+  "preVerificationGas": "0x…",
+  "maxFeePerGas": "0x…",
+  "maxPriorityFeePerGas": "0x…",
+  "paymaster": "0x…",
+  "paymasterData": "0x…",
+  "paymasterVerificationGasLimit": "0x…",
+  "paymasterPostOpGasLimit": "0x…"
+}
+```
+
+All gas fields populated, all paymaster fields present. Bedrock merges them
+into the UserOp and calls `with_paymaster_data()` before signing.
+
+## Per-step details
+
+### 1. Build callData
+
+Done locally with Alloy. The relevant function is encoded against the contract ABI.
+
+### 2. Wrap in `executeUserOp`
+
+The actual call is wrapped in `executeUserOp(to, value, data, operation)` on
+the Safe's ERC-4337 module. This becomes the `callData` field of the UserOp;
+when the EntryPoint dispatches the UserOp, it calls `executeUserOp` on the
+smart account, which performs the inner call.
+
+### 3. Compute the UserOp hash
+
+ERC-4337's UserOp hash is deterministic given the fully-assembled UserOp,
+the EntryPoint address, and the chain ID. Bedrock computes it locally.
+
+### 4. First sponsorship call
+
+`pm_sponsorUserOperation` is called with the partial UserOp (sender, nonce,
+callData, signature placeholder) and an empty context. The endpoint inspects current conditions and either:
+
+- returns a 200 response carrying the fields needed to sign and submit, or
+- returns `-32602 "sponsorship declined"` with the structured payload above.
+
+### 5. Self-sponsored retry
+
+When the protocol declines to sponsor, Bedrock retries the request in
+self-sponsored mode using the token returned in the decline payload. The
+second response carries the gas estimates and paymaster fields needed to
+finalise the UserOp.
+
+### 6. Sign
+
+The UserOp is finalised by merging the gas and
+paymaster fields. Bedrock recomputes the UserOp hash to ensure it still
+corresponds to the intent shown to the user, then signs with the device key.
+
+### 7. Submit
+
+`eth_sendUserOperation(signedUserOp, entryPoint)`. The endpoint forwards to
+a bundler. Bedrock receives the userOpHash back and stores it for receipt
+polling.
+
+### 8. Poll for receipt
+
+`eth_getUserOperationReceipt` is polled until the UserOp is mined or until a
+deadline is reached. The user-facing state machine (`pending`, `mined`,
+`failed`) is derived from the receipt.
+
+## References
+
+- [ERC-4337 — Account Abstraction Using EntryPoint](https://eips.ethereum.org/EIPS/eip-4337)
+- [EIP-7677 — Paymaster Web Service Capability](https://eips.ethereum.org/EIPS/eip-7677)
+- [EIP-7769 — JSON-RPC error codes for ERC-4337](https://eips.ethereum.org/EIPS/eip-7769)
+- [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)
+- [Safe Smart Account documentation](https://docs.safe.global/)
+- Bedrock source: `bedrock/src/transactions/` (`rpc.rs`, `mod.rs`,
+  `contracts/`)

--- a/bedrock/src/transactions/transaction.md
+++ b/bedrock/src/transactions/transaction.md
@@ -4,8 +4,7 @@ This document describes the **V2** on-device flow: how Bedrock — the
 open-source, on-device SDK that powers the wallet — turns a user intent
 (e.g. "send 5 WLD to `0x…`") into a signed
 [ERC-4337 UserOperation](https://eips.ethereum.org/EIPS/eip-4337) that lands on
-chain. The earlier prepare/send flow is being phased out per transaction type;
-see [Versioning and compatibility](#versioning-and-compatibility) below.
+chain.
 
 It is a living document. The wallet's sponsorship policy evolves over time;
 when it changes, this file changes with it. The on-device steps Bedrock performs


### PR DESCRIPTION
V2 RPC client surface on top of path-versioned routing, plus a
public-facing description of the on-device prepare-and-sign flow.
Additive: no existing caller is migrated, no V1 behaviour changes.
Orchestration (sign_and_execute_v2) and per-tx-type opt-in land in
follow-up PRs.

RPC primitives (bedrock/src/transactions/rpc.rs):

- Path-versioned endpoint routing. rpc_endpoint picks /v1 or /v2 per
  RpcMethod; existing methods stay on /v1.
- New RpcMethod variants: PmSponsorUserOperation and
  SendUserOperationV2, both routing to /v2.
- PmSponsorUserOperationResponse models paymaster fields as Option<T>
  so the same type deserializes both the protocol-sponsored shape
  (paymaster fields absent) and the self-sponsored shape (populated).
- SponsorshipContext enum — Protocol (empty {}) and
  SelfSponsoredToken(Address). Named to avoid the ERC-4337 "bundler
  sponsorship" collision.
- pm_sponsor_user_operation sends the three-element params vec
  [userOp, entryPoint, context] required by the V2 contract.
- send_user_operation_v2 client method.
- Unit tests for routing, response parsing, and context serialization.
