### PR TITLE
docs: link backup & recovery docs

### DIFF
--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -1,3 +1,11 @@
+//! World App's "Backup & Recovery" (client-side primitives).
+//!
+//! This module owns the backup file format, manifest computation, sealing/unsealing,
+//! and the Turnkey stamping helpers shared across iOS and Android.
+//!
+//! For the architecture, factor model, flows, and threat model, see the central docs:
+//! <https://docs.toolsforhumanity.com/world-app/backup>.
+
 mod backup_format;
 mod client_events;
 mod manifest;
@@ -252,7 +260,7 @@ impl BackupManager {
     }
 
     /// Adds new factor by re-encrypting the backup keypair (not the backup itself!)
-    /// with a new factor secret.
+    /// with a new factor secret. (See BF-3 Adding a Main Faactor)
     ///
     /// * `encrypted_backup_key_with_existing_factor_secret` - is the backup keypair that was
     ///   encrypted with the existing factor secret. Hex encoded.
@@ -637,6 +645,8 @@ impl<'de> Deserialize<'de> for BackupFileDesignator {
 }
 
 /// Errors that can occur when working with backups and manifests.
+///
+/// Further error documentation: <https://docs.toolsforhumanity.com/world-app/backup/components#what-the-service-rejects>
 #[crate::bedrock_error]
 pub enum BackupError {
     #[error("Failed to decode factor secret as hex")]

--- a/bedrock/src/lib.rs
+++ b/bedrock/src/lib.rs
@@ -30,8 +30,6 @@ pub mod transactions;
 /// Introduces low level primitives for the crypto wallet, including logging functionality.
 pub mod primitives;
 
-/// Tools for storing, retrieving, encrypting and decrypting backup data and metadata.
-/// See `backup::BackupManager` for the high-level API.
 pub mod backup;
 
 /// Introduces low level operations for interacting with a Nitro Enclave.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Doc-only changes (module and error documentation) with no functional or behavioral impact.
> 
> **Overview**
> Adds **central Backup & Recovery documentation links** and clearer module-level docs in `backup/mod.rs`, including references for architecture/threat model and service rejection reasons.
> 
> Removes redundant crate-root `backup` module doc comments from `lib.rs` and tweaks a factor-management docstring for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee98c424c8edcfe90265d6fb25855048ec3810ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->