### PR TITLE
feat: ID-1567: Add AnonymizedThirdPartyAnalytics to BackupFileDesignator

### DIFF
--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -615,6 +615,8 @@ pub enum BackupFileDesignator {
     CredentialVault,
     /// Face Personal Custody Package (PCP) or "Face Credential"
     FacePkg,
+    /// Anonymized user IDs and associated requests per Relying Party
+    AnonymizedThirdPartyAnalytics,
 }
 
 impl Serialize for BackupFileDesignator {


### PR DESCRIPTION
## What

- Adds `AnonymizedThirdPartyAnalytics` variant to `BackupFileDesignator` for backing up anonymized user IDs and associated requests per Relying Party

## Why

Third-party request records need to survive device restore via Bedrock's encrypted backup system. This designator provides a stable, semantically meaningful key for the backup manifest entry.

## Test plan

- [ ] Verify `AnonymizedThirdPartyAnalytics` serializes to `"anonymized_third_party_analytics"` via `strum::Display`
- [ ] Verify round-trip through `replaceAllFilesForDesignator` / `restoreFilesForDesignator`