### PR TITLE
feat(swift): add make_local_swift_package.sh to build and patch WorldApp for local development

### DIFF
--- a/swift/Package.swift.template
+++ b/swift/Package.swift.template
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Bedrock",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "Bedrock",
+            targets: ["Bedrock"]),
+    ],
+    targets: [
+        .target(
+            name: "Bedrock",
+            dependencies: ["BedrockFFI"],
+            path: "Sources/Bedrock"
+        ),
+        <binary_target>
+    ]
+)

--- a/swift/archive_swift.sh
+++ b/swift/archive_swift.sh
@@ -4,6 +4,8 @@ set -e
 # Creates the dynamic Package.swift file for release.
 # Usage: ./archive_swift.sh --asset-url <URL> --checksum <CHECKSUM> --release-version <VERSION>
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Initialize variables
 ASSET_URL=""
 CHECKSUM=""
@@ -56,40 +58,21 @@ echo "   Checksum: $CHECKSUM"
 echo "   Release Version: $RELEASE_VERSION"
 echo ""
 
-cat > Package.swift << EOF
-// swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+awk -v url="$ASSET_URL" -v checksum="$CHECKSUM" '
+/<binary_target>/ {
+    print "        .binaryTarget("
+    print "            name: \"BedrockFFI\","
+    print "            url: \"" url "\","
+    print "            checksum: \"" checksum "\""
+    print "        )"
+    next
+}
+{ print }
+' "$SCRIPT_DIR/Package.swift.template" > Package.swift
 
-// Release version: $RELEASE_VERSION
+echo "// Release version: $RELEASE_VERSION" >> Package.swift
 
-import PackageDescription
-
-let package = Package(
-    name: "Bedrock",
-    platforms: [
-        .iOS(.v13)
-    ],
-    products: [
-        .library(
-            name: "Bedrock",
-            targets: ["Bedrock"]),
-    ],
-    targets: [
-        .target(
-            name: "Bedrock",
-            dependencies: ["BedrockFFI"],
-            path: "Sources/Bedrock"
-        ),
-        .binaryTarget(
-            name: "BedrockFFI",
-            url: "$ASSET_URL",
-            checksum: "$CHECKSUM"
-        )
-    ]
-)
-EOF
-
-swiftlint lint --autocorrect Package.swift 
+swiftlint lint --autocorrect Package.swift
 
 echo ""
 echo "✅ Package.swift built successfully for version $RELEASE_VERSION!"

--- a/swift/local_swift.sh
+++ b/swift/local_swift.sh
@@ -8,7 +8,7 @@ set -e
 
 PROJECT_ROOT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE_PATH="$PROJECT_ROOT_PATH/swift" # The base path for the Swift build
-LOCAL_BUILD_PATH="$BASE_PATH/local_build" # Local build artifacts directory
+LOCAL_BUILD_PATH="$BASE_PATH/local_build/bedrock-swift" # Local build artifacts directory
 FRAMEWORK="Bedrock.xcframework"
 
 echo "Building $FRAMEWORK for local iOS development"
@@ -26,36 +26,16 @@ bash "$BASE_PATH/build_swift.sh" "$LOCAL_BUILD_PATH"
 
 echo "Creating Package.swift for local development..."
 
-# Create Package.swift for local development
-cat > $LOCAL_BUILD_PATH/Package.swift << EOF
-// swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
-import PackageDescription
-
-let package = Package(
-    name: "Bedrock",
-    platforms: [
-        .iOS(.v13)
-    ],
-    products: [
-        .library(
-            name: "Bedrock",
-            targets: ["Bedrock"]),
-    ],
-    targets: [
-        .target(
-            name: "Bedrock",
-            dependencies: ["BedrockFFI"],
-            path: "Sources/Bedrock"
-        ),
-        .binaryTarget(
-            name: "BedrockFFI",
-            path: "Bedrock.xcframework"
-        )
-    ]
-)
-EOF
+awk -v path="$FRAMEWORK" '
+/<binary_target>/ {
+    print "        .binaryTarget("
+    print "            name: \"BedrockFFI\","
+    print "            path: \"" path "\""
+    print "        )"
+    next
+}
+{ print }
+' "$BASE_PATH/Package.swift.template" > "$LOCAL_BUILD_PATH/Package.swift"
 
 echo ""
 echo "✅ Swift package built successfully!"
@@ -68,4 +48,4 @@ echo "2. Click 'Add Local...' and select the local_build directory: $LOCAL_BUILD
 echo "3. Or add it to your Package.swift dependencies:"
 echo "   .package(path: \"$LOCAL_BUILD_PATH\")"
 echo ""
-echo "The package exports the 'Bedrock' library that you can import in your Swift code." 
+echo "The package exports the 'Bedrock' library that you can import in your Swift code."

--- a/swift/make_local_swift_package.sh
+++ b/swift/make_local_swift_package.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load local env overrides if present
+[[ -f "$PROJECT_ROOT/.env" ]] && source "$PROJECT_ROOT/.env"
+
+WORLD_APP_PATH="${1:-$WORLD_APP_PATH}"
+
+if [ -z "$WORLD_APP_PATH" ]; then
+  echo "Error: Missing path to the WorldApp project. This is used to find and update the Package.swift that references bedrock-swift."
+  echo "Usage: $0 /Path/To/WorldApp"
+  echo "Or set WORLD_APP_PATH in .env"
+  exit 1
+fi
+
+LOCAL_BUILD_PATH="$SCRIPT_DIR/local_build/bedrock-swift"
+
+echo "Building the Bedrock Swift package..."
+bash "$SCRIPT_DIR/local_swift.sh"
+
+echo "Finding Package.swift files that reference bedrock-swift..."
+PACKAGE_FILES=$(grep -rl "worldcoin/bedrock-swift" "$WORLD_APP_PATH" --include="Package.swift" --exclude-dir=".build" --exclude-dir=".claude" || true)
+
+if [ -z "$PACKAGE_FILES" ]; then
+  echo "Warning: No Package.swift found referencing worldcoin/bedrock-swift in $WORLD_APP_PATH"
+  exit 1
+fi
+
+while IFS= read -r pkg_file; do
+  echo "Patching $pkg_file..."
+  sed -i '' "s|\.package(url: \"https://github.com/worldcoin/bedrock-swift\", exact: \"[^\"]*\")|.package(path: \"$LOCAL_BUILD_PATH\")|" "$pkg_file"
+done <<< "$PACKAGE_FILES"
+
+echo "Done! In Xcode, make sure package resolution succeeds (via the Issue Navigator). You can get opaque build failures if the package isn't where the app expects it to be."


### PR DESCRIPTION
## Summary
- Adds `make_local_swift_package.sh`: one command to build bedrock-swift locally and patch WorldApp's `Package.swift` to reference the local build instead of the remote release
- Supporting changes: extract `Package.swift` into a shared template (`Package.swift.template`) so both `archive_swift.sh` and `local_swift.sh` generate it consistently

## Test plan
- [ ] Run `./swift/make_local_swift_package.sh /Path/To/WorldApp` and verify WorldApp's Package.swift is patched to `local_build/bedrock-swift`
- [ ] Open WorldApp in Xcode, resolve packages, and confirm it picks up the local bedrock build