### PR TITLE
feat(rpc): sign_and_execute_v2 + typed decline parsing

### DIFF
--- a/bedrock/src/primitives/contracts.rs
+++ b/bedrock/src/primitives/contracts.rs
@@ -1,5 +1,7 @@
 use crate::primitives::PrimitiveError;
-use crate::transactions::rpc::SponsorUserOperationResponse;
+use crate::transactions::rpc::{
+    PmSponsorUserOperationResponse, SponsorUserOperationResponse,
+};
 use alloy::hex::FromHex;
 use alloy::primitives::{aliases::U48, keccak256, Address, Bytes, FixedBytes, U128};
 use alloy::sol;
@@ -273,6 +275,47 @@ impl UserOperation {
         self.call_gas_limit = sponsor_response.call_gas_limit;
         self.max_fee_per_gas = sponsor_response.max_fee_per_gas;
         self.max_priority_fee_per_gas = sponsor_response.max_priority_fee_per_gas;
+
+        self
+    }
+
+    /// Merges a V2 `pm_sponsorUserOperation` response into the `UserOperation`.
+    ///
+    /// Gas fields are always written; paymaster fields are conditional. On the
+    /// protocol-sponsored response shape, the paymaster fields are absent — the
+    /// `Option`s on `PmSponsorUserOperationResponse` are `None` and the
+    /// corresponding `UserOperation` fields are left untouched at their
+    /// preflight defaults (no paymaster). On the self-sponsored response shape,
+    /// the paymaster fields are populated and copied through verbatim.
+    ///
+    /// See `bedrock/src/transactions/transaction.md` for the wire contract.
+    #[must_use]
+    pub fn with_sponsorship_data(
+        mut self,
+        sponsor_response: &PmSponsorUserOperationResponse,
+    ) -> Self {
+        // Gas fields are always populated on both response shapes.
+        self.pre_verification_gas = sponsor_response.pre_verification_gas;
+        self.verification_gas_limit = sponsor_response.verification_gas_limit;
+        self.call_gas_limit = sponsor_response.call_gas_limit;
+        self.max_fee_per_gas = sponsor_response.max_fee_per_gas;
+        self.max_priority_fee_per_gas = sponsor_response.max_priority_fee_per_gas;
+
+        // Paymaster fields are absent on the protocol-sponsored path. Only
+        // overwrite the UserOp when the response actually carries them so the
+        // protocol-sponsored UserOp stays paymaster-less.
+        if let Some(paymaster) = sponsor_response.paymaster {
+            self.paymaster = Some(paymaster);
+        }
+        if let Some(data) = &sponsor_response.paymaster_data {
+            self.paymaster_data = Some(data.clone());
+        }
+        if let Some(p_ver_gas) = sponsor_response.paymaster_verification_gas_limit {
+            self.paymaster_verification_gas_limit = Some(p_ver_gas);
+        }
+        if let Some(p_post_op_gas) = sponsor_response.paymaster_post_op_gas_limit {
+            self.paymaster_post_op_gas_limit = Some(p_post_op_gas);
+        }
 
         self
     }

--- a/bedrock/src/primitives/contracts.rs
+++ b/bedrock/src/primitives/contracts.rs
@@ -281,12 +281,13 @@ impl UserOperation {
 
     /// Merges a V2 `pm_sponsorUserOperation` response into the `UserOperation`.
     ///
-    /// Gas fields are always written; paymaster fields are conditional. On the
-    /// protocol-sponsored response shape, the paymaster fields are absent — the
-    /// `Option`s on `PmSponsorUserOperationResponse` are `None` and the
-    /// corresponding `UserOperation` fields are left untouched at their
-    /// preflight defaults (no paymaster). On the self-sponsored response shape,
-    /// the paymaster fields are populated and copied through verbatim.
+    /// Every field on the response is written through unconditionally — the
+    /// response is the source of truth for the post-merge `UserOp`. Gas fields
+    /// always carry values on both response shapes; paymaster fields are
+    /// `Some(...)` only on the self-sponsored shape, `None` on the
+    /// protocol-sponsored shape. A `None` clears any prior paymaster data on
+    /// the input `UserOp`, so the protocol-sponsored merge cannot accidentally
+    /// preserve stale paymaster fields from earlier mutations.
     ///
     /// See `bedrock/src/transactions/transaction.md` for the wire contract.
     #[must_use]
@@ -301,21 +302,15 @@ impl UserOperation {
         self.max_fee_per_gas = sponsor_response.max_fee_per_gas;
         self.max_priority_fee_per_gas = sponsor_response.max_priority_fee_per_gas;
 
-        // Paymaster fields are absent on the protocol-sponsored path. Only
-        // overwrite the UserOp when the response actually carries them so the
-        // protocol-sponsored UserOp stays paymaster-less.
-        if let Some(paymaster) = sponsor_response.paymaster {
-            self.paymaster = Some(paymaster);
-        }
-        if let Some(data) = &sponsor_response.paymaster_data {
-            self.paymaster_data = Some(data.clone());
-        }
-        if let Some(p_ver_gas) = sponsor_response.paymaster_verification_gas_limit {
-            self.paymaster_verification_gas_limit = Some(p_ver_gas);
-        }
-        if let Some(p_post_op_gas) = sponsor_response.paymaster_post_op_gas_limit {
-            self.paymaster_post_op_gas_limit = Some(p_post_op_gas);
-        }
+        // Paymaster fields: overwrite unconditionally. `None` on the
+        // protocol-sponsored shape clears any prior paymaster data, mirroring
+        // V1's `with_paymaster_data` so the two merge paths stay symmetric.
+        self.paymaster = sponsor_response.paymaster;
+        self.paymaster_data
+            .clone_from(&sponsor_response.paymaster_data);
+        self.paymaster_verification_gas_limit =
+            sponsor_response.paymaster_verification_gas_limit;
+        self.paymaster_post_op_gas_limit = sponsor_response.paymaster_post_op_gas_limit;
 
         self
     }

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -409,6 +409,56 @@ mod tests {
         assert!(updated.paymaster_post_op_gas_limit.is_none());
     }
 
+    /// A protocol-sponsored response clears any stale paymaster fields that
+    /// were already on the `UserOp` — the response is the source of truth, so
+    /// `None` overwrites prior `Some(...)`.
+    #[test]
+    fn test_with_sponsorship_data_protocol_clears_stale_paymaster() {
+        use crate::transactions::rpc::PmSponsorUserOperationResponse;
+
+        let mut user_op = UserOperation::new_with_defaults(
+            address!("0x1111111111111111111111111111111111111111"),
+            U256::ZERO,
+            Bytes::from_str("0x1234").unwrap(),
+        );
+        // Pre-populate paymaster fields as if a prior self-sponsored merge had
+        // happened on this UserOp; the protocol-sponsored merge below must
+        // clear them.
+        user_op.paymaster =
+            Some(address!("0x3333333333333333333333333333333333333333"));
+        user_op.paymaster_data = Some(Bytes::from_str("0xdead").unwrap());
+        user_op.paymaster_verification_gas_limit = Some(U128::from(999));
+        user_op.paymaster_post_op_gas_limit = Some(U128::from(888));
+
+        let sponsor_response = PmSponsorUserOperationResponse {
+            call_gas_limit: U128::from(500),
+            verification_gas_limit: U128::from(400),
+            pre_verification_gas: U256::from(300),
+            max_fee_per_gas: U128::from(900),
+            max_priority_fee_per_gas: U128::from(800),
+            paymaster: None,
+            paymaster_verification_gas_limit: None,
+            paymaster_post_op_gas_limit: None,
+            paymaster_data: None,
+        };
+
+        let updated = user_op.with_sponsorship_data(&sponsor_response);
+
+        assert!(updated.paymaster.is_none(), "stale paymaster not cleared");
+        assert!(
+            updated.paymaster_data.is_none(),
+            "stale paymaster_data not cleared"
+        );
+        assert!(
+            updated.paymaster_verification_gas_limit.is_none(),
+            "stale paymaster_verification_gas_limit not cleared"
+        );
+        assert!(
+            updated.paymaster_post_op_gas_limit.is_none(),
+            "stale paymaster_post_op_gas_limit not cleared"
+        );
+    }
+
     /// Self-sponsored V2 response (token context): every field, including the
     /// paymaster ones, is merged onto the `UserOp`.
     #[test]

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -6,7 +6,7 @@
 use crate::primitives::contracts::{EncodedSafeOpStruct, UserOperation};
 use crate::primitives::{Network, PrimitiveError};
 use crate::smart_account::{SafeSmartAccount, SafeSmartAccountSigner};
-use crate::transactions::rpc::{RpcError, RpcProviderName};
+use crate::transactions::rpc::{RpcError, RpcProviderName, SponsorshipContext};
 
 use alloy::primitives::{aliases::U48, Address, Bytes, FixedBytes};
 use chrono::{Duration, Utc};
@@ -152,6 +152,67 @@ pub trait Is4337Encodable {
             .await?;
 
         Ok(user_op_hash)
+    }
+
+    /// V2 of [`sign_and_execute`] targeting the wallet provider's
+    /// path-versioned RPC at `/v2/rpc/{network}`.
+    ///
+    /// Happy path only: requests protocol sponsorship by calling
+    /// `pm_sponsorUserOperation` with `SponsorshipContext::Protocol`,
+    /// merges the response's gas fields (and any paymaster fields the
+    /// response carries) into the `UserOp`, signs locally, and submits via
+    /// `eth_sendUserOperation` on the V2 path.
+    ///
+    /// Decline handling — parsing the `-32602 "sponsorship declined"`
+    /// payload and retrying as self-sponsored with
+    /// `SponsorshipContext::SelfSponsoredToken` — is not implemented yet
+    /// and will be added in a follow-up. A decline today surfaces as the
+    /// RPC error from `pm_sponsor_user_operation`.
+    ///
+    /// V1 [`sign_and_execute`] remains the active path for every existing
+    /// UniFFI export until its caller in `transactions/mod.rs` opts in to
+    /// V2 explicitly. See `bedrock/src/transactions/transaction.md` for
+    /// the on-device wire contract.
+    ///
+    /// # Errors
+    /// * Returns `RpcError` if any RPC operation fails
+    /// * Returns `RpcError` if signing fails
+    /// * Returns `RpcError` if the global HTTP client has not been initialized
+    async fn sign_and_execute_v2(
+        &self,
+        safe_account: &SafeSmartAccount,
+        network: Network,
+        metadata: Option<Self::MetadataArg>,
+    ) -> Result<FixedBytes<32>, RpcError> {
+        // 0. Global RPC client
+        let rpc_client = crate::transactions::rpc::get_rpc_client()?;
+
+        // 1. Preflight UserOperation
+        let mut user_operation =
+            self.build_preflight_user_operation(safe_account.wallet_address, metadata)?;
+
+        // 2. Request protocol sponsorship via V2 pm_sponsorUserOperation
+        let sponsor_response = rpc_client
+            .pm_sponsor_user_operation(
+                network,
+                &user_operation,
+                *ENTRYPOINT_4337,
+                &SponsorshipContext::Protocol,
+            )
+            .await?;
+
+        // 3. Merge gas (and paymaster fields if any) into the `UserOp`.
+        //    For SponsorshipContext::Protocol the response carries only
+        //    gas fields; paymaster fields stay None.
+        user_operation = user_operation.with_sponsorship_data(&sponsor_response);
+
+        // 4. Sign with fresh validity timestamps
+        safe_account.sign_user_operation(&mut user_operation, network)?;
+
+        // 5. Submit via the V2 RPC path
+        rpc_client
+            .send_user_operation_v2(network, &user_operation, *ENTRYPOINT_4337)
+            .await
     }
 }
 
@@ -302,6 +363,93 @@ mod tests {
         );
         assert_eq!(updated_user_op.max_priority_fee_per_gas, U128::from(800));
         assert_eq!(updated_user_op.max_fee_per_gas, U128::from(900));
+    }
+
+    /// Protocol-sponsored V2 response (empty context): gas fields overwritten,
+    /// paymaster fields stay at their preflight defaults because the response
+    /// omits them.
+    #[test]
+    fn test_with_sponsorship_data_protocol() {
+        use crate::transactions::rpc::PmSponsorUserOperationResponse;
+
+        let mut user_op = UserOperation::new_with_defaults(
+            address!("0x1111111111111111111111111111111111111111"),
+            U256::ZERO,
+            Bytes::from_str("0x1234").unwrap(),
+        );
+        // Seed paymaster fields with the preflight defaults so we can assert
+        // they survive the merge unchanged.
+        user_op.paymaster = None;
+        user_op.paymaster_data = None;
+        user_op.paymaster_verification_gas_limit = None;
+        user_op.paymaster_post_op_gas_limit = None;
+
+        let sponsor_response = PmSponsorUserOperationResponse {
+            call_gas_limit: U128::from(500),
+            verification_gas_limit: U128::from(400),
+            pre_verification_gas: U256::from(300),
+            max_fee_per_gas: U128::from(900),
+            max_priority_fee_per_gas: U128::from(800),
+            paymaster: None,
+            paymaster_verification_gas_limit: None,
+            paymaster_post_op_gas_limit: None,
+            paymaster_data: None,
+        };
+
+        let updated = user_op.with_sponsorship_data(&sponsor_response);
+
+        assert_eq!(updated.call_gas_limit, U128::from(500));
+        assert_eq!(updated.verification_gas_limit, U128::from(400));
+        assert_eq!(updated.pre_verification_gas, U256::from(300));
+        assert_eq!(updated.max_fee_per_gas, U128::from(900));
+        assert_eq!(updated.max_priority_fee_per_gas, U128::from(800));
+        assert!(updated.paymaster.is_none());
+        assert!(updated.paymaster_data.is_none());
+        assert!(updated.paymaster_verification_gas_limit.is_none());
+        assert!(updated.paymaster_post_op_gas_limit.is_none());
+    }
+
+    /// Self-sponsored V2 response (token context): every field, including the
+    /// paymaster ones, is merged onto the `UserOp`.
+    #[test]
+    fn test_with_sponsorship_data_self_sponsored() {
+        use crate::transactions::rpc::PmSponsorUserOperationResponse;
+
+        let user_op = UserOperation::new_with_defaults(
+            address!("0x1111111111111111111111111111111111111111"),
+            U256::ZERO,
+            Bytes::from_str("0x1234").unwrap(),
+        );
+
+        let sponsor_response = PmSponsorUserOperationResponse {
+            call_gas_limit: U128::from(500),
+            verification_gas_limit: U128::from(400),
+            pre_verification_gas: U256::from(300),
+            max_fee_per_gas: U128::from(900),
+            max_priority_fee_per_gas: U128::from(800),
+            paymaster: Some(address!("0x2222222222222222222222222222222222222222")),
+            paymaster_verification_gas_limit: Some(U128::from(600)),
+            paymaster_post_op_gas_limit: Some(U128::from(700)),
+            paymaster_data: Some(Bytes::from_str("0xabcd").unwrap()),
+        };
+
+        let updated = user_op.with_sponsorship_data(&sponsor_response);
+
+        assert_eq!(
+            updated.paymaster,
+            Some(address!("0x2222222222222222222222222222222222222222"))
+        );
+        assert_eq!(
+            updated.paymaster_data,
+            Some(Bytes::from_str("0xabcd").unwrap())
+        );
+        assert_eq!(
+            updated.paymaster_verification_gas_limit,
+            Some(U128::from(600))
+        );
+        assert_eq!(updated.paymaster_post_op_gas_limit, Some(U128::from(700)));
+        assert_eq!(updated.call_gas_limit, U128::from(500));
+        assert_eq!(updated.max_fee_per_gas, U128::from(900));
     }
 
     #[test]

--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -112,6 +112,7 @@ fn parse_json_rpc_response(response_bytes: &[u8]) -> Result<Value, RpcError> {
         return Err(RpcError::RpcResponseError {
             code: ep.code,
             error_message: ep.message,
+            data: ep.data.and_then(|d| serde_json::to_string(&d).ok()),
         });
     }
 

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -112,7 +112,6 @@ pub(crate) struct ErrorPayload {
     pub code: i64,
     pub message: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub data: Option<Value>,
 }
 
@@ -135,6 +134,13 @@ pub enum RpcError {
         code: i64,
         /// The error message from the RPC response
         error_message: String,
+        /// The optional `data` field from the JSON-RPC error object as a raw
+        /// JSON string. Carries the structured payload of decisions like
+        /// sponsorship declines so callers can route on it; stored as a
+        /// `String` (rather than `serde_json::Value`) so the variant remains
+        /// UniFFI-liftable. Callers parse it on demand — see
+        /// [`RpcError::as_sponsorship_decline`].
+        data: Option<String>,
     },
 
     /// Invalid response format
@@ -266,6 +272,70 @@ impl SponsorshipContext {
     }
 }
 
+/// Server-side decline of a V2 sponsorship request.
+///
+/// When `pm_sponsorUserOperation` is called with protocol context (empty `{}`)
+/// and the server refuses to sponsor, it returns a `-32602` error with this
+/// payload carried in the JSON-RPC `data` field. Bedrock parses it to decide
+/// whether to retry as self-sponsored, and to surface the worst-case cost to
+/// the wallet UI so the user can confirm the WLD spend.
+///
+/// Wire shape (see `bedrock/src/transactions/transaction.md` and the
+/// temporal-apps `docs/architecture/jsonrpc/sponsorship_triggers.md`):
+///
+/// ```json
+/// {
+///   "token": "0x<wld>",
+///   "paymasterAddress": "0x<pimlico-paymaster>",
+///   "costNative": "0x<wei>",
+///   "costToken": "0x<wld-wei>"
+/// }
+/// ```
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SponsorshipDecline {
+    /// ERC-20 token Bedrock should retry against (typically WLD on the network).
+    pub token: Address,
+    /// Pimlico ERC-20 paymaster that will pull the fee at execution time.
+    pub paymaster_address: Address,
+    /// Worst-case gas cost in native wei, for the self-sponsored retry.
+    pub cost_native: U256,
+    /// Worst-case gas cost in the ERC-20 token's smallest unit, for the
+    /// self-sponsored retry.
+    pub cost_token: U256,
+}
+
+/// Sentinel error message used by the temporal-apps server when declining a
+/// sponsorship request. See `apps/jsonrpc/controllers/userop.go` (the
+/// `jsonRpcInvalidParams(..., "sponsorship declined", ...)` callsite).
+const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
+
+impl RpcError {
+    /// Returns the decline payload when this error is the server's
+    /// "sponsorship declined" signal — `code == -32602`, the canonical
+    /// error message, and a `data` field whose shape matches
+    /// [`SponsorshipDecline`]. Returns `None` for every other error.
+    ///
+    /// This is the entry point callers like `sign_and_execute_v2` use to
+    /// route on decline without pattern-matching the raw error.
+    #[must_use]
+    pub fn as_sponsorship_decline(&self) -> Option<SponsorshipDecline> {
+        let Self::RpcResponseError {
+            code,
+            error_message,
+            data,
+        } = self
+        else {
+            return None;
+        };
+        if *code != -32602 || error_message != SPONSORSHIP_DECLINED_MESSAGE {
+            return None;
+        }
+        let raw = data.as_deref()?;
+        serde_json::from_str(raw).ok()
+    }
+}
+
 /// Response from `wa_getUserOperationReceipt`
 #[derive(Debug, Deserialize, uniffi::Record, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -371,6 +441,9 @@ impl RpcClient {
             return Err(RpcError::RpcResponseError {
                 code: error_payload.code,
                 error_message: error_payload.message,
+                data: error_payload
+                    .data
+                    .and_then(|d| serde_json::to_string(&d).ok()),
             });
         }
 
@@ -703,6 +776,111 @@ mod tests {
 
         assert_eq!(error_payload.code, -32000);
         assert_eq!(error_payload.message, "execution reverted");
+    }
+
+    /// Builds a sponsorship-declined `RpcError` from the four wire fields, mirroring what
+    /// the JSON-RPC layer produces on `-32602 sponsorship declined`. Returns the error so
+    /// each test can inspect `as_sponsorship_decline()`.
+    fn build_declined_error(code: i64, message: &str, data: Option<&str>) -> RpcError {
+        RpcError::RpcResponseError {
+            code,
+            error_message: message.to_string(),
+            data: data.map(str::to_string),
+        }
+    }
+
+    /// Happy path: `-32602` + canonical message + well-formed `data` parses to
+    /// a populated `SponsorshipDecline`.
+    #[test]
+    fn test_sponsorship_decline_parses_happy_path() {
+        let data = json!({
+            "token": "0x2cfC85d8E48F8EAB294be644d9E25C3030863003",
+            "paymasterAddress": "0x00000000000000fB866DaAa79352cC568a005D96",
+            "costNative": "0x16345785d8a0000",
+            "costToken": "0x29a2241af62c0000",
+        });
+        let err = build_declined_error(
+            -32602,
+            "sponsorship declined",
+            Some(&data.to_string()),
+        );
+
+        let decline = err
+            .as_sponsorship_decline()
+            .expect("expected a SponsorshipDecline");
+
+        assert_eq!(
+            decline.token,
+            address!("2cfC85d8E48F8EAB294be644d9E25C3030863003")
+        );
+        assert_eq!(
+            decline.paymaster_address,
+            address!("00000000000000fB866DaAa79352cC568a005D96")
+        );
+        assert_eq!(decline.cost_native, U256::from(0x0163_4578_5d8a_0000u64));
+        assert_eq!(decline.cost_token, U256::from(0x29a2_241a_f62c_0000u64));
+    }
+
+    /// A different JSON-RPC error code with the same shape is not a decline.
+    #[test]
+    fn test_sponsorship_decline_rejects_wrong_code() {
+        let data = json!({
+            "token": "0x2cfC85d8E48F8EAB294be644d9E25C3030863003",
+            "paymasterAddress": "0x00000000000000fB866DaAa79352cC568a005D96",
+            "costNative": "0x1",
+            "costToken": "0x1",
+        });
+        let err = build_declined_error(
+            -32603,
+            "sponsorship declined",
+            Some(&data.to_string()),
+        );
+        assert!(err.as_sponsorship_decline().is_none());
+    }
+
+    /// `-32602` is a generic JSON-RPC code used for many invalid-params errors,
+    /// so the message gate matters.
+    #[test]
+    fn test_sponsorship_decline_rejects_wrong_message() {
+        let data = json!({
+            "token": "0x2cfC85d8E48F8EAB294be644d9E25C3030863003",
+            "paymasterAddress": "0x00000000000000fB866DaAa79352cC568a005D96",
+            "costNative": "0x1",
+            "costToken": "0x1",
+        });
+        let err =
+            build_declined_error(-32602, "invalid params", Some(&data.to_string()));
+        assert!(err.as_sponsorship_decline().is_none());
+    }
+
+    /// Missing `data` (e.g. a malformed server response) is treated as not-a-decline
+    /// rather than panicking.
+    #[test]
+    fn test_sponsorship_decline_rejects_missing_data() {
+        let err = build_declined_error(-32602, "sponsorship declined", None);
+        assert!(err.as_sponsorship_decline().is_none());
+    }
+
+    /// `data` present but not matching the decline shape (e.g. only `token`)
+    /// returns None — we don't half-populate the struct.
+    #[test]
+    fn test_sponsorship_decline_rejects_partial_data() {
+        let data = json!({
+            "token": "0x2cfC85d8E48F8EAB294be644d9E25C3030863003",
+        });
+        let err = build_declined_error(
+            -32602,
+            "sponsorship declined",
+            Some(&data.to_string()),
+        );
+        assert!(err.as_sponsorship_decline().is_none());
+    }
+
+    /// Non-`RpcResponseError` variants never look like a decline.
+    #[test]
+    fn test_sponsorship_decline_rejects_other_error_variants() {
+        let err = RpcError::JsonError;
+        assert!(err.as_sponsorship_decline().is_none());
     }
 
     #[test]

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -280,8 +280,7 @@ impl SponsorshipContext {
 /// whether to retry as self-sponsored, and to surface the worst-case cost to
 /// the wallet UI so the user can confirm the WLD spend.
 ///
-/// Wire shape (see `bedrock/src/transactions/transaction.md` and the
-/// temporal-apps `docs/architecture/jsonrpc/sponsorship_triggers.md`):
+/// Wire shape (see `bedrock/src/transactions/transaction.md`):
 ///
 /// ```json
 /// {
@@ -305,9 +304,8 @@ pub struct SponsorshipDecline {
     pub cost_token: U256,
 }
 
-/// Sentinel error message used by the temporal-apps server when declining a
-/// sponsorship request. See `apps/jsonrpc/controllers/userop.go` (the
-/// `jsonRpcInvalidParams(..., "sponsorship declined", ...)` callsite).
+/// Sentinel error message returned by the sponsorship endpoint when
+/// declining a sponsorship request.
 const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
 
 impl RpcError {


### PR DESCRIPTION
Wires the V2 RPC primitives from #348 into an end-to-end orchestration that transaction types in transactions/mod.rs will opt into to migrate off the legacy V1 sign_and_execute. Happy path only: pm_sponsorUserOperation with SponsorshipContext::Protocol, merge gas (and any paymaster fields) into the UserOp via the new with_sponsorship_data, sign, submit via send_user_operation_v2. V1 sign_and_execute is untouched; no UniFFI export moves yet.

The JSON-RPC layer now preserves the error data field into RpcError::RpcResponseError (as a raw JSON string, kept UniFFI-liftable), and RpcError::as_sponsorship_decline parses the temporal-apps "sponsorship declined" payload (-32602 with token, paymasterAddress, costNative, costToken) into a typed SponsorshipDecline. The retry path — prepending an ERC-20 approve and re-calling with SponsorshipContext::SelfSponsoredToken — lands in the follow-up.