### PR TITLE
fix: siegel binary target

### DIFF
--- a/bedrock/tests/common.rs
+++ b/bedrock/tests/common.rs
@@ -99,7 +99,7 @@ pub fn setup_anvil() -> AnvilInstance {
     dotenvy::dotenv().ok();
     let rpc_url = std::env::var("WORLDCHAIN_RPC_URL").unwrap_or_else(|_| {
         // Fallback to a public, no-key RPC if available.
-        "https://worldchain-mainnet.g.alchemy.com/v2/demo".to_string()
+        "https://worldchain-mainnet.g.alchemy.com/public".to_string()
     });
 
     alloy::node_bindings::Anvil::new().fork(rpc_url).spawn()

--- a/swift/build_swift.sh
+++ b/swift/build_swift.sh
@@ -90,21 +90,36 @@ cargo run -p uniffi-bindgen generate \
     --no-format \
     --out-dir "$BASE_PATH"/ios_build/bindings
 
-# uniffi-bindgen emits one set of files per linked uniffi crate. Move all
-# generated Swift sources to the Sources directory and all FFI headers.
+# uniffi-bindgen emits one set of files per linked uniffi crate. Xcode 16's
+# explicit-module scanner resolves a single clang module per SPM .binaryTarget,
+# so multiple top-level FFI modules in one xcframework would leave all but one
+# unresolved. Collapse the per-crate modulemaps into one umbrella module named
+# BedrockFFI and rewrite the per-crate `import ...FFI` lines accordingly.
 shopt -s nullglob
 for swift_file in "$BASE_PATH"/ios_build/bindings/*.swift; do
+    sed -i '' -E \
+        -e 's/canImport\([a-zA-Z_][a-zA-Z0-9_]*FFI\)/canImport(BedrockFFI)/g' \
+        -e 's/^import [a-zA-Z_][a-zA-Z0-9_]*FFI$/import BedrockFFI/' \
+        "$swift_file"
     mv "$swift_file" "$SWIFT_SOURCES_DIR/"
 done
 
+{
+    echo "module BedrockFFI {"
+    for header in "$BASE_PATH"/ios_build/bindings/*FFI.h; do
+        echo "    header \"$(basename "$header")\""
+    done
+    cat <<'EOF'
+    export *
+    use "Darwin"
+    use "_Builtin_stdbool"
+    use "_Builtin_stdint"
+}
+EOF
+} >"$SWIFT_HEADERS_DIR"/module.modulemap
+
 for header in "$BASE_PATH"/ios_build/bindings/*FFI.h; do
     mv "$header" "$SWIFT_HEADERS_DIR/"
-done
-
-: >"$SWIFT_HEADERS_DIR"/module.modulemap
-for modmap in "$BASE_PATH"/ios_build/bindings/*FFI.modulemap; do
-    cat "$modmap" >>"$SWIFT_HEADERS_DIR"/module.modulemap
-    printf '\n' >>"$SWIFT_HEADERS_DIR"/module.modulemap
 done
 shopt -u nullglob
 


### PR DESCRIPTION
with xcode 16 (explicit-modules build) every C module has to resolve to a swift package manager dep, so siegelFFI wasn't found by SPM. this PR will bundle all "sub-modules" into a single top-level bedrock module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and test-infrastructure changes only; no runtime auth or on-chain logic. Risk is mainly iOS packaging regressions if sed/modulemap generation misses a crate header.
> 
> **Overview**
> Fixes Swift Package Manager integration under **Xcode 16 explicit modules**, where a single `.binaryTarget` could only resolve one Clang module—so per-crate UniFFI modules like `siegelFFI` failed to link.
> 
> The iOS build script now **collapses** all generated `*FFI` headers into one umbrella **`BedrockFFI`** `module.modulemap` (with standard Darwin/builtin uses) instead of appending multiple per-crate modulemaps. Generated Swift bindings are **rewritten** so `canImport(...FFI)` and `import ...FFI` point at **`BedrockFFI`**, matching the existing SPM binary target name.
> 
> Test Anvil fork fallback RPC is updated from Alchemy’s **`/v2/demo`** URL to **`/public`** when `WORLDCHAIN_RPC_URL` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 255308afc4c1f541a99a069db96f27692f13fc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->