### PR TITLE
chore: remove unused Morpho TransactionTypeId enum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @paolodamico @sideround @tomislavhoman @Dzejkop @Guardiola31337 @andy-t-wang @aurel-fr @murph @karankurbur
+* @paolodamico @sideround @tomislavhoman @Dzejkop @Guardiola31337 @aurel-fr @murph @karankurbur
 .github/CODEOWNERS @paolodamico @murph
-bedrock/src/smart_account/nonce.rs @aurel-fr
+bedrock/src/smart_account/nonce.rs @aurel-fr @crystalt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @paolodamico @sideround @tomislavhoman @Dzejkop @Guardiola31337 @andy-t-wang @aurel-fr @murph @karankurbur
 .github/CODEOWNERS @paolodamico @murph
+bedrock/src/smart_account/nonce.rs @aurel-fr

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -13,7 +13,7 @@ use ruint::aliases::U256;
 use crate::primitives::BEDROCK_NONCE_PREFIX_CONST;
 
 /// Stable, never-reordered identifiers for transaction classes.
-/// Changes to this enum require maintainer approval because downstream 
+/// Changes to this enum require maintainer approval because downstream
 /// systems may depend on these exact numeric values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -13,6 +13,8 @@ use ruint::aliases::U256;
 use crate::primitives::BEDROCK_NONCE_PREFIX_CONST;
 
 /// Stable, never-reordered identifiers for transaction classes.
+/// Changes to this enum require maintainer approval because downstream 
+/// systems may depend on these exact numeric values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum TransactionTypeId {
@@ -38,10 +40,6 @@ pub enum TransactionTypeId {
     ERC4626Withdraw = 134,
     /// Generic ERC-4626 redeem
     ERC4626Redeem = 135,
-    /// Morpho-specific vault deposit
-    MorphoDeposit = 136,
-    /// Morpho-specific vault withdraw
-    MorphoWithdraw = 137,
     /// ERC-20 approve for Permit2 contract
     Permit2Approve = 138,
     /// WLD Vault migration to ERC-4626 vault


### PR DESCRIPTION
This PR introduced them but never used them:
- https://github.com/worldcoin/bedrock/pull/218


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; grep shows no remaining references to the Morpho variants. Numeric IDs 136–137 are freed but were unused; the new maintainer note reflects existing stability expectations for other type IDs.
> 
> **Overview**
> Removes **`MorphoDeposit` (136)** and **`MorphoWithdraw` (137)** from `TransactionTypeId` in `bedrock/src/smart_account/nonce.rs`—variants that were added but never referenced in the codebase.
> 
> Documents that **`TransactionTypeId` numeric values are stable** and that changes need maintainer approval because downstream systems may depend on them.
> 
> Adds **CODEOWNERS** for `bedrock/src/smart_account/nonce.rs` (`@aurel-fr`) and fixes the `.github/CODEOWNERS` line formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d1043e177c77b04d2bc263f59b1519397b5561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->