### PR TITLE
chore: add gzip feature to reqwest

### DIFF
--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -66,7 +66,7 @@ p256 = { version = "0.13.2", default-features = false, features = [
 ] }
 p384 = { version = "0.13", default-features = false, features = ["ecdsa", "sha384"] }
 rand = { version = "0.8.5", default-features = false, features = ["std"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "rustls-tls"] }
 ruint = { version = "1.16.0", default-features = false, features = ["serde"] }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = "1.0.219"

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -66,7 +66,10 @@ p256 = { version = "0.13.2", default-features = false, features = [
 ] }
 p384 = { version = "0.13", default-features = false, features = ["ecdsa", "sha384"] }
 rand = { version = "0.8.5", default-features = false, features = ["std"] }
-reqwest = { version = "0.12", default-features = false, features = ["gzip", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "gzip",
+  "rustls-tls",
+] }
 ruint = { version = "1.16.0", default-features = false, features = ["serde"] }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = "1.0.219"

--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -66,6 +66,7 @@ async fn post_json_rpc_to_url(url: &str, body: Vec<u8>) -> Result<Vec<u8>, RpcEr
         reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
             .redirect(reqwest::redirect::Policy::none())
+            .gzip(true)
             .build()
             .map_err(|e| {
                 RpcError::HttpError(format!(


### PR DESCRIPTION
https://docs.rs/reqwest/latest/reqwest/#optional-features

> gzip: Provides response body gzip decompression.

https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.gzip

> If the `gzip` feature is turned on, the default option is enabled.

I ran this: `cargo add reqwest@0.12 --features rustls-tls,gzip --no-default-features -p bedrock`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency feature flag plus explicit client builder option for response decompression only; no auth, signing, or request payload changes.
> 
> **Overview**
> Enables **automatic gzip decompression** on bundler JSON-RPC responses by turning on reqwest’s `gzip` feature and calling `.gzip(true)` on the shared client in `custom_bundler`.
> 
> Bundlers that return `Content-Encoding: gzip` should now parse correctly instead of failing JSON-RPC handling on compressed bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb3fb2f00f9a4adec6b1b2f1966eb2105c2c30a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->