### PR TITLE
chore: bump anyhow to address RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"

--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -99,7 +99,7 @@ async fn post_json_rpc_to_url(url: &str, body: Vec<u8>) -> Result<Vec<u8>, RpcEr
     Ok(bytes.to_vec())
 }
 
-// ── Parsing helper ─────────────────────────────────────────────────────────────
+// ── Parsing helper ────────────────────────────────────────────────────────────
 
 /// Parses a JSON-RPC response, extracting the `result` field or surfacing the `error`.
 fn parse_json_rpc_response(response_bytes: &[u8]) -> Result<Value, RpcError> {

--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -99,7 +99,7 @@ async fn post_json_rpc_to_url(url: &str, body: Vec<u8>) -> Result<Vec<u8>, RpcEr
     Ok(bytes.to_vec())
 }
 
-// ── Parsing helper ────────────────────────────────────────────────────────────
+// ── Parsing helper ─────────────────────────────────────────────────────────────
 
 /// Parses a JSON-RPC response, extracting the `result` field or surfacing the `error`.
 fn parse_json_rpc_response(response_bytes: &[u8]) -> Result<Value, RpcError> {


### PR DESCRIPTION
We saw `cargo deny` in CI: https://github.com/worldcoin/bedrock/actions/runs/28540313977/job/84612149167?pr=382

```
anyhow 1.0.102 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
   │
   ├ ID: RUSTSEC-2026-0190
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0190
   ├ Affected versions of this crate violate borrow rules, resulting in undefined behavior, when the user adds context to an error via `Error::context` and then later calls `Error::downcast_mut` on the returned `Error`.
...
   ├ Announcement: https://github.com/dtolnay/anyhow/issues/451
   ├ Solution: Upgrade to >=1.0.103 (try `cargo update -p anyhow`)
   ├ anyhow v1.0.102
```

This PR bumps `anyhow` from 1.0.102 to 1.0.103 to address this. 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only patch dependency bump with no code changes; typical low-risk maintenance.
> 
> **Overview**
> Updates the lockfile so the **`anyhow`** dependency moves from **1.0.102** to **1.0.103**, with the corresponding registry checksum change. No application or library source files are modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfd2f7ffdc6df2a573b9b069accf536de5d435c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->