### PR TITLE
feat: add is_json detail to KeyParseError

### DIFF
--- a/bedrock/src/root_key/mod.rs
+++ b/bedrock/src/root_key/mod.rs
@@ -15,8 +15,8 @@ type KeyType = [u8; KEY_LENGTH];
 #[bedrock_error]
 pub enum RootKeyError {
     /// The provided input is likely not an actual `RootKey`. It is malformed or not the right format.
-    #[error("failed to parse key")]
-    KeyParseError,
+    #[error("failed to parse key. is_json: {is_json}")]
+    KeyParseError { is_json: bool },
     /// Key derivation unexpectedly fail
     #[error("key derivation failure: {0}")]
     KeyDerivation(String),
@@ -106,8 +106,11 @@ impl RootKey {
     #[uniffi::constructor]
     pub fn from_json(json_str: &str) -> Result<Self, RootKeyError> {
         // no need to zeroize `key` because it's moved into the `SecretBox`
-        let key: VersionedKey =
-            serde_json::from_str(json_str).map_err(|_| RootKeyError::KeyParseError)?;
+        let key: VersionedKey = serde_json::from_str(json_str).map_err(|e| {
+            RootKeyError::KeyParseError {
+                is_json: e.is_data(),
+            }
+        })?;
 
         Ok(Self {
             inner: SecretBox::new(Box::new(key)),


### PR DESCRIPTION
When a KeyParseError is encountered, it's helpful to know if the error stems from a completely invalid JSON or a wrong parsing for a specific struct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-type shape change for RootKey JSON parsing only; no crypto or key-handling logic changes.
> 
> **Overview**
> **`RootKeyError::KeyParseError`** is now a struct variant carrying **`is_json`**, and the display message includes that flag so callers can tell invalid JSON syntax from JSON that parses but does not match **`VersionedKey`**.
> 
> **`RootKey::from_json`** maps **`serde_json`** failures with **`e.is_data()`** into **`is_json`** instead of returning a unit **`KeyParseError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e93dfce26d0609bd12754020eb93ef51ed8acc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->