### PR TITLE
feat: document rpc details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Run tests
         env:
+          # Details in http://go/rpc-ci-account (
           WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://worldchain-mainnet.g.alchemy.com/public' }}
         run: |
           cp .env.example .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run tests
         env:
-          # Details in http://go/rpc-ci-account (
+          # Details in http://go/rpc-ci-account (`bedrock` app)
           WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://worldchain-mainnet.g.alchemy.com/public' }}
         run: |
           cp .env.example .env


### PR DESCRIPTION
Add link with more info on RPC details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in GitHub Actions; no runtime or secret behavior changes.
> 
> **Overview**
> Adds an inline comment in the CI **Tests** job explaining where to find details about the `WORLDCHAIN_RPC_URL` secret (internal link `http://go/rpc-ci-account`, `bedrock` app). No change to how tests run or which RPC URL is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181a94e0a2303549e23ef5b52128775e601ea7f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->