### PR TITLE
feat: introduce sandbox environment support

### DIFF
--- a/bedrock/src/nitro_enclave/mod.rs
+++ b/bedrock/src/nitro_enclave/mod.rs
@@ -15,7 +15,7 @@ use crate::primitives::config::{get_config, BedrockEnvironment};
 /// Constants for enclave verification
 pub mod constants;
 
-/// Types for enclave verification  
+/// Types for enclave verification
 pub mod types;
 
 #[cfg(test)]
@@ -37,7 +37,7 @@ use constants::{
 /// This class performs comprehensive verification of attestation documents including:
 /// - COSE Sign1 signature verification
 /// - Certificate chain validation against AWS Nitro root certificates
-/// - PCR (Platform Configuration Register) value validation  
+/// - PCR (Platform Configuration Register) value validation
 /// - Attestation document freshness checks
 /// - Public key extraction
 #[derive(Debug, uniffi::Object)]
@@ -78,14 +78,16 @@ impl EnclaveAttestationVerifier {
             BedrockEnvironment::Production => {
                 production_pcr_configs(&EnclaveApplication::WorldChatNotifications)
             }
-            BedrockEnvironment::Staging => {
+            BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
                 staging_pcr_configs(&EnclaveApplication::WorldChatNotifications)
             }
         };
 
         let root_certificate = match env {
             BedrockEnvironment::Production => AWS_NITRO_ROOT_CERT_PROD.to_vec(),
-            BedrockEnvironment::Staging => AWS_NITRO_ROOT_CERT_STAGING.to_vec(),
+            BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
+                AWS_NITRO_ROOT_CERT_STAGING.to_vec()
+            }
         };
 
         Self {

--- a/bedrock/src/primitives/config.rs
+++ b/bedrock/src/primitives/config.rs
@@ -9,8 +9,16 @@ static CONFIG_INSTANCE: OnceLock<Arc<BedrockConfig>> = OnceLock::new();
 /// Represents the environment for Bedrock operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum BedrockEnvironment {
-    /// Staging environment  
+    /// Staging environment
     Staging,
+    /// The sandbox environment is an externally available and reliable environment,
+    /// and with a set of tools that allows breaking boxes and testing anything.
+    ///
+    /// The sandbox environment is available for TFH Apps (World App, World ID), and uses
+    /// the `staging` environment of the World ID Protocol.
+    ///
+    /// Reference: <http://go/sandbox>
+    Sandbox,
     /// Production environment
     Production,
 }
@@ -43,6 +51,7 @@ impl BedrockEnvironment {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Staging => "staging",
+            Self::Sandbox => "sandbox",
             Self::Production => "production",
         }
     }

--- a/bedrock/src/transactions/contracts/world_gift_manager.rs
+++ b/bedrock/src/transactions/contracts/world_gift_manager.rs
@@ -24,7 +24,7 @@ use crate::{
 #[must_use]
 pub fn world_gift_manager_address() -> Address {
     match current_environment_or_default() {
-        BedrockEnvironment::Staging => {
+        BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
             address!("0x91479943841A4350f614Abb9745314F262F45b2e")
         }
         BedrockEnvironment::Production => {

--- a/bedrock/tests/common.rs
+++ b/bedrock/tests/common.rs
@@ -224,7 +224,7 @@ where
 /// Reference <https://github.com/worldcoin/worldcoin-vault/blob/main/src/WorldIDAddressBook.sol>
 fn address_book_address() -> Address {
     match current_environment_or_default() {
-        BedrockEnvironment::Staging => {
+        BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
             Address::from_str("0xfd5b7aefdd478f34ae61d8399a206a4879f0af0a")
                 .expect("failed to decode staging address book address")
         }


### PR DESCRIPTION
Fairly explanatory. Reference project linked in the code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public enum variant affects all clients via UniFFI; misconfigured sandbox could point at wrong contracts or attestation trust if other env matches were missed (this diff only updates the sites shown).
> 
> **Overview**
> Adds a third **`BedrockEnvironment::Sandbox`** value (UniFFI-exposed) with wire string `"sandbox"` and docs describing it as an external TFH testing environment that still uses World ID **staging** protocol settings.
> 
> **Sandbox is treated like staging** everywhere this PR touches environment branching: Nitro enclave attestation uses staging PCR configs and the staging AWS Nitro root cert; **`world_gift_manager_address`** and test helper **`address_book_address`** resolve to the same contract addresses as staging.
> 
> Minor comment whitespace fixes in `nitro_enclave/mod.rs` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed7f07d9777f80a2617afd89408992bd5e121e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->