### PR TITLE
fix: match exact uniffi dependency name

### DIFF
--- a/.github/actions/version-alignment/check_uniffi_version.py
+++ b/.github/actions/version-alignment/check_uniffi_version.py
@@ -23,8 +23,9 @@ def find_uniffi_version(content: str) -> Optional[str]:
     #   plain string:   uniffi = "0.31.0"
     #   inline table:   uniffi = { version = "0.31.0", ... }
     match = re.search(
-        r'uniffi\s*=\s*(?:"([^"]+)"|\{[^}]*version\s*=\s*"([^"]+)")',
+        r'^\s*uniffi\s*=\s*(?:"([^"]+)"|\{[^}]*version\s*=\s*"([^"]+)")',
         content,
+        re.MULTILINE,
     )
     if not match:
         return None
@@ -121,6 +122,13 @@ uniffi = "0.31.0"
         cargo_toml = """
 [workspace.dependencies]
 uniffi = { git = "https://github.com/mozilla/uniffi-rs" }
+"""
+        self.assertIsNone(find_uniffi_version(cargo_toml))
+
+    def test_ignores_dependency_names_ending_in_uniffi(self):
+        cargo_toml = """
+[workspace.dependencies]
+ruint-uniffi = "0.1"
 """
         self.assertIsNone(find_uniffi_version(cargo_toml))
 


### PR DESCRIPTION
## Summary
- anchor the UniFFI dependency matcher to the start of a TOML assignment
- prevent crates such as `ruint-uniffi` from being treated as `uniffi`
- add regression coverage

## Testing
- `python3 .github/actions/version-alignment/check_uniffi_version.py test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only regex fix in a version check script with unit tests; no runtime or product code paths.
> 
> **Overview**
> Tightens the **UniFFI version alignment** check so only a top-level `uniffi = …` assignment in `Cargo.toml` is parsed, not keys that merely end with `uniffi` (e.g. `ruint-uniffi`).
> 
> `find_uniffi_version` now uses a **line-anchored** regex (`^\s*uniffi\s*=`) with `re.MULTILINE`, keeping support for plain string and inline-table `version` forms. A regression test asserts that `ruint-uniffi = "0.1"` does not produce a version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669250b9ac06be58cf02e75b0ec4d4b4c1f41943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->