### PR TITLE
fix: XCFramework module lookup for Xcode 26.4+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
           cargo install taplo-cli
           taplo fmt --check
 
-  swift-build-and-test:
-    name: Build and Test Swift Bindings
-    runs-on: macos-14
+  swift-build:
+    name: Build Swift
+    runs-on: macos-26
     permissions:
       contents: read
 
@@ -67,19 +67,64 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Ensure a specific Xcode version is selected to match available simulators
-      - name: Select Xcode 16.2
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "16.2"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
 
-      - name: Build and test Swift bindings
-        run: cargo xtask swift test
+      - name: Build Swift bindings
+        run: cargo xtask swift build
+
+      - name: Upload Swift build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bedrock-swift-build
+          path: |
+            swift/Bedrock.xcframework
+            swift/Sources/Bedrock
+          retention-days: 1
+
+  swift-test:
+    name: Swift Foreign Binding Tests (Xcode ${{ matrix.xcode-version }})
+    needs: swift-build
+    runs-on: macos-26
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Update as GitHub's runner image adds/drops Xcode versions:
+        # actions/runner-images macos-26-arm64-Readme.md. If a version fails
+        # with a missing-SDK/platform error, just drop it from this list.
+        xcode-version:
+          - "26.2"
+          - "26.3"
+          - "26.4.1"
+          - "26.5"
+          - "26.6"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ matrix.xcode-version }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Download Swift build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bedrock-swift-build
+          path: swift
+
+      - name: Run Swift foreign binding tests
+        run: cargo xtask swift run-tests
 
       - name: Install SwiftLint
         run: |
@@ -146,7 +191,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,6 +45,8 @@ enum SwiftCmd {
     Local,
     /// Build bindings and run the foreign Swift test suite on a simulator.
     Test,
+    /// Run the foreign Swift test suite against an already-built `Bedrock.xcframework`.
+    RunTests,
     /// Emit `Package.swift` referencing a hosted xcframework asset.
     Archive {
         #[arg(long)]
@@ -84,6 +86,7 @@ fn main() -> Result<()> {
             SwiftCmd::Build { out_dir } => swift::build(out_dir.as_deref()),
             SwiftCmd::Local => swift::local(),
             SwiftCmd::Test => swift::test(),
+            SwiftCmd::RunTests => swift::run_tests(),
             SwiftCmd::Archive {
                 asset_url,
                 checksum,

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -16,6 +16,7 @@ const IOS_TARGETS: &[&str] = &[
     "aarch64-apple-ios",
     "x86_64-apple-ios",
 ];
+const FRAMEWORK_NAME: &str = "BedrockFFI";
 
 /// Absolute path to the `swift/` directory inside the workspace.
 fn swift_dir() -> PathBuf {
@@ -66,7 +67,8 @@ pub fn build(out_dir: Option<&Path>) -> Result<()> {
     create_xcframework(
         &root.join("target/aarch64-apple-ios/release/libbedrock.a"),
         &sim_universal,
-        &ios_build.join("Headers"),
+        &headers_dir,
+        &ios_build.join("Frameworks"),
         &framework_out,
     )?;
 
@@ -161,27 +163,79 @@ fn assemble_ffi_module(
     Ok(())
 }
 
-/// Invoke `xcodebuild -create-xcframework` with the device and simulator slices.
+/// Assemble both platform slices as real `BedrockFFI.framework` bundles and hand them to
+/// `xcodebuild -create-xcframework`.
 fn create_xcframework(
     device_lib: &Path,
     sim_lib: &Path,
-    headers: &Path,
+    headers_dir: &Path,
+    frameworks_dir: &Path,
     out: &Path,
 ) -> Result<()> {
     println!("Creating XCFramework...");
+    let device_framework = frameworks_dir
+        .join("ios-arm64")
+        .join(format!("{FRAMEWORK_NAME}.framework"));
+    let sim_framework = frameworks_dir
+        .join("ios-arm64_x86_64-simulator")
+        .join(format!("{FRAMEWORK_NAME}.framework"));
+
+    make_framework(&device_framework, device_lib, "iPhoneOS", headers_dir)?;
+    make_framework(&sim_framework, sim_lib, "iPhoneSimulator", headers_dir)?;
+
     run(Command::new("xcodebuild")
         .arg("-create-xcframework")
-        .arg("-library")
-        .arg(device_lib)
-        .arg("-headers")
-        .arg(headers)
-        .arg("-library")
-        .arg(sim_lib)
-        .arg("-headers")
-        .arg(headers)
+        .arg("-framework")
+        .arg(&device_framework)
+        .arg("-framework")
+        .arg(&sim_framework)
         .arg("-output")
         .arg(out))?;
     Ok(())
+}
+
+/// Assemble one `BedrockFFI.framework` slice from a static library and the umbrella
+/// header/modulemap, as a real framework bundle (`Headers/`, `Modules/module.modulemap`,
+/// `Info.plist`) rather than a flat headers dir.
+fn make_framework(
+    framework_dir: &Path,
+    static_lib: &Path,
+    platform: &str,
+    headers_dir: &Path,
+) -> Result<()> {
+    reset_dir(framework_dir)?;
+    let headers_out = framework_dir.join("Headers");
+    let modules_out = framework_dir.join("Modules");
+    std::fs::create_dir_all(&headers_out)?;
+    std::fs::create_dir_all(&modules_out)?;
+
+    std::fs::copy(static_lib, framework_dir.join(FRAMEWORK_NAME))?;
+
+    for entry in std::fs::read_dir(headers_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension() == Some(OsStr::new("h")) {
+            std::fs::copy(&path, headers_out.join(path.file_name().expect("named")))?;
+        }
+    }
+    std::fs::copy(
+        headers_dir.join("module.modulemap"),
+        modules_out.join("module.modulemap"),
+    )?;
+
+    std::fs::write(
+        framework_dir.join("Info.plist"),
+        framework_info_plist(FRAMEWORK_NAME, platform),
+    )?;
+    Ok(())
+}
+
+/// Render an `Info.plist` for a static-library framework bundle.
+fn framework_info_plist(name: &str, platform: &str) -> String {
+    include_str!("templates/swift_framework_info.plist")
+        .replace("__NAME__", name)
+        .replace("__PLATFORM__", platform)
+        .replace("__IOS_DEPLOYMENT_TARGET__", IOS_DEPLOYMENT_TARGET)
 }
 
 /// Move each generated `.swift` file into `sources_dir`, rewriting the
@@ -209,9 +263,12 @@ fn rewrite_swift_imports(bindings_dir: &Path, sources_dir: &Path) -> Result<()> 
     Ok(())
 }
 
-/// Emit a clang modulemap declaring a single `BedrockFFI` module over all FFI headers.
+/// Emit a clang modulemap declaring a single `BedrockFFI` framework module over all FFI
+/// headers. Declared as a `framework module` (rather than a plain `module`) because this
+/// modulemap is only ever consumed from inside the real `BedrockFFI.framework` bundle built by
+/// `make_framework`.
 fn write_umbrella_modulemap(path: &Path, headers: &[String]) -> Result<()> {
-    let mut out = String::from("module BedrockFFI {\n");
+    let mut out = String::from("framework module BedrockFFI {\n");
     for h in headers {
         writeln!(out, "    header \"{h}\"").expect("writing to String is infallible");
     }
@@ -312,6 +369,13 @@ pub fn archive(asset_url: &str, checksum: &str, release_version: &str) -> Result
 
 /// Build the bindings and run the foreign Swift test suite on an iOS simulator.
 pub fn test() -> Result<()> {
+    println!("🔨 Building Swift bindings");
+    build(None)?;
+    run_tests()
+}
+
+/// Run the foreign Swift test suite against an already-built `Bedrock.xcframework`
+pub fn run_tests() -> Result<()> {
     let swift = swift_dir();
     let tests = swift.join("tests");
 
@@ -320,12 +384,12 @@ pub fn test() -> Result<()> {
         bail!("No iOS Simulator SDK installed. Available SDKs:\n{sdks}");
     }
 
-    println!("🔨 Building Swift bindings");
-    build(None)?;
-
     let framework = swift.join("Bedrock.xcframework");
     if !framework.exists() {
-        bail!("Failed to build XCFramework at {}", framework.display());
+        bail!(
+            "Bedrock.xcframework not found at {} — run `cargo xtask swift build` first",
+            framework.display()
+        );
     }
 
     println!("📦 Copying generated Swift files to test package");
@@ -589,5 +653,35 @@ mod tests {
         let line = "    .package(url: \"https://github.com/worldcoin/bedrock-swift\", exact: \"0.4.0\")\n";
         let out = rewrite_consumer_package(line, Path::new("/tmp/local"));
         assert_eq!(out, "    .package(path: \"/tmp/local\"),\n");
+    }
+
+    #[test]
+    fn umbrella_modulemap_declares_a_framework_module() {
+        let dir = std::env::temp_dir().join("bedrock_swift_test_umbrella_modulemap");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("module.modulemap");
+        write_umbrella_modulemap(
+            &path,
+            &["bedrockFFI.h".to_owned(), "siegel_uniffiFFI.h".to_owned()],
+        )
+        .unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+
+        assert!(contents.starts_with("framework module BedrockFFI {\n"));
+        assert!(contents.contains("header \"bedrockFFI.h\"\n"));
+        assert!(contents.contains("header \"siegel_uniffiFFI.h\"\n"));
+    }
+
+    #[test]
+    fn framework_info_plist_sets_executable_and_platform() {
+        let plist = framework_info_plist("BedrockFFI", "iPhoneSimulator");
+        assert!(plist
+            .contains("<key>CFBundleExecutable</key>\n\t<string>BedrockFFI</string>"));
+        assert!(
+            plist.contains("<key>CFBundlePackageType</key>\n\t<string>FMWK</string>")
+        );
+        assert!(plist.contains("<string>iPhoneSimulator</string>"));
+        assert!(plist.contains(&format!("<string>{IOS_DEPLOYMENT_TARGET}</string>")));
     }
 }

--- a/xtask/src/templates/swift_framework_info.plist
+++ b/xtask/src/templates/swift_framework_info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>__NAME__</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.worldcoin.__NAME__</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>__NAME__</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>__PLATFORM__</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>__IOS_DEPLOYMENT_TARGET__</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Why
- Xcode 26.4+ disabled the implicit subdirectory modulemap scan that `-library/-headers` xcframework assembly relied on, breaking `BedrockFFI` module lookup for downstream consumers
- CI is pinned to Xcode 16.2, so it stayed green while consumers on newer Xcode would break — reproduced locally by stashing this fix and running the foreign test suite under Xcode 26.6 (`cannot find type 'RustBuffer' in scope`)
- Reimplements walletkit's equivalent fix (worldcoin/walletkit#440) against bedrock's Rust build tooling (`xtask/src/swift.rs`) instead of shell scripts

## What
- `create_xcframework` / new `make_framework` in `xtask/src/swift.rs` assemble a real `BedrockFFI.framework` bundle (`Headers/`, `Modules/module.modulemap`, `Info.plist`) per platform slice; `xcodebuild -create-xcframework` now takes `-framework` instead of `-library/-headers`
- `write_umbrella_modulemap` now declares a `framework module` instead of a plain `module`
- Split `swift::test()` into `test()` (build + run) and a new `run_tests()`; added `cargo xtask swift run-tests` so CI can build once and re-verify across an Xcode matrix without repeating the Rust cross-compile
- CI restructured into `swift-build` (single build + upload artifact) and `swift-test` (matrix over Xcode 26.2, 26.3, 26.4.1, 26.5, 26.6; downloads artifact, runs tests + SwiftLint)

## Risk
- Build-tooling only change; no Rust/runtime logic touched
- `Bedrock.xcframework` output name and `BedrockFFI` module name unchanged, so no consumer-facing API break
- Verified locally on Xcode 26.3 and 26.6: with this fix reverted (stashed), the foreign Swift test suite fails to compile under 26.6; with the fix, all 40 tests pass on both versions
- Added unit tests for the new pure logic (`framework_info_plist`, `write_umbrella_modulemap`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packaging-only but changes every Swift consumer’s xcframework layout; wrong bundles would break imports at compile time, though Rust runtime logic is untouched.
> 
> **Overview**
> Fixes **BedrockFFI** module resolution on Xcode 26.4+ by changing how `Bedrock.xcframework` is assembled in `xtask/src/swift.rs`. Instead of `xcodebuild -create-xcframework` with `-library/-headers` (which depended on Clang’s implicit modulemap search), the build now produces per-slice **`BedrockFFI.framework`** bundles via new **`make_framework`** (`Headers/`, `Modules/module.modulemap`, `Info.plist`) and passes them with **`-framework`**. The umbrella **`module.modulemap`** is now a **`framework module BedrockFFI`**.
> 
> Adds **`cargo xtask swift run-tests`** and splits **`swift::test()`** so CI can build once and only re-run simulator tests. **CI** replaces the single macOS/Xcode 16.2 Swift job with **`swift-build`** (artifact upload) plus **`swift-test`** on **macos-26** across Xcode **26.2–26.6**, and pins Kotlin’s checkout action to a specific SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba655214468f64ad6349bed14d2c6c711748755c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->