### PR TITLE
feat!: stamping with backup account key

### DIFF
--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -386,7 +386,7 @@ impl BackupManager {
         &self,
         root_secret: Arc<SiegelSession>,
     ) -> Result<BackupAccount, BackupError> {
-        Self::with_root_key(root_secret, |root_key| Self::backup_account(root_key))
+        Self::with_root_key(root_secret, Self::backup_account)
     }
 
     /// Should be called after the backup is disabled/deleted.

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -181,8 +181,6 @@ impl BackupManager {
     /// * `factor_secret` - is the factor secret that was used to encrypt the backup keypair. Hex encoded.
     /// * `factor_type` - is the type of factor that was used to encrypt the backup keypair.
     ///   It should mark what kind of key `factor_secret` is.
-    /// * `current_manifest_hash` - hex-encoded 32-byte blake3 hash of the manifest head at the time
-    ///   the fetched backup was created (returned by the remote and provided by the native layer).
     ///
     /// # Errors
     /// * `BackupError::DecodeFactorSecretError` - if the factor secret is invalid, e.g. not hex encoded.
@@ -204,7 +202,6 @@ impl BackupManager {
         encrypted_backup_keypair: String,
         factor_secret: String,
         factor_type: FactorType,
-        current_manifest_hash: &str,
     ) -> Result<DecryptedBackup, BackupError> {
         crate::info!("Decrypting sealed backup with factor: {factor_type:?}");
 
@@ -239,7 +236,7 @@ impl BackupManager {
 
         crate::info!("Backup successfully decrypted, initiating unpacking.");
 
-        Self::unpack_backup_to_filesystem(&unsealed_backup, current_manifest_hash)?;
+        Self::unpack_backup_to_filesystem(&unsealed_backup)?;
 
         crate::info!("Backup successfully unpacked to filesystem.");
 
@@ -569,7 +566,6 @@ impl BackupManager {
 
     fn unpack_backup_to_filesystem(
         unsealed_backup: &BackupFormat,
-        current_manifest_hash_hex: &str,
     ) -> Result<(), BackupError> {
         let BackupFormat::V0(backup) = unsealed_backup;
 

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -630,10 +630,9 @@ impl BackupManager {
             files: manifest_entries,
         });
 
-        crate::info!(
-            "Saving manifest file with {} files and hash: {} (current hash: {current_manifest_hash_hex})",
+        crate::debug!(
+            "Saving manifest file with {} files",
             manifest.entries_length(),
-            hex::encode(manifest.to_hash()?)
         );
 
         let manifest_manager = ManifestManager::new();

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -23,6 +23,8 @@ pub use client_events::{
 };
 use k256::ecdsa::{signature::Signer, Signature, SigningKey};
 pub use manifest::ManifestManager;
+use siegel_uniffi::SiegelSession;
+use std::sync::Arc;
 
 use crate::backup::backup_format::v0::{
     V0Backup, V0BackupManifest, V0BackupManifestEntry,
@@ -94,17 +96,14 @@ impl BackupManager {
         );
 
         // 1: Decode the root secret from multiple formats
+        // TODO: Migrate to Siegel
         let root_key = RootKey::from_json(root_secret).map_err(|_| {
             BackupError::InvalidRootSecretError(format!(
                 "attempting to add an invalid secret to a new backup: {}",
                 root_secret.chars().next().unwrap_or_default() == '{'
             ))
         })?;
-        let backup_account_id =
-            root_key.derive_public_backup_account_id().map_err(|e| {
-                let msg = format!("Unexpected. Deriving public backup id: {e:?}");
-                BackupError::Generic { error_message: msg }
-            })?;
+        let backup_account_id = Self::backup_account(&root_key)?.id;
 
         // 2.1: Decode factor secret from hex
         let factor_secret_bytes = hex::decode(factor_secret)
@@ -376,6 +375,20 @@ impl BackupManager {
         Ok(STANDARD.encode(sig.to_der()))
     }
 
+    /// Returns the backup account public key and fully qualified id.
+    ///
+    /// # Errors
+    /// * `BackupError::InvalidRootSecretError` - if the session is not valid UTF-8 or the
+    ///   root secret cannot be parsed.
+    /// * `BackupError::Generic` - if the Siegel session cannot be read or key derivation
+    ///   fails.
+    pub fn get_backup_account(
+        &self,
+        root_secret: Arc<SiegelSession>,
+    ) -> Result<BackupAccount, BackupError> {
+        Self::with_root_key(root_secret, |root_key| Self::backup_account(root_key))
+    }
+
     /// Should be called after the backup is disabled/deleted.
     ///
     /// It processes local state after the backup is disabled/deleted.
@@ -514,6 +527,46 @@ pub struct ManifestDebug {
 
 // Internal helpers (not exported)
 impl BackupManager {
+    /// Reads the root secret out of a one-shot Siegel session, parses it into a
+    /// [`RootKey`], and hands it to `f`.
+    fn with_root_key<T>(
+        root_secret: Arc<SiegelSession>,
+        f: impl FnOnce(&RootKey) -> Result<T, BackupError>,
+    ) -> Result<T, BackupError> {
+        let result = root_secret.read_once(|bytes| {
+            let root_key = RootKey::from_slice(bytes).map_err(|_| {
+                BackupError::InvalidRootSecretError(
+                    "failed to parse root secret from siegel session".to_string(),
+                )
+            })?;
+            f(&root_key)
+        });
+
+        // `read_once` already wiped the loaded secret; take ownership specifically so we
+        // release the secure-memory session here rather than deferring to the caller.
+        drop(root_secret);
+
+        result.map_err(|e| BackupError::Generic {
+            error_message: format!("siegel session read failed: {e}"),
+        })?
+    }
+
+    /// Computes the backup account id and public key from the [`RootKey`].
+    fn backup_account(root_key: &RootKey) -> Result<BackupAccount, BackupError> {
+        let public_key = root_key.derive_public_backup_account_key().map_err(|e| {
+            BackupError::Generic {
+                error_message: format!(
+                    "unexpected. deriving backup account public key: {e:?}"
+                ),
+            }
+        })?;
+
+        Ok(BackupAccount {
+            id: format!("backup_account_{public_key}"),
+            public_key,
+        })
+    }
+
     fn unpack_backup_to_filesystem(
         unsealed_backup: &BackupFormat,
         current_manifest_hash_hex: &str,
@@ -821,4 +874,16 @@ pub enum FactorType {
     IcloudKeychain,
     /// Generated randomly and stored in Turnkey.
     Turnkey,
+}
+
+/// A representation of the Backup Account and its id.
+#[derive(Debug, uniffi::Record)]
+pub struct BackupAccount {
+    /// The full identifier of the backup account. This is the identifier used with
+    /// the remote backup-service.
+    id: String,
+    /// The underlying public key of the backup account. Hex-encoded SEC.1 compressed point.
+    ///
+    /// This public key can be used to authenticate with a specific backup.
+    public_key: String,
 }

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -940,7 +940,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             prf_result.clone(),
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 
@@ -967,7 +966,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             create_result.encrypted_backup_keypair.clone(),
             incorrect_factor_secret,
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .expect_err("Expected decryption to fail with incorrect factor secret");
     assert_eq!(
@@ -988,7 +986,6 @@ fn test_decrypt_sealed_backup_with_prf() {
             incorrect_encrypted_backup_keypair,
             prf_result,
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .expect_err(
             "Expected decryption to fail with incorrect encrypted backup keypair",
@@ -1028,7 +1025,6 @@ async fn test_decrypt_and_unpack_default_manifest_hash() {
             create_result.encrypted_backup_keypair.clone(),
             prf_result,
             FactorType::Prf,
-            &create_result.manifest_hash,
         )
         .unwrap();
 
@@ -1090,7 +1086,6 @@ fn test_unpack_writes_files_and_manifest() {
             hex::encode(encrypted_backup_keypair),
             hex::encode(factor_sk.to_bytes()),
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 
@@ -1174,7 +1169,6 @@ fn test_unpack_writes_files_and_manifest_unicode() {
             hex::encode(encrypted_backup_keypair),
             hex::encode(factor_sk.to_bytes()),
             FactorType::Prf,
-            BackupManifest::default_hash_hex(),
         )
         .unwrap();
 

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -13,13 +13,29 @@ use crate::primitives::filesystem::{
 };
 use crate::primitives::filesystem::{set_filesystem, InMemoryFileSystem};
 use crate::root_key::RootKey;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use crypto_box::{PublicKey, SecretKey};
 use k256::ecdsa::signature::Verifier;
 use k256::ecdsa::{Signature, VerifyingKey};
 use serial_test::serial;
+use siegel_uniffi::{siegel_fill, SiegelSession, FILL_OK};
 use std::str::FromStr;
 use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
+
+/// Wraps a string in a one-shot [`SiegelSession`], mirroring how the foreign key store
+/// delivers the root secret to `BackupManager` at runtime.
+fn siegel_from_str(secret: &str) -> Arc<SiegelSession> {
+    let bytes = secret.as_bytes();
+    let len = u32::try_from(bytes.len()).expect("secret len must fit in u32");
+    let session = SiegelSession::new(len).expect("failed to create siegel session");
+    // SAFETY: `session` was just allocated with capacity `len == bytes.len()`, `bytes`
+    // is owned by the caller and valid for `len` reads for the duration of this call.
+    let rc = unsafe { siegel_fill(session.handle_id(), bytes.as_ptr(), bytes.len()) };
+    assert_eq!(rc, FILL_OK, "siegel_fill failed with code {rc}");
+    session
+}
 
 fn ensure_fs_initialized() {
     if crate::primitives::filesystem::get_filesystem_raw().is_err() {
@@ -1316,5 +1332,118 @@ fn test_sign_with_backup_account_key_invalid_root_secret() {
         .sign_with_backup_account_key("not json", b"challenge")
         .expect_err("should fail with invalid root secret");
 
+    assert!(err.to_string().contains("Invalid root secret"));
+}
+
+// SECTION: Turnkey backup-account stamp tests
+
+fn known_root_secret() -> String {
+    format!("{{\"version\":\"V1\",\"key\":\"{}\"}}", "1".repeat(64))
+}
+
+/// Compressed SEC1 hex of the backup-account public key derived from
+/// [`known_root_secret`]. Cross-checked against `test_derive_public_backup_account_key`.
+///
+/// NOTE this is **NOT** a sensitive value, it's a public key for a test key.
+const KNOWN_BACKUP_ACCOUNT_PUBLIC_KEY: &str =
+    "039797dc9fec4e3d3f2f27173ba0faac160ee2f803954e8552c308da22ab40ab5c";
+
+#[test]
+fn test_get_backup_account_returns_public_key() {
+    let manager = BackupManager::new();
+    let root_secret = known_root_secret();
+
+    let account = manager
+        .get_backup_account(siegel_from_str(&root_secret))
+        .expect("deriving backup account should succeed");
+
+    // Turnkey's `API_KEY_CURVE_SECP256K1` expects compressed SEC1 hex: 66 chars, no `0x`,
+    // leading `02`/`03` parity byte.
+    assert_eq!(account.public_key.len(), 66);
+    assert!(
+        account.public_key.starts_with("02") || account.public_key.starts_with("03")
+    );
+    assert!(account.public_key.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(account.public_key, KNOWN_BACKUP_ACCOUNT_PUBLIC_KEY);
+
+    // The remote-service id is the same key with the `backup_account_` prefix.
+    assert_eq!(
+        account.id,
+        format!("backup_account_{KNOWN_BACKUP_ACCOUNT_PUBLIC_KEY}")
+    );
+
+    // Cross-check against the underlying `RootKey` derivation.
+    let derived = RootKey::from_json(&root_secret)
+        .unwrap()
+        .derive_public_backup_account_key()
+        .unwrap();
+    assert_eq!(derived, account.public_key);
+}
+
+#[test]
+fn test_stamp_with_backup_account_key_produces_valid_secp256k1_stamp() {
+    let turnkey = crate::backup::turnkey::Turnkey::new();
+    let manager = BackupManager::new();
+    let root_secret = known_root_secret();
+    let body = serde_json::json!({"example": 123}).to_string();
+
+    let stamp = turnkey
+        .stamp_with_backup_account_key(siegel_from_str(&root_secret), body.clone())
+        .expect("stamping should succeed");
+
+    // Decode and inspect the stamp.
+    let decoded = URL_SAFE_NO_PAD.decode(&stamp).unwrap();
+    let decoded: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+
+    assert_eq!(
+        decoded["scheme"].as_str().unwrap(),
+        "SIGNATURE_SCHEME_TK_API_SECP256K1"
+    );
+
+    // The stamped public key must be the same key the reset_user is registered with.
+    let public_key_hex = decoded["publicKey"].as_str().unwrap();
+    let registered = manager
+        .get_backup_account(siegel_from_str(&root_secret))
+        .unwrap()
+        .public_key;
+    assert_eq!(public_key_hex, registered);
+    assert_eq!(public_key_hex, KNOWN_BACKUP_ACCOUNT_PUBLIC_KEY);
+
+    // The signature is a valid ECDSA-secp256k1 signature of SHA256(body) under that key.
+    // `Verifier::verify` hashes the message with SHA256 internally, and k256 rejects
+    // high-S signatures, so a successful verify also proves low-S normalization.
+    let sig_der = hex::decode(decoded["signature"].as_str().unwrap()).unwrap();
+    let signature = Signature::from_der(&sig_der).unwrap();
+    let verifying_key =
+        VerifyingKey::from_sec1_bytes(&hex::decode(public_key_hex).unwrap()).unwrap();
+    verifying_key
+        .verify(body.as_bytes(), &signature)
+        .expect("stamp signature must verify against the backup-account public key");
+}
+
+#[test]
+fn test_stamp_with_backup_account_key_rejects_invalid_body() {
+    let turnkey = crate::backup::turnkey::Turnkey::new();
+    let root_secret = known_root_secret();
+
+    let err = turnkey
+        .stamp_with_backup_account_key(
+            siegel_from_str(&root_secret),
+            "not json".to_string(),
+        )
+        .expect_err("should fail with invalid stamp body");
+    assert_eq!(err.to_string(), "Failed to decode request body as JSON");
+}
+
+#[test]
+fn test_stamp_with_backup_account_key_rejects_invalid_root_secret() {
+    let turnkey = crate::backup::turnkey::Turnkey::new();
+
+    let err = turnkey
+        .stamp_with_backup_account_key(
+            siegel_from_str("not json"),
+            serde_json::json!({"example": 123}).to_string(),
+        )
+        .expect_err("should fail with invalid root secret");
     assert!(err.to_string().contains("Invalid root secret"));
 }

--- a/bedrock/src/backup/turnkey.rs
+++ b/bedrock/src/backup/turnkey.rs
@@ -1,16 +1,20 @@
 //! This module allows interactions with the Turnkey API for the user's backup.
 
+use std::sync::Arc;
+
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use bedrock_macros::{bedrock_error, bedrock_export};
 use hpke::kem::DhP256HkdfSha256;
 use hpke::{Deserializable, Kem as KemTrait};
 use p256::ecdsa::signature::Signer;
-use p256::ecdsa::Signature;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use serde_json::json;
+use siegel_uniffi::SiegelSession;
 use turnkey_enclave_encrypt::client::EnclaveEncryptClient;
 use turnkey_enclave_encrypt::QuorumPublicKey;
+
+use crate::root_key::RootKey;
 
 /// Allows interactions with Turnkey API.
 #[derive(uniffi::Object, Clone, Debug, Default)]
@@ -96,13 +100,82 @@ impl Turnkey {
             serde_json::from_str(body).map_err(|_| TurnkeyError::DecodeBodyError)?;
 
         // Sign the body with the private key
-        let signature: Signature = signing_key.sign(body.as_bytes());
+        let signature: p256::ecdsa::Signature = signing_key.sign(body.as_bytes());
 
         // Convert the signature to the expected header format
         let json_stamp = json!({
             "publicKey": hex::encode(private_key.public_key().to_encoded_point(true).as_bytes()),
             "signature": hex::encode(signature.to_der()),
             "scheme": "SIGNATURE_SCHEME_TK_API_P256",
+        });
+        let json_stamp = serde_json::to_string(&json_stamp)
+            .map_err(|_| TurnkeyError::SerializeStampError)?;
+
+        Ok(URL_SAFE_NO_PAD.encode(json_stamp.as_bytes()))
+    }
+
+    /// Stamps a JSON activity with the backup account key. See [`Self::stamp`] for
+    /// more details on stamping.
+    ///
+    /// This should only be used for disaster recovery (`/reset`) to clear the Turnkey
+    /// account that will go out of use.
+    ///
+    /// # Errors
+    /// * `TurnkeyError::InvalidRootSecretError` - if the session is not valid UTF-8 or the
+    ///   root secret cannot be parsed.
+    /// * `TurnkeyError::DecodeBodyError` - if `body` is not valid JSON.
+    /// * `TurnkeyError::SigningError` - if signing fails.
+    /// * `TurnkeyError::Generic` - if the Siegel session cannot be read, key derivation
+    ///   fails, or the stamp cannot be serialized.
+    #[expect(
+        clippy::unused_self,
+        reason = "uniffi doesn't support associated functions"
+    )]
+    pub fn stamp_with_backup_account_key(
+        &self,
+        root_secret: Arc<SiegelSession>,
+        body: String,
+    ) -> Result<String, TurnkeyError> {
+        // Validate JSON body, but raw bytes are signed
+        let _json: serde_json::Value =
+            serde_json::from_str(&body).map_err(|_| TurnkeyError::DecodeBodyError)?;
+
+        let (signature, public_key) = root_secret.read_once(
+            move |bytes| -> Result<
+                (k256::ecdsa::Signature, k256::EncodedPoint),
+                TurnkeyError,
+            > {
+                let root_key = RootKey::from_slice(bytes)
+                    .map_err(|_| TurnkeyError::InvalidRootSecretError)?;
+                let key = root_key.derive_backup_account_key().map_err(|_| {
+                    TurnkeyError::Generic {
+                        error_message: "unexpected kdf failure".to_string(),
+                    }
+                })?;
+
+                // the backup account is `secp256k1`; zeroized on drop
+                let signing_key = k256::ecdsa::SigningKey::from(key);
+
+                // note: k256 already normalizes to low-S
+                let signature: k256::ecdsa::Signature =
+                    signing_key.try_sign(body.as_bytes())?;
+
+                // Return the (public) compressed point so no reference to the local
+                // signing key escapes the closure.
+                Ok((
+                    signature,
+                    signing_key.verifying_key().to_encoded_point(true),
+                ))
+            },
+        )??;
+
+        // release the session explicitly
+        drop(root_secret);
+
+        let json_stamp = json!({
+            "publicKey": hex::encode(public_key.as_bytes()),
+            "signature": hex::encode(signature.to_der()),
+            "scheme": "SIGNATURE_SCHEME_TK_API_SECP256K1",
         });
         let json_stamp = serde_json::to_string(&json_stamp)
             .map_err(|_| TurnkeyError::SerializeStampError)?;
@@ -131,7 +204,10 @@ impl Turnkey {
     /// - `InvalidFactorSecret`: The factor secret is not a valid hex-encoded 32-byte string.
     /// - `EncryptFactorSecretError`: Failed to encrypt the factor secret using the import bundle.
     /// - `SerializeEncryptedBundleError`: Failed to serialize the encrypted bundle to a JSON string.
-    #[allow(clippy::unused_self)] // Uniffi doesn't support associated functions
+    #[expect(
+        clippy::unused_self,
+        reason = "uniffi doesn't support associated functions"
+    )]
     pub fn generate_import_bundle_for_factor_secret(
         &self,
         factor_secret: &str,
@@ -293,6 +369,23 @@ pub enum TurnkeyError {
     ConvertP256KeypairToHpkeKeypairError,
     #[error("Failed to convert enclave public key to verifying key")]
     ConvertEnclavePublicKeyToVerifyingKeyError,
+    /// Errors propagated from a Siegel session
+    #[error(transparent)]
+    SiegelError(#[from] siegel_uniffi::SessionError),
+    /// Root secret is invalid.
+    #[error("Invalid root secret provided in Siegel session")]
+    InvalidRootSecretError,
+    /// Unexpected error signing Turnkey activity
+    #[error("error signing turnkey activity")]
+    SigningError,
+}
+
+impl From<k256::ecdsa::Error> for TurnkeyError {
+    fn from(_e: k256::ecdsa::Error) -> Self {
+        // while `e` is already opaque, the source could leak some privacy info, and it's generally
+        // not very useful anyway, so it's not logged
+        Self::SigningError
+    }
 }
 
 #[cfg(test)]

--- a/bedrock/src/backup/turnkey.rs
+++ b/bedrock/src/backup/turnkey.rs
@@ -370,14 +370,20 @@ pub enum TurnkeyError {
     #[error("Failed to convert enclave public key to verifying key")]
     ConvertEnclavePublicKeyToVerifyingKeyError,
     /// Errors propagated from a Siegel session
-    #[error(transparent)]
-    SiegelError(#[from] siegel_uniffi::SessionError),
+    #[error("siegel session error: {0}")]
+    SiegelSession(String),
     /// Root secret is invalid.
     #[error("Invalid root secret provided in Siegel session")]
     InvalidRootSecretError,
     /// Unexpected error signing Turnkey activity
     #[error("error signing turnkey activity")]
     SigningError,
+}
+
+impl From<siegel_uniffi::SessionError> for TurnkeyError {
+    fn from(e: siegel_uniffi::SessionError) -> Self {
+        Self::SiegelSession(e.to_string())
+    }
 }
 
 impl From<k256::ecdsa::Error> for TurnkeyError {

--- a/bedrock/src/root_key/mod.rs
+++ b/bedrock/src/root_key/mod.rs
@@ -237,7 +237,7 @@ impl RootKey {
     /// Key derivation. "Public" value.
     ///
     /// Derives the deterministic public backup account used to uniquely identify a backup. This
-    /// method returns only the public key (SEC.1 compressesed point, hex-encoded).
+    /// method returns only the public key (SEC.1 compressed point, hex-encoded).
     ///
     /// The `backup_account_id` is generally used to ensure that only a single backup can exist
     /// per account, otherwise this could lead to race conditions and undefined behavior with

--- a/bedrock/src/root_key/mod.rs
+++ b/bedrock/src/root_key/mod.rs
@@ -114,6 +114,18 @@ impl RootKey {
         })
     }
 
+    /// Initialize an existing `RootKey` from JSON bytes
+    #[uniffi::constructor]
+    pub fn from_slice(json_bytes: &[u8]) -> Result<Self, RootKeyError> {
+        // no need to zeroize `key` because it's moved into the `SecretBox`
+        let key: VersionedKey = serde_json::from_slice(json_bytes)
+            .map_err(|_| RootKeyError::KeyParseError)?;
+
+        Ok(Self {
+            inner: SecretBox::new(Box::new(key)),
+        })
+    }
+
     /// Returns `true` if the `RootKey` is a version 0 key.
     pub fn is_v0(&self) -> bool {
         matches!(self.inner.expose_secret(), VersionedKey::V0(_))
@@ -221,6 +233,29 @@ impl RootKey {
         subkey.zeroize();
         Ok(backup_key)
     }
+
+    /// Key derivation. "Public" value.
+    ///
+    /// Derives the deterministic public backup account used to uniquely identify a backup. This
+    /// method returns only the public key (SEC.1 compressesed point, hex-encoded).
+    ///
+    /// The `backup_account_id` is generally used to ensure that only a single backup can exist
+    /// per account, otherwise this could lead to race conditions and undefined behavior with
+    /// the backup (including user confusion).
+    ///
+    /// The `backup_account_id` is the public key of a `secp256k1` key. Public key cryptography is introduced
+    /// so the user can prove ownership of the backup account ID for certain disaster recovery scenarios.
+    ///
+    /// # Errors
+    /// No errors are generally expected, but key derivation may unexpectedly fail.
+    pub(crate) fn derive_public_backup_account_key(
+        &self,
+    ) -> Result<String, RootKeyError> {
+        let backup_key = self.derive_backup_account_key()?;
+        Ok(hex::encode(
+            backup_key.public_key().to_encoded_point(true).as_bytes(),
+        ))
+    }
 }
 
 /// Public key derivation implementations. These are not considered secret and may be exposed. They are also exposed
@@ -228,26 +263,7 @@ impl RootKey {
 ///
 /// Note these values are not returned in a `SecretBox`.
 #[bedrock_export]
-impl RootKey {
-    /// Key derivation. "Public" value.
-    ///
-    /// Derives the deterministic public backup account ID to uniquely identify a backup for an account.
-    ///
-    /// This is used to ensure that only a single backup can exist per account, otherwise this could lead
-    /// to race conditions and undefined behavior with the backup (including user confusion).
-    ///
-    /// The public backup account ID is the public key of a `secp256k1` key. Public key cryptography is introduced
-    /// so the user can prove ownership of the backup account ID for certain disaster recovery scenarios.
-    ///
-    /// # Errors
-    /// No errors are generally expected, but key derivation may unexpectedly fail.
-    pub fn derive_public_backup_account_id(&self) -> Result<String, RootKeyError> {
-        let backup_key = self.derive_backup_account_key()?;
-        let backup_id =
-            hex::encode(backup_key.public_key().to_encoded_point(true).as_bytes());
-        Ok(format!("backup_account_{backup_id}"))
-    }
-}
+impl RootKey {}
 
 #[cfg(test)]
 mod test;

--- a/bedrock/src/root_key/mod.rs
+++ b/bedrock/src/root_key/mod.rs
@@ -258,12 +258,5 @@ impl RootKey {
     }
 }
 
-/// Public key derivation implementations. These are not considered secret and may be exposed. They are also exposed
-/// to foreign bindings.
-///
-/// Note these values are not returned in a `SecretBox`.
-#[bedrock_export]
-impl RootKey {}
-
 #[cfg(test)]
 mod test;

--- a/bedrock/src/root_key/test.rs
+++ b/bedrock/src/root_key/test.rs
@@ -100,7 +100,7 @@ fn test_derive_public_backup_account_key() {
 }
 
 #[test]
-fn test_ensure_backup_account_id_can_be_used_to_sign() {
+fn test_ensure_backup_account_public_key_can_be_used_to_sign() {
     let key = RootKey::new_random();
     let backup_account_key = key.derive_public_backup_account_key().unwrap();
     let signing_secret_key = key.derive_backup_account_key().unwrap();

--- a/bedrock/src/root_key/test.rs
+++ b/bedrock/src/root_key/test.rs
@@ -76,40 +76,41 @@ fn test_new_generates_seemingly_random_keys() {
 }
 
 #[test]
-fn test_derive_public_backup_account_id() {
+fn test_derive_public_backup_account_key() {
     // Test with a known V1 key to verify deterministic output
     let key = r#"{"key":"1111111111111111111111111111111111111111111111111111111111111111","version":"V1"}"#;
     let key = RootKey::from_json(key).unwrap();
 
-    let backup_id = key.derive_public_backup_account_id().unwrap();
+    let backup_key = key.derive_public_backup_account_key().unwrap();
 
-    // Assert format and expected well-known output
-    assert_eq!(backup_id, "backup_account_039797dc9fec4e3d3f2f27173ba0faac160ee2f803954e8552c308da22ab40ab5c");
+    // Assert format and expected well-known output (compressed SEC1 hex, no prefix)
+    assert_eq!(
+        backup_key,
+        "039797dc9fec4e3d3f2f27173ba0faac160ee2f803954e8552c308da22ab40ab5c"
+    );
 
-    // Verify determinism - same key should produce same ID
-    let backup_id2 = key.derive_public_backup_account_id().unwrap();
-    assert_eq!(backup_id, backup_id2);
+    // Verify determinism - same key should produce same public key
+    let backup_key2 = key.derive_public_backup_account_key().unwrap();
+    assert_eq!(backup_key, backup_key2);
 
-    // Different keys produce different IDs
+    // Different keys produce different public keys
     let key2 = RootKey::new_random();
-    let backup_id3 = key2.derive_public_backup_account_id().unwrap();
-    assert_ne!(backup_id, backup_id3);
+    let backup_key3 = key2.derive_public_backup_account_key().unwrap();
+    assert_ne!(backup_key, backup_key3);
 }
 
 #[test]
 fn test_ensure_backup_account_id_can_be_used_to_sign() {
     let key = RootKey::new_random();
-    let backup_account_id = key.derive_public_backup_account_id().unwrap();
-    let backup_account_key = key.derive_backup_account_key().unwrap();
+    let backup_account_key = key.derive_public_backup_account_key().unwrap();
+    let signing_secret_key = key.derive_backup_account_key().unwrap();
 
-    let signing_key = k256::ecdsa::SigningKey::from(backup_account_key);
+    let signing_key = k256::ecdsa::SigningKey::from(signing_secret_key);
 
     let message = "Hello, world!";
     let (signature, rec_id) = signing_key.sign_recoverable(message.as_bytes()).unwrap();
 
-    let public_key_bytes =
-        hex::decode(backup_account_id.strip_prefix("backup_account_").unwrap())
-            .unwrap();
+    let public_key_bytes = hex::decode(&backup_account_key).unwrap();
     let public_key = VerifyingKey::from_sec1_bytes(&public_key_bytes).unwrap();
     assert!(public_key.verify(message.as_bytes(), &signature).is_ok());
 


### PR DESCRIPTION
### Motivation
[Disaster recovery](https://docs.toolsforhumanity.com/world-app/backup/advanced#disaster-recovery-via-/reset) `/reset` lets the user start the backup all over. When this happens, currently the Turnkey account is left stale, with authenticators, the factor secret, etc. 

To address this, the user will register their backup account public key as a separate reset user in Turnkey. This PR sets the groundwork to allow authenticating with that key.

### Changes
- ⚠️ **Breaking Change**. The way the backup account id is obtained by foreign clients changes. This logic is moved to the `BackupManager` where it makes more sense instead of on `RootKey`. This method will now return both the raw public key (sec.1 point) as well as the fully prefixed id for use with the `backup-service.`
- `stamp_with_backup_account_key` is exposed in the `TurnkeyService` which lets the caller stamp an arbitrary Turnkey activity with the user's backup account key. This would be used to authenticate a `DELETE_SUBORGANIZATION` request with Turnkey to clear the now stale Turnkey account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking FFI/API changes plus new cryptographic signing paths that handle root secrets via Siegel; incorrect integration could break backup identity or Turnkey disaster-recovery auth.
> 
> **Overview**
> **Breaking:** Foreign clients should use `BackupManager.get_backup_account(SiegelSession)` instead of `RootKey.derive_public_backup_account_id()`. The new `BackupAccount` record exposes the compressed secp256k1 public key and the `backup_account_{key}` service id.
> 
> `Turnkey.stamp_with_backup_account_key` signs Turnkey JSON activities with the derived backup account key (`SIGNATURE_SCHEME_TK_API_SECP256K1`), intended for disaster-recovery flows such as clearing a stale Turnkey sub-org. Root secrets are read once via `SiegelSession` with explicit session teardown in both paths.
> 
> `decrypt_and_unpack_sealed_backup` no longer takes `current_manifest_hash`; unpack logging no longer compares against that hash. `RootKey` gains `from_slice` for byte JSON; public backup derivation is `derive_public_backup_account_key()` (hex key only, crate-internal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e404dabfd29329ac8bdfc2cede2c057ec16e46c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->