### PR TITLE
feat: move to tracing for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,6 +5447,7 @@ dependencies = [
  "getrandom 0.4.1",
  "siegel",
  "thiserror 2.0.18",
+ "tracing",
  "uniffi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,6 @@ dependencies = [
  "hpke",
  "http 1.4.0",
  "k256",
- "log",
  "once_cell",
  "p256 0.13.2",
  "p384",
@@ -1711,6 +1710,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+ "tracing",
+ "tracing-log",
  "turnkey_enclave_encrypt",
  "uniffi",
  "uuid",
@@ -5428,9 +5429,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siegel"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e7be3bd3792e86519ef639757407f1abd86d21aa65bb3313d4327172f0f9b0"
+checksum = "4ed5bfb37b157b43f440871733d711ded36f2ce963e565c1b269ba0ac72fd02a"
 dependencies = [
  "libc",
  "thiserror 2.0.18",
@@ -5439,9 +5440,9 @@ dependencies = [
 
 [[package]]
 name = "siegel-uniffi"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b1af96d641e2c8c7cc8d8c2c16d4b8ddd73f9068a2100721f46c23533012e1"
+checksum = "972773eabd6749c998807d650f4139b92c1f4a4b9706a1d837a5e7e4a1c102f2"
 dependencies = [
  "getrandom 0.4.1",
  "siegel",
@@ -6055,6 +6056,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -57,7 +57,6 @@ hpke = { version = "0.10", features = [
   "serde_impls",
 ], default-features = false }
 k256 = { version = "0.13.4", default-features = false, features = ["std", "ecdsa"] }
-log = "0.4.31"
 once_cell = "1.21"
 p256 = { version = "0.13.2", default-features = false, features = [
   "ecdsa",
@@ -81,6 +80,8 @@ futures = "0.3"
 tar = "0.4.40"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["time"] }
+tracing = "0.1.41"
+tracing-log = "0.2.0"
 turnkey_enclave_encrypt = "0.6.1"
 uniffi = { workspace = true, features = ["build", "tokio"] }
 uuid = { version = "1.23.0", features = ["v4"], default-features = false }
@@ -89,7 +90,7 @@ x509-cert = { version = "0.2.5", features = ["pem"] }
 zeroize = "1.8"
 hex-literal = "1.1.0" # Provides the `hex!` macro for compile-time hex decoding
 http = "1.4.0"
-siegel-uniffi = "=0.2.0"
+siegel-uniffi = "=0.3.0"
 
 # TODO: once `rand` can be bumped to 0.9, add the explicit feature flag `os_rng`. this explicitly determines no `thread_rng`;
 # bumping this requires crypto_box to update rand: https://github.com/RustCrypto/nacl-compat/issues/176

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -90,7 +90,7 @@ x509-cert = { version = "0.2.5", features = ["pem"] }
 zeroize = "1.8"
 hex-literal = "1.1.0" # Provides the `hex!` macro for compile-time hex decoding
 http = "1.4.0"
-siegel-uniffi = "=0.3.0"
+siegel-uniffi = { version = "=0.3.0", features = ["tracing"] }
 
 # TODO: once `rand` can be bumped to 0.9, add the explicit feature flag `os_rng`. this explicitly determines no `thread_rng`;
 # bumping this requires crypto_box to update rand: https://github.com/RustCrypto/nacl-compat/issues/176

--- a/bedrock/src/backup/backup_format/v0.rs
+++ b/bedrock/src/backup/backup_format/v0.rs
@@ -133,9 +133,7 @@ impl V0Backup {
 
                 let file: V0BackupFile = ciborium::from_reader(Cursor::new(&data))
                     .map_err(|e| {
-                        tracing::error!(
-                            "Failed to deserialize backup file {path}: {e}"
-                        );
+                        crate::error!("Failed to deserialize backup file {path}: {e}");
                         e
                     })?;
 

--- a/bedrock/src/backup/backup_format/v0.rs
+++ b/bedrock/src/backup/backup_format/v0.rs
@@ -133,7 +133,9 @@ impl V0Backup {
 
                 let file: V0BackupFile = ciborium::from_reader(Cursor::new(&data))
                     .map_err(|e| {
-                        log::error!("Failed to deserialize backup file {path}: {e}");
+                        tracing::error!(
+                            "Failed to deserialize backup file {path}: {e}"
+                        );
                         e
                     })?;
 

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -84,7 +84,7 @@ impl BackupManifest {
 
                     // Checksum: 32 raw bytes from hex
                     let ck_bytes = hex::decode(&entry.checksum_hex).map_err(|_| {
-                        log::error!(
+                        tracing::error!(
                             "[Critical] Unable to decode checksum hex for file with designator: {}. Manifest entry is invalid.",
                             entry.designator
                         );
@@ -94,7 +94,7 @@ impl BackupManifest {
                         ))
                     })?;
                     let ck_arr: [u8; 32] = ck_bytes.try_into().map_err(|_| {
-                        log::error!(
+                        tracing::error!(
                             "[Critical] Decoded checksum has invalid length for file with designator: {}. Manifest entry is invalid.",
                             entry.designator
                         );
@@ -208,7 +208,7 @@ impl ManifestManager {
                         .iter()
                         .any(|e| e.file_path == normalized_path)
                     {
-                        log::warn!(
+                        tracing::warn!(
                             "File already exists in the manifest: {}",
                             normalized_path.get(..14).unwrap_or(&normalized_path)
                         );
@@ -394,7 +394,7 @@ impl ManifestManager {
             let data = fs.read_file(rel.to_string()).map_err(|e| {
                 let msg =
                     format!("Failed to load file from {:?}: {e}", entry.designator);
-                log::error!("{msg}");
+                tracing::error!("{msg}");
                 BackupError::InvalidFileForBackup(msg)
             })?;
 
@@ -402,7 +402,7 @@ impl ManifestManager {
             let computed_checksum = blake3::hash(&data);
             let expected_checksum: [u8; 32] = hex::decode(&entry.checksum_hex)
                 .map_err(|_| {
-                    log::error!(
+                    tracing::error!(
                         "[Critical] Unable to decode checksum hex for file with designator: {}. Manifest entry is invalid.",
                         entry.designator
                     );
@@ -413,7 +413,7 @@ impl ManifestManager {
                 })?
                 .try_into()
                 .map_err(|_| {
-                    log::error!(
+                    tracing::error!(
                         "[Critical] Decoded checksum has invalid length for file with designator: {}. Manifest entry is invalid.",
                         entry.designator
                     );
@@ -483,7 +483,7 @@ impl ManifestManager {
             .map(|(checksum, size)| (hex::encode(checksum), size))
             .map_err(|e| {
                 let msg = format!("Failed to load file: {e}");
-                log::error!("{msg}");
+                tracing::error!("{msg}");
                 BackupError::InvalidFileForBackup(msg)
             })
     }
@@ -536,7 +536,7 @@ impl ManifestManager {
 
         // Refresh backup report from manifest; ignore errors
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            log::warn!(
+            tracing::warn!(
                 "[ClientEvents] failed to refresh backup report after manifest update: {e:?}"
             );
         }
@@ -555,7 +555,7 @@ impl ManifestManager {
             )
             .await
         {
-            log::warn!("[ClientEvents] failed to send Sync event: {e:?}");
+            tracing::warn!("[ClientEvents] failed to send Sync event: {e:?}");
         }
     }
 }

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -84,7 +84,7 @@ impl BackupManifest {
 
                     // Checksum: 32 raw bytes from hex
                     let ck_bytes = hex::decode(&entry.checksum_hex).map_err(|_| {
-                        tracing::error!(
+                        crate::error!(
                             "[Critical] Unable to decode checksum hex for file with designator: {}. Manifest entry is invalid.",
                             entry.designator
                         );
@@ -94,7 +94,7 @@ impl BackupManifest {
                         ))
                     })?;
                     let ck_arr: [u8; 32] = ck_bytes.try_into().map_err(|_| {
-                        tracing::error!(
+                        crate::error!(
                             "[Critical] Decoded checksum has invalid length for file with designator: {}. Manifest entry is invalid.",
                             entry.designator
                         );
@@ -208,7 +208,7 @@ impl ManifestManager {
                         .iter()
                         .any(|e| e.file_path == normalized_path)
                     {
-                        tracing::warn!(
+                        crate::warn!(
                             "File already exists in the manifest: {}",
                             normalized_path.get(..14).unwrap_or(&normalized_path)
                         );
@@ -394,7 +394,7 @@ impl ManifestManager {
             let data = fs.read_file(rel.to_string()).map_err(|e| {
                 let msg =
                     format!("Failed to load file from {:?}: {e}", entry.designator);
-                tracing::error!("{msg}");
+                crate::error!("{msg}");
                 BackupError::InvalidFileForBackup(msg)
             })?;
 
@@ -402,7 +402,7 @@ impl ManifestManager {
             let computed_checksum = blake3::hash(&data);
             let expected_checksum: [u8; 32] = hex::decode(&entry.checksum_hex)
                 .map_err(|_| {
-                    tracing::error!(
+                    crate::error!(
                         "[Critical] Unable to decode checksum hex for file with designator: {}. Manifest entry is invalid.",
                         entry.designator
                     );
@@ -413,7 +413,7 @@ impl ManifestManager {
                 })?
                 .try_into()
                 .map_err(|_| {
-                    tracing::error!(
+                    crate::error!(
                         "[Critical] Decoded checksum has invalid length for file with designator: {}. Manifest entry is invalid.",
                         entry.designator
                     );
@@ -483,7 +483,7 @@ impl ManifestManager {
             .map(|(checksum, size)| (hex::encode(checksum), size))
             .map_err(|e| {
                 let msg = format!("Failed to load file: {e}");
-                tracing::error!("{msg}");
+                crate::error!("{msg}");
                 BackupError::InvalidFileForBackup(msg)
             })
     }
@@ -536,7 +536,7 @@ impl ManifestManager {
 
         // Refresh backup report from manifest; ignore errors
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            tracing::warn!(
+            crate::warn!(
                 "[ClientEvents] failed to refresh backup report after manifest update: {e:?}"
             );
         }
@@ -555,7 +555,7 @@ impl ManifestManager {
             )
             .await
         {
-            tracing::warn!("[ClientEvents] failed to send Sync event: {e:?}");
+            crate::warn!("[ClientEvents] failed to send Sync event: {e:?}");
         }
     }
 }

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -152,7 +152,7 @@ impl BackupManager {
         // Keep the base report in sync with the freshly initialized (empty) manifest.
         // This ensures we don't keep stale designators (e.g., `orb_pkg`) from a previous state.
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            tracing::warn!(
+            crate::warn!(
                 "[ClientEvents] failed to refresh backup report after manifest init: {e:?}"
             );
         }
@@ -404,7 +404,7 @@ impl BackupManager {
         // state (designators, size, counters) is fully cleared. It will be recreated
         // automatically if/when backup is enabled again.
         if let Err(e) = ClientEventsReporter::new().delete_base_report() {
-            tracing::warn!(
+            crate::warn!(
                 "[ClientEvents] failed to delete base report after manifest deletion: {e:?}"
             );
         }
@@ -586,21 +586,21 @@ impl BackupManager {
                 Ok(true) => match fs.calculate_checksum_and_size(rel_path) {
                     Ok((local_checksum, _)) => {
                         if local_checksum != file.checksum {
-                            tracing::error!(
+                            crate::error!(
                                     "[BackupManager] checksum mismatch for existing file at {path_ref} (designator: {}). Replacing with remote content.",
                                     file.designator
                                 );
                         }
                     }
                     Err(e) => {
-                        tracing::error!(
+                        crate::error!(
                                 "[BackupManager] failed to compute checksum for existing file at {path_ref}: {e:?}. Replacing with remote content.",
                             );
                     }
                 },
                 Ok(false) => {}
                 Err(e) => {
-                    tracing::error!(
+                    crate::error!(
                         "[BackupManager] failed to check existence for {path_ref}: {e:?}. Proceeding to write.",
                     );
                 }
@@ -637,7 +637,7 @@ impl BackupManager {
         // Refresh the base report to reflect the unpacked manifest contents. This keeps
         // `backup_file_designators` and `backup_size_kb` in sync after a restore.
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            tracing::warn!(
+            crate::warn!(
                 "[ClientEvents] failed to refresh backup report after unpacking backup: {e:?}"
             );
         }

--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -152,7 +152,7 @@ impl BackupManager {
         // Keep the base report in sync with the freshly initialized (empty) manifest.
         // This ensures we don't keep stale designators (e.g., `orb_pkg`) from a previous state.
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            log::warn!(
+            tracing::warn!(
                 "[ClientEvents] failed to refresh backup report after manifest init: {e:?}"
             );
         }
@@ -404,7 +404,7 @@ impl BackupManager {
         // state (designators, size, counters) is fully cleared. It will be recreated
         // automatically if/when backup is enabled again.
         if let Err(e) = ClientEventsReporter::new().delete_base_report() {
-            log::warn!(
+            tracing::warn!(
                 "[ClientEvents] failed to delete base report after manifest deletion: {e:?}"
             );
         }
@@ -586,21 +586,21 @@ impl BackupManager {
                 Ok(true) => match fs.calculate_checksum_and_size(rel_path) {
                     Ok((local_checksum, _)) => {
                         if local_checksum != file.checksum {
-                            log::error!(
+                            tracing::error!(
                                     "[BackupManager] checksum mismatch for existing file at {path_ref} (designator: {}). Replacing with remote content.",
                                     file.designator
                                 );
                         }
                     }
                     Err(e) => {
-                        log::error!(
+                        tracing::error!(
                                 "[BackupManager] failed to compute checksum for existing file at {path_ref}: {e:?}. Replacing with remote content.",
                             );
                     }
                 },
                 Ok(false) => {}
                 Err(e) => {
-                    log::error!(
+                    tracing::error!(
                         "[BackupManager] failed to check existence for {path_ref}: {e:?}. Proceeding to write.",
                     );
                 }
@@ -637,7 +637,7 @@ impl BackupManager {
         // Refresh the base report to reflect the unpacked manifest contents. This keeps
         // `backup_file_designators` and `backup_size_kb` in sync after a restore.
         if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
-            log::warn!(
+            tracing::warn!(
                 "[ClientEvents] failed to refresh backup report after unpacking backup: {e:?}"
             );
         }

--- a/bedrock/src/backup/service_client.rs
+++ b/bedrock/src/backup/service_client.rs
@@ -127,7 +127,7 @@ impl BackupServiceClient {
                     is_backup_enabled: None,
                 },
             ) {
-                tracing::warn!(
+                crate::warn!(
                     "[ClientEvents] failed to merge retrieve_metadata into base report: {e:?}"
                 );
             }

--- a/bedrock/src/backup/service_client.rs
+++ b/bedrock/src/backup/service_client.rs
@@ -127,7 +127,7 @@ impl BackupServiceClient {
                     is_backup_enabled: None,
                 },
             ) {
-                log::warn!(
+                tracing::warn!(
                     "[ClientEvents] failed to merge retrieve_metadata into base report: {e:?}"
                 );
             }

--- a/bedrock/src/backup/turnkey.rs
+++ b/bedrock/src/backup/turnkey.rs
@@ -244,7 +244,7 @@ impl Turnkey {
                 turnkey_user_id,
             )
             .map_err(|err| {
-                tracing::error!("Failed to encrypt factor secret: {err:?}");
+                crate::error!("Failed to encrypt factor secret: {err:?}");
                 TurnkeyError::EncryptFactorSecretError
             })?;
 

--- a/bedrock/src/backup/turnkey.rs
+++ b/bedrock/src/backup/turnkey.rs
@@ -244,7 +244,7 @@ impl Turnkey {
                 turnkey_user_id,
             )
             .map_err(|err| {
-                log::error!("Failed to encrypt factor secret: {err:?}");
+                tracing::error!("Failed to encrypt factor secret: {err:?}");
                 TurnkeyError::EncryptFactorSecretError
             })?;
 

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -5,12 +5,12 @@ use crate::migration::processors::permit2_approval_processor::Permit2ApprovalPro
 use crate::migration::state::{MigrationRecord, MigrationStatus};
 use crate::primitives::key_value_store::{DeviceKeyValueStore, KeyValueStoreError};
 use crate::smart_account::SafeSmartAccount;
+use crate::warn;
 use chrono::{Duration, Utc};
 use futures::future::join_all;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::warn;
 
 const MIGRATION_KEY_PREFIX: &str = "migration:";
 const MIGRATION_SUCCESS_TTL_DAYS: i64 = 30; // Re-check succeeded migrations after 30 days

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -7,10 +7,10 @@ use crate::primitives::key_value_store::{DeviceKeyValueStore, KeyValueStoreError
 use crate::smart_account::SafeSmartAccount;
 use chrono::{Duration, Utc};
 use futures::future::join_all;
-use log::warn;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing::warn;
 
 const MIGRATION_KEY_PREFIX: &str = "migration:";
 const MIGRATION_SUCCESS_TTL_DAYS: i64 = 30; // Re-check succeeded migrations after 30 days

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -1,7 +1,7 @@
 use crate::migration::error::MigrationError;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};
 use async_trait::async_trait;
-use log::info;
+use tracing::info;
 
 /// Example processor skeleton showing how to implement a migration
 ///

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -1,7 +1,7 @@
+use crate::info;
 use crate::migration::error::MigrationError;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};
 use async_trait::async_trait;
-use tracing::info;
 
 /// Example processor skeleton showing how to implement a migration
 ///

--- a/bedrock/src/migration/processors/permit2_approval_processor.rs
+++ b/bedrock/src/migration/processors/permit2_approval_processor.rs
@@ -1,8 +1,8 @@
+use crate::info;
 use alloy::primitives::{Address, Bytes, U256};
 use async_trait::async_trait;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::info;
 
 use crate::migration::error::MigrationError;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};

--- a/bedrock/src/migration/processors/permit2_approval_processor.rs
+++ b/bedrock/src/migration/processors/permit2_approval_processor.rs
@@ -1,8 +1,8 @@
 use alloy::primitives::{Address, Bytes, U256};
 use async_trait::async_trait;
-use log::info;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tracing::info;
 
 use crate::migration::error::MigrationError;
 use crate::migration::processor::{MigrationProcessor, ProcessorResult};

--- a/bedrock/src/primitives/logger.rs
+++ b/bedrock/src/primitives/logger.rs
@@ -1,5 +1,8 @@
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{sync::Arc, sync::OnceLock};
+
+use tracing::{span, Event, Level, Metadata, Subscriber};
 
 thread_local! {
     static LOG_CONTEXT: RefCell<Option<String>> = const { RefCell::new(None) };
@@ -91,88 +94,124 @@ pub enum LogLevel {
     Error,
 }
 
-/// A logger that forwards log messages to a user-provided `Logger` implementation.
+/// A [`tracing::Subscriber`] that forwards events to the foreign [`Logger`].
 ///
-/// This struct implements the `log::Log` trait and integrates with the Rust `log` crate.
-struct ForeignLogger;
+/// This is the internal bridge between Bedrock's `tracing` instrumentation and
+/// the platform-provided logger. Spans are not recorded: Bedrock relies on the
+/// [`LogContext`] thread-local for contextual prefixes rather than span state,
+/// so span callbacks are no-ops.
+struct ForeignLoggerSubscriber {
+    /// Monotonic source of span identifiers. Spans carry no data, but the
+    /// `tracing` contract requires a unique non-zero [`span::Id`] per span.
+    next_span_id: AtomicU64,
+}
 
-impl log::Log for ForeignLogger {
-    /// Determines if a log message with the specified metadata should be logged.
-    ///
-    /// This implementation logs all messages. Modify this method to implement log level filtering.
-    ///
-    /// # Arguments
-    ///
-    /// * `_metadata` - Metadata about the log message.
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        // Currently, we log all messages. Adjust this if you need to filter messages.
+impl Subscriber for ForeignLoggerSubscriber {
+    /// Debug and trace events are only forwarded when they originate from the
+    /// `bedrock` crate. Dependency noise at those levels is rejected at the
+    /// callsite so it is never even formatted.
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        let level = *metadata.level();
+        if level == Level::DEBUG || level == Level::TRACE {
+            return is_bedrock_target(metadata);
+        }
         true
     }
 
-    /// Logs a record.
-    ///
-    /// This method is called by the `log` crate when a log message needs to be logged.
-    /// It forwards the log message to the user-provided `Logger` implementation if available.
-    ///
-    /// # Arguments
-    ///
-    /// * `record` - The log record containing the message and metadata.
-    fn log(&self, record: &log::Record) {
-        // Determine if the record originates from the "bedrock" module.
-        let is_record_from_bedrock = record
-            .module_path()
-            .is_some_and(|module_path| module_path.starts_with("bedrock"));
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        // `fetch_add` starts at 1 so the id is never 0 (which `Id::from_u64` rejects).
+        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
+        span::Id::from_u64(id)
+    }
 
-        // Determine if the log level is Debug or Trace.
-        let is_debug_or_trace_level =
-            record.level() == log::Level::Debug || record.level() == log::Level::Trace;
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
 
-        // Skip logging Debug or Trace level messages that are not from the "bedrock" module.
-        if is_debug_or_trace_level && !is_record_from_bedrock {
-            return;
-        }
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
-        // Forward the log message to the user-provided logger if available.
+    /// Forwards an event to the foreign logger after redacting hex secrets.
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+        let message = sanitize_hex_secrets(visitor.into_message());
+        let level = log_level(*event.metadata().level());
+
         if let Some(logger) = LOGGER_INSTANCE.get() {
-            let level = log_level(record.level());
-            let message = sanitize_hex_secrets(format!("{}", record.args()));
             logger.log(level, message);
         } else {
-            // Handle the case when the logger is not set.
-            eprintln!("Logger not set: {}", record.args());
+            // Unreachable via `set_logger`
+            eprintln!("Logger not set: {message}");
         }
     }
 
-    /// Flushes any buffered records.
-    ///
-    /// This implementation does nothing because buffering is not used.
-    fn flush(&self) {}
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
 }
 
-/// Converts a `log::Level` to a `LogLevel`.
+/// Returns `true` when the event originates from the `bedrock` crate.
+fn is_bedrock_target(metadata: &Metadata<'_>) -> bool {
+    metadata.target().starts_with("bedrock")
+        || metadata
+            .module_path()
+            .is_some_and(|module_path| module_path.starts_with("bedrock"))
+}
+
+/// Collects a `tracing` event's fields into a single log line.
 ///
-/// This function maps the log levels from the `log` crate to your own `LogLevel` enum.
+/// The `message` field (the format string passed to the logging macros) forms
+/// the body; any additional structured fields are appended as ` key=value` so
+/// they are never silently dropped.
+#[derive(Default)]
+struct EventVisitor {
+    message: String,
+    fields: String,
+}
+
+impl tracing::field::Visit for EventVisitor {
+    fn record_debug(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        use std::fmt::Write as _;
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={value:?}", field.name());
+        }
+    }
+}
+
+impl EventVisitor {
+    /// Consumes the visitor, returning the message with structured fields appended.
+    fn into_message(mut self) -> String {
+        self.message.push_str(&self.fields);
+        self.message
+    }
+}
+
+/// Converts a [`tracing::Level`] to a [`LogLevel`].
 ///
-/// # Arguments
-///
-/// * `level` - The `log::Level` to convert.
-///
-/// # Returns
-///
-/// A corresponding `LogLevel`.
-const fn log_level(level: log::Level) -> LogLevel {
-    match level {
-        log::Level::Error => LogLevel::Error,
-        log::Level::Warn => LogLevel::Warn,
-        log::Level::Info => LogLevel::Info,
-        log::Level::Debug => LogLevel::Debug,
-        log::Level::Trace => LogLevel::Trace,
+/// `tracing` levels are associated constants rather than enum variants, so this
+/// uses equality comparisons; the final branch necessarily maps [`Level::TRACE`].
+fn log_level(level: Level) -> LogLevel {
+    if level == Level::ERROR {
+        LogLevel::Error
+    } else if level == Level::WARN {
+        LogLevel::Warn
+    } else if level == Level::INFO {
+        LogLevel::Info
+    } else if level == Level::DEBUG {
+        LogLevel::Debug
+    } else {
+        LogLevel::Trace
     }
 }
 
 /// A global instance of the user-provided logger.
 ///
-/// This static variable holds the logger provided by the user and is accessed by `ForeignLogger` to forward log messages.
+/// This static variable holds the logger provided by the user and is accessed by
+/// [`ForeignLoggerSubscriber`] to forward log messages.
 static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
 
 /// Sets the global logger.
@@ -184,41 +223,37 @@ static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
 ///
 /// * `logger` - An `Arc` containing your logger implementation.
 ///
-/// # Panics
-///
-/// Panics if the logger has already been set.
-///
 /// # Note
 ///
-/// If the logger has already been set, this function will print a message and do nothing.
+/// Only the first logger is used. Calling this more than once keeps the original
+/// logger and is otherwise a no-op.
 #[allow(clippy::module_name_repetitions)]
 #[uniffi::export]
 pub fn set_logger(logger: Arc<dyn Logger>) {
-    match LOGGER_INSTANCE.set(logger) {
-        Ok(()) => (),
-        Err(_) => println!("Logger already set"),
+    if LOGGER_INSTANCE.set(logger).is_err() {
+        // A logger is already installed; keep the first one.
+        return;
     }
 
-    // Initialize the logger system.
-    init_logger().expect("Failed to set logger");
+    init_subscriber();
 }
 
-/// Initializes the logger system.
+/// Installs the global `tracing` subscriber and the `log` compatibility bridge.
 ///
-/// This function sets up the global logger with the `ForeignLogger` implementation and sets the maximum log level.
+/// Bedrock instruments with `tracing` directly; the [`tracing_log::LogTracer`]
+/// bridge captures records emitted by dependencies that still use the `log`
+/// crate. Debug and trace records from those dependencies are filtered out here
+/// because [`ForeignLoggerSubscriber`] would drop them anyway.
 ///
-/// # Returns
-///
-/// A `Result` indicating success or failure.
-///
-/// # Errors
-///
-/// Returns a `log::SetLoggerError` if the logger could not be set (e.g., if a logger was already set).
-fn init_logger() -> Result<(), log::SetLoggerError> {
-    static LOGGER: ForeignLogger = ForeignLogger;
-    log::set_logger(&LOGGER)?;
-    log::set_max_level(log::LevelFilter::Trace);
-    Ok(())
+/// Idempotent: the global default subscriber and the `log` bridge can each only
+/// be installed once, so repeated calls are silently ignored.
+fn init_subscriber() {
+    let subscriber = ForeignLoggerSubscriber {
+        next_span_id: AtomicU64::new(1),
+    };
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    let _ =
+        tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Info);
 }
 
 /// Context-aware logging macros that automatically use the current logging context.
@@ -241,9 +276,9 @@ fn init_logger() -> Result<(), log::SetLoggerError> {
 macro_rules! trace {
     ($($arg:tt)*) => {
         if let Some(ctx) = $crate::primitives::logger::get_context() {
-            log::trace!("{} {}", ctx, format_args!($($arg)*))
+            tracing::trace!("{} {}", ctx, format_args!($($arg)*))
         } else {
-            log::trace!($($arg)*)
+            tracing::trace!($($arg)*)
         }
     };
 }
@@ -253,9 +288,9 @@ macro_rules! trace {
 macro_rules! debug {
     ($($arg:tt)*) => {
         if let Some(ctx) = $crate::primitives::logger::get_context() {
-            log::debug!("{} {}", ctx, format_args!($($arg)*))
+            tracing::debug!("{} {}", ctx, format_args!($($arg)*))
         } else {
-            log::debug!($($arg)*)
+            tracing::debug!($($arg)*)
         }
     };
 }
@@ -265,9 +300,9 @@ macro_rules! debug {
 macro_rules! info {
     ($($arg:tt)*) => {
         if let Some(ctx) = $crate::primitives::logger::get_context() {
-            log::info!("{} {}", ctx, format_args!($($arg)*))
+            tracing::info!("{} {}", ctx, format_args!($($arg)*))
         } else {
-            log::info!($($arg)*)
+            tracing::info!($($arg)*)
         }
     };
 }
@@ -277,9 +312,9 @@ macro_rules! info {
 macro_rules! warn {
     ($($arg:tt)*) => {
         if let Some(ctx) = $crate::primitives::logger::get_context() {
-            log::warn!("{} {}", ctx, format_args!($($arg)*))
+            tracing::warn!("{} {}", ctx, format_args!($($arg)*))
         } else {
-            log::warn!($($arg)*)
+            tracing::warn!($($arg)*)
         }
     };
 }
@@ -289,9 +324,9 @@ macro_rules! warn {
 macro_rules! error {
     ($($arg:tt)*) => {
         if let Some(ctx) = $crate::primitives::logger::get_context() {
-            log::error!("{} {}", ctx, format_args!($($arg)*))
+            tracing::error!("{} {}", ctx, format_args!($($arg)*))
         } else {
-            log::error!($($arg)*)
+            tracing::error!($($arg)*)
         }
     };
 }
@@ -305,8 +340,8 @@ macro_rules! error {
 ///
 /// {
 ///     let _bedrock_logger_ctx = LogContext::new("SmartAccount");
-///     log::info!("This will be prefixed with [Bedrock][SmartAccount]");
-///     log::debug!("This too!");
+///     tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
+///     tracing::debug!("This too!");
 /// } // Context automatically cleared here
 /// ```
 pub struct LogContext {
@@ -352,8 +387,8 @@ pub fn get_context() -> Option<String> {
 /// use bedrock::with_log_context;
 ///
 /// with_log_context!("SmartAccount" => {
-///     log::info!("This will be prefixed with [Bedrock][SmartAccount]");
-///     log::debug!("This too!");
+///     tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
+///     tracing::debug!("This too!");
 /// });
 /// ```
 #[macro_export]
@@ -375,7 +410,7 @@ macro_rules! with_log_context {
 /// use bedrock::set_log_context;
 ///
 /// let _bedrock_logger_ctx = set_log_context!("SmartAccount");
-/// log::info!("This will be prefixed with [Bedrock][SmartAccount]");
+/// tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
 /// ```
 #[macro_export]
 macro_rules! set_log_context {

--- a/bedrock/src/primitives/logger.rs
+++ b/bedrock/src/primitives/logger.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::{sync::Arc, sync::OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use tracing::{span, Event, Level, Metadata, Subscriber};
 
@@ -94,26 +94,29 @@ pub enum LogLevel {
     Error,
 }
 
-/// A [`tracing::Subscriber`] that forwards events to the foreign-provided [`Logger`].
+/// A best-effort [`tracing::Subscriber`] that forwards **non-Bedrock** events
+/// (siegel, plus dependencies that log via `tracing`/`log`) to the host [`Logger`].
 ///
-/// This is the internal bridge between Bedrock's `tracing` instrumentation and
-/// the Android/iOS logger. Spans are not recorded: Bedrock relies on the
-/// [`LogContext`] thread-local for contextual prefixes.
+/// Bedrock's own logs never flow through here — they are delivered directly by
+/// [`log_message`], so they reach the host even when another Rust library in the
+/// process owns the global `tracing` dispatcher. This subscriber is installed as
+/// that global default only when it is still free. Spans are not recorded.
 struct ForeignLoggerSubscriber {
-    /// Monotonic source of span identifiers. `tracing` requirement
+    /// Monotonic source of span identifiers, required by the `tracing` contract.
     next_span_id: AtomicU64,
 }
 
 impl Subscriber for ForeignLoggerSubscriber {
-    /// Debug and trace events are only forwarded when they originate from the
-    /// `bedrock` crate. Dependency noise at those levels is rejected at the
+    /// Bedrock's own events use the direct path ([`log_message`]) and are ignored
+    /// here to avoid double-forwarding. Dependency (non-Bedrock) events are
+    /// forwarded at `INFO` and above; their debug/trace noise is rejected at the
     /// callsite so it is never even formatted.
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        let level = *metadata.level();
-        if level == Level::DEBUG || level == Level::TRACE {
-            return is_bedrock_target(metadata);
+        if is_bedrock_target(metadata) {
+            return false;
         }
-        true
+        let level = *metadata.level();
+        level != Level::DEBUG && level != Level::TRACE
     }
 
     fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
@@ -126,19 +129,16 @@ impl Subscriber for ForeignLoggerSubscriber {
 
     fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
 
-    /// Forwards an event to the foreign logger after redacting hex secrets.
+    /// Forwards a dependency event to the host logger after redacting hex secrets.
     fn event(&self, event: &Event<'_>) {
+        let Some(logger) = LOGGER_INSTANCE.get() else {
+            return;
+        };
         let mut visitor = EventVisitor::default();
         event.record(&mut visitor);
         let message = sanitize_hex_secrets(visitor.into_message());
         let level = log_level(*event.metadata().level());
-
-        if let Some(logger) = LOGGER_INSTANCE.get() {
-            logger.log(level, message);
-        } else {
-            // Unreachable via `set_logger`
-            eprintln!("Logger not set: {message}");
-        }
+        logger.log(level, message);
     }
 
     fn enter(&self, _span: &span::Id) {}
@@ -206,16 +206,18 @@ fn log_level(level: Level) -> LogLevel {
     }
 }
 
-/// A global instance of the user-provided logger.
-///
-/// This static variable holds the logger provided by the user and is accessed by
-/// [`ForeignLoggerSubscriber`] to forward log messages.
+/// The host-provided logger. Bedrock's own logs are delivered here directly by
+/// [`log_message`], independent of the global `tracing` dispatcher.
 static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
 
-/// Sets the global logger.
+/// Sets the logger that receives Bedrock's log messages.
 ///
-/// This function allows you to provide your own implementation of the `Logger` trait.
-/// It initializes the logging system and should be called before any logging occurs.
+/// Bedrock's own instrumentation is delivered to `logger` **directly**, so it is
+/// unaffected by whichever Rust library in the process owns the global `tracing`
+/// dispatcher. As a best effort, this also installs a global `tracing` subscriber
+/// (plus a `log` bridge) to forward *dependency* logs — notably siegel's `mlock`
+/// warning — to the same logger; if the global dispatcher is already taken, that
+/// extra capture is skipped and only dependency logs are missed.
 ///
 /// # Arguments
 ///
@@ -223,35 +225,54 @@ static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
 ///
 /// # Note
 ///
-/// Only the first logger is used. Calling this more than once keeps the original
-/// logger and is otherwise a no-op.
+/// Only the first logger is used; later calls keep the original and are no-ops.
 #[allow(clippy::module_name_repetitions)]
 #[uniffi::export]
 pub fn set_logger(logger: Arc<dyn Logger>) {
     if LOGGER_INSTANCE.set(logger).is_err() {
-        // A logger is already installed; keep the first one.
+        // Already configured; the first logger stays active.
         return;
     }
-
-    init_subscriber();
+    install_dependency_capture();
 }
 
-/// Installs the global `tracing` subscriber and the `log` compatibility bridge.
+/// Best-effort install of the global `tracing` subscriber and `log` bridge that
+/// forward dependency (non-Bedrock) logs to the host logger.
 ///
-/// Bedrock instruments with `tracing` directly; the [`tracing_log::LogTracer`]
-/// bridge captures records emitted by dependencies that still use the `log`
-/// crate. Debug and trace records from those dependencies are filtered out here
-/// because [`ForeignLoggerSubscriber`] would drop them anyway.
-///
-/// Idempotent: the global default subscriber and the `log` bridge can each only
-/// be installed once, so repeated calls are silently ignored.
-fn init_subscriber() {
+/// Bedrock's own logging does not depend on this succeeding. If another global
+/// subscriber already owns the dispatcher, dependency logs (e.g. siegel's `mlock`
+/// warning) are not captured; that degradation is reported once, via the direct
+/// path, so it is not silent.
+fn install_dependency_capture() {
     let subscriber = ForeignLoggerSubscriber {
         next_span_id: AtomicU64::new(1),
     };
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    if tracing::subscriber::set_global_default(subscriber).is_err() {
+        crate::warn!(
+            "another global tracing subscriber is already installed; siegel and \
+             dependency logs will not be forwarded (Bedrock's own logs are unaffected)"
+        );
+        return;
+    }
+
+    // Bridge dependencies that still use the `log` crate; `INFO`+ only, since the
+    // subscriber drops dependency debug/trace anyway.
     let _ =
         tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Info);
+}
+
+/// Delivers a Bedrock-originated log record directly to the host [`Logger`],
+/// bypassing the global `tracing` dispatcher so delivery never depends on Bedrock
+/// owning it. Applies the active [`LogContext`] prefix and hex-secret redaction.
+/// A no-op until [`set_logger`] has been called.
+#[doc(hidden)]
+pub fn log_message(level: LogLevel, args: std::fmt::Arguments<'_>) {
+    let Some(logger) = LOGGER_INSTANCE.get() else {
+        return;
+    };
+    let message = get_context()
+        .map_or_else(|| args.to_string(), |context| format!("{context} {args}"));
+    logger.log(level, sanitize_hex_secrets(message));
 }
 
 /// Context-aware logging macros that automatically use the current logging context.
@@ -273,11 +294,10 @@ fn init_subscriber() {
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => {
-        if let Some(ctx) = $crate::primitives::logger::get_context() {
-            tracing::trace!("{} {}", ctx, format_args!($($arg)*))
-        } else {
-            tracing::trace!($($arg)*)
-        }
+        $crate::primitives::logger::log_message(
+            $crate::primitives::logger::LogLevel::Trace,
+            format_args!($($arg)*),
+        )
     };
 }
 
@@ -285,11 +305,10 @@ macro_rules! trace {
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => {
-        if let Some(ctx) = $crate::primitives::logger::get_context() {
-            tracing::debug!("{} {}", ctx, format_args!($($arg)*))
-        } else {
-            tracing::debug!($($arg)*)
-        }
+        $crate::primitives::logger::log_message(
+            $crate::primitives::logger::LogLevel::Debug,
+            format_args!($($arg)*),
+        )
     };
 }
 
@@ -297,11 +316,10 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => {
-        if let Some(ctx) = $crate::primitives::logger::get_context() {
-            tracing::info!("{} {}", ctx, format_args!($($arg)*))
-        } else {
-            tracing::info!($($arg)*)
-        }
+        $crate::primitives::logger::log_message(
+            $crate::primitives::logger::LogLevel::Info,
+            format_args!($($arg)*),
+        )
     };
 }
 
@@ -309,11 +327,10 @@ macro_rules! info {
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => {
-        if let Some(ctx) = $crate::primitives::logger::get_context() {
-            tracing::warn!("{} {}", ctx, format_args!($($arg)*))
-        } else {
-            tracing::warn!($($arg)*)
-        }
+        $crate::primitives::logger::log_message(
+            $crate::primitives::logger::LogLevel::Warn,
+            format_args!($($arg)*),
+        )
     };
 }
 
@@ -321,11 +338,10 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => {
-        if let Some(ctx) = $crate::primitives::logger::get_context() {
-            tracing::error!("{} {}", ctx, format_args!($($arg)*))
-        } else {
-            tracing::error!($($arg)*)
-        }
+        $crate::primitives::logger::log_message(
+            $crate::primitives::logger::LogLevel::Error,
+            format_args!($($arg)*),
+        )
     };
 }
 
@@ -334,12 +350,13 @@ macro_rules! error {
 /// # Examples
 ///
 /// ```rust
+/// use bedrock::{debug, info};
 /// use bedrock::primitives::logger::LogContext;
 ///
 /// {
 ///     let _bedrock_logger_ctx = LogContext::new("SmartAccount");
-///     tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
-///     tracing::debug!("This too!");
+///     info!("This will be prefixed with [Bedrock][SmartAccount]");
+///     debug!("This too!");
 /// } // Context automatically cleared here
 /// ```
 pub struct LogContext {
@@ -382,11 +399,11 @@ pub fn get_context() -> Option<String> {
 /// # Examples
 ///
 /// ```rust
-/// use bedrock::with_log_context;
+/// use bedrock::{debug, info, with_log_context};
 ///
 /// with_log_context!("SmartAccount" => {
-///     tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
-///     tracing::debug!("This too!");
+///     info!("This will be prefixed with [Bedrock][SmartAccount]");
+///     debug!("This too!");
 /// });
 /// ```
 #[macro_export]
@@ -405,10 +422,10 @@ macro_rules! with_log_context {
 /// # Examples
 ///
 /// ```rust
-/// use bedrock::set_log_context;
+/// use bedrock::{info, set_log_context};
 ///
 /// let _bedrock_logger_ctx = set_log_context!("SmartAccount");
-/// tracing::info!("This will be prefixed with [Bedrock][SmartAccount]");
+/// info!("This will be prefixed with [Bedrock][SmartAccount]");
 /// ```
 #[macro_export]
 macro_rules! set_log_context {

--- a/bedrock/src/primitives/logger.rs
+++ b/bedrock/src/primitives/logger.rs
@@ -94,118 +94,6 @@ pub enum LogLevel {
     Error,
 }
 
-/// A best-effort [`tracing::Subscriber`] that forwards **non-Bedrock** events
-/// (siegel, plus dependencies that log via `tracing`/`log`) to the host [`Logger`].
-///
-/// Bedrock's own logs never flow through here — they are delivered directly by
-/// [`log_message`], so they reach the host even when another Rust library in the
-/// process owns the global `tracing` dispatcher. This subscriber is installed as
-/// that global default only when it is still free. Spans are not recorded.
-struct ForeignLoggerSubscriber {
-    /// Monotonic source of span identifiers, required by the `tracing` contract.
-    next_span_id: AtomicU64,
-}
-
-impl Subscriber for ForeignLoggerSubscriber {
-    /// Bedrock's own events use the direct path ([`log_message`]) and are ignored
-    /// here to avoid double-forwarding. Dependency (non-Bedrock) events are
-    /// forwarded at `INFO` and above; their debug/trace noise is rejected at the
-    /// callsite so it is never even formatted.
-    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        if is_bedrock_target(metadata) {
-            return false;
-        }
-        let level = *metadata.level();
-        level != Level::DEBUG && level != Level::TRACE
-    }
-
-    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
-        // `fetch_add` starts at 1 so the id is never 0 (which `Id::from_u64` rejects).
-        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
-        span::Id::from_u64(id)
-    }
-
-    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
-
-    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
-
-    /// Forwards a dependency event to the host logger after redacting hex secrets.
-    fn event(&self, event: &Event<'_>) {
-        let Some(logger) = LOGGER_INSTANCE.get() else {
-            return;
-        };
-        let mut visitor = EventVisitor::default();
-        event.record(&mut visitor);
-        let message = sanitize_hex_secrets(visitor.into_message());
-        let level = log_level(*event.metadata().level());
-        logger.log(level, message);
-    }
-
-    fn enter(&self, _span: &span::Id) {}
-
-    fn exit(&self, _span: &span::Id) {}
-}
-
-/// Returns `true` when the event originates from the `bedrock` crate.
-fn is_bedrock_target(metadata: &Metadata<'_>) -> bool {
-    metadata.target().starts_with("bedrock")
-        || metadata
-            .module_path()
-            .is_some_and(|module_path| module_path.starts_with("bedrock"))
-}
-
-/// Collects a `tracing` event's fields into a single log line.
-///
-/// The `message` field (the format string passed to the logging macros) forms
-/// the body; any additional structured fields are appended as ` key=value` so
-/// they are never silently dropped.
-#[derive(Default)]
-struct EventVisitor {
-    message: String,
-    fields: String,
-}
-
-impl tracing::field::Visit for EventVisitor {
-    fn record_debug(
-        &mut self,
-        field: &tracing::field::Field,
-        value: &dyn std::fmt::Debug,
-    ) {
-        use std::fmt::Write as _;
-        if field.name() == "message" {
-            let _ = write!(self.message, "{value:?}");
-        } else {
-            let _ = write!(self.fields, " {}={value:?}", field.name());
-        }
-    }
-}
-
-impl EventVisitor {
-    /// Consumes the visitor, returning the message with structured fields appended.
-    fn into_message(mut self) -> String {
-        self.message.push_str(&self.fields);
-        self.message
-    }
-}
-
-/// Converts a [`tracing::Level`] to a [`LogLevel`].
-///
-/// `tracing` levels are associated constants rather than enum variants, so this
-/// uses equality comparisons; the final branch necessarily maps [`Level::TRACE`].
-fn log_level(level: Level) -> LogLevel {
-    if level == Level::ERROR {
-        LogLevel::Error
-    } else if level == Level::WARN {
-        LogLevel::Warn
-    } else if level == Level::INFO {
-        LogLevel::Info
-    } else if level == Level::DEBUG {
-        LogLevel::Debug
-    } else {
-        LogLevel::Trace
-    }
-}
-
 /// The host-provided logger. Bedrock's own logs are delivered here directly by
 /// [`log_message`], independent of the global `tracing` dispatcher.
 static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
@@ -234,31 +122,6 @@ pub fn set_logger(logger: Arc<dyn Logger>) {
         return;
     }
     install_dependency_capture();
-}
-
-/// Best-effort install of the global `tracing` subscriber and `log` bridge that
-/// forward dependency (non-Bedrock) logs to the host logger.
-///
-/// Bedrock's own logging does not depend on this succeeding. If another global
-/// subscriber already owns the dispatcher, dependency logs (e.g. siegel's `mlock`
-/// warning) are not captured; that degradation is reported once, via the direct
-/// path, so it is not silent.
-fn install_dependency_capture() {
-    let subscriber = ForeignLoggerSubscriber {
-        next_span_id: AtomicU64::new(1),
-    };
-    if tracing::subscriber::set_global_default(subscriber).is_err() {
-        crate::warn!(
-            "another global tracing subscriber is already installed; siegel and \
-             dependency logs will not be forwarded (Bedrock's own logs are unaffected)"
-        );
-        return;
-    }
-
-    // Bridge dependencies that still use the `log` crate; `INFO`+ only, since the
-    // subscriber drops dependency debug/trace anyway.
-    let _ =
-        tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Info);
 }
 
 /// Delivers a Bedrock-originated log record directly to the host [`Logger`],
@@ -502,6 +365,145 @@ fn has_long_hex_run(bytes: &[u8]) -> bool {
         }
     }
     false
+}
+
+// SECTION: `tracing` dependency capture
+
+/// Best-effort install of the global `tracing` subscriber and `log` bridge that
+/// forward dependency (non-Bedrock) logs to the host logger.
+///
+/// Bedrock's own logging does not depend on this succeeding. If another global
+/// subscriber already owns the dispatcher, dependency logs (e.g. siegel's `mlock`
+/// warning) are not captured; that degradation is reported once, via the direct
+/// path, so it is not silent.
+fn install_dependency_capture() {
+    let subscriber = ForeignLoggerSubscriber {
+        next_span_id: AtomicU64::new(1),
+    };
+    if tracing::subscriber::set_global_default(subscriber).is_err() {
+        crate::warn!(
+            "another global tracing subscriber is already installed; siegel and \
+             dependency logs will not be forwarded (Bedrock's own logs are unaffected)"
+        );
+        return;
+    }
+
+    // Bridge dependencies that still use the `log` crate; `INFO`+ only, since the
+    // subscriber drops dependency debug/trace anyway.
+    let _ =
+        tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Info);
+}
+
+/// A best-effort [`tracing::Subscriber`] that forwards **non-Bedrock** events
+/// (siegel, plus dependencies that log via `tracing`/`log`) to the host [`Logger`].
+///
+/// Bedrock's own logs never flow through here — they are delivered directly by
+/// [`log_message`], so they reach the host even when another Rust library in the
+/// process owns the global `tracing` dispatcher. This subscriber is installed as
+/// that global default only when it is still free. Spans are not recorded.
+struct ForeignLoggerSubscriber {
+    /// Monotonic source of span identifiers, required by the `tracing` contract.
+    next_span_id: AtomicU64,
+}
+
+impl Subscriber for ForeignLoggerSubscriber {
+    /// Bedrock's own events use the direct path ([`log_message`]) and are ignored
+    /// here to avoid double-forwarding. Dependency (non-Bedrock) events are
+    /// forwarded at `INFO` and above; their debug/trace noise is rejected at the
+    /// callsite so it is never even formatted.
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        if is_bedrock_target(metadata) {
+            return false;
+        }
+        let level = *metadata.level();
+        level != Level::DEBUG && level != Level::TRACE
+    }
+
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        // `fetch_add` starts at 1 so the id is never 0 (which `Id::from_u64` rejects).
+        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
+        span::Id::from_u64(id)
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    /// Forwards a dependency event to the host logger after redacting hex secrets.
+    fn event(&self, event: &Event<'_>) {
+        let Some(logger) = LOGGER_INSTANCE.get() else {
+            return;
+        };
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+        let message = sanitize_hex_secrets(visitor.into_message());
+        let level = log_level(*event.metadata().level());
+        logger.log(level, message);
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+/// Returns `true` when the event originates from the `bedrock` crate.
+fn is_bedrock_target(metadata: &Metadata<'_>) -> bool {
+    metadata.target().starts_with("bedrock")
+        || metadata
+            .module_path()
+            .is_some_and(|module_path| module_path.starts_with("bedrock"))
+}
+
+/// Collects a `tracing` event's fields into a single log line.
+///
+/// The `message` field (the format string passed to the logging macros) forms
+/// the body; any additional structured fields are appended as ` key=value` so
+/// they are never silently dropped.
+#[derive(Default)]
+struct EventVisitor {
+    message: String,
+    fields: String,
+}
+
+impl tracing::field::Visit for EventVisitor {
+    fn record_debug(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        use std::fmt::Write as _;
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={value:?}", field.name());
+        }
+    }
+}
+
+impl EventVisitor {
+    /// Consumes the visitor, returning the message with structured fields appended.
+    fn into_message(mut self) -> String {
+        self.message.push_str(&self.fields);
+        self.message
+    }
+}
+
+/// Converts a [`tracing::Level`] to a [`LogLevel`].
+///
+/// `tracing` levels are associated constants rather than enum variants, so this
+/// uses equality comparisons; the final branch necessarily maps [`Level::TRACE`].
+fn log_level(level: Level) -> LogLevel {
+    if level == Level::ERROR {
+        LogLevel::Error
+    } else if level == Level::WARN {
+        LogLevel::Warn
+    } else if level == Level::INFO {
+        LogLevel::Info
+    } else if level == Level::DEBUG {
+        LogLevel::Debug
+    } else {
+        LogLevel::Trace
+    }
 }
 
 #[cfg(test)]

--- a/bedrock/src/primitives/logger.rs
+++ b/bedrock/src/primitives/logger.rs
@@ -103,9 +103,7 @@ static LOGGER_INSTANCE: OnceLock<Arc<dyn Logger>> = OnceLock::new();
 /// Bedrock's own instrumentation is delivered to `logger` **directly**, so it is
 /// unaffected by whichever Rust library in the process owns the global `tracing`
 /// dispatcher. As a best effort, this also installs a global `tracing` subscriber
-/// (plus a `log` bridge) to forward *dependency* logs — notably siegel's `mlock`
-/// warning — to the same logger; if the global dispatcher is already taken, that
-/// extra capture is skipped and only dependency logs are missed.
+/// to forward relevant *dependency* logs (notably siegel's `mlock` warning).
 ///
 /// # Arguments
 ///
@@ -369,13 +367,10 @@ fn has_long_hex_run(bytes: &[u8]) -> bool {
 
 // SECTION: `tracing` dependency capture
 
-/// Best-effort install of the global `tracing` subscriber and `log` bridge that
+/// Best-effort install of the global `tracing` subscriber and
 /// forward dependency (non-Bedrock) logs to the host logger.
 ///
-/// Bedrock's own logging does not depend on this succeeding. If another global
-/// subscriber already owns the dispatcher, dependency logs (e.g. siegel's `mlock`
-/// warning) are not captured; that degradation is reported once, via the direct
-/// path, so it is not silent.
+/// Bedrock's own logging does not depend on this succeeding.
 fn install_dependency_capture() {
     let subscriber = ForeignLoggerSubscriber {
         next_span_id: AtomicU64::new(1),
@@ -388,19 +383,14 @@ fn install_dependency_capture() {
         return;
     }
 
-    // Bridge dependencies that still use the `log` crate; `INFO`+ only, since the
-    // subscriber drops dependency debug/trace anyway.
     let _ =
-        tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Info);
+        tracing_log::LogTracer::init_with_filter(tracing_log::log::LevelFilter::Warn);
 }
 
 /// A best-effort [`tracing::Subscriber`] that forwards **non-Bedrock** events
 /// (siegel, plus dependencies that log via `tracing`/`log`) to the host [`Logger`].
 ///
-/// Bedrock's own logs never flow through here — they are delivered directly by
-/// [`log_message`], so they reach the host even when another Rust library in the
-/// process owns the global `tracing` dispatcher. This subscriber is installed as
-/// that global default only when it is still free. Spans are not recorded.
+/// Spans are not recorded.
 struct ForeignLoggerSubscriber {
     /// Monotonic source of span identifiers, required by the `tracing` contract.
     next_span_id: AtomicU64,
@@ -409,18 +399,17 @@ struct ForeignLoggerSubscriber {
 impl Subscriber for ForeignLoggerSubscriber {
     /// Bedrock's own events use the direct path ([`log_message`]) and are ignored
     /// here to avoid double-forwarding. Dependency (non-Bedrock) events are
-    /// forwarded at `INFO` and above; their debug/trace noise is rejected at the
+    /// forwarded at `WARN` and above; their debug/trace noise is rejected at the
     /// callsite so it is never even formatted.
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         if is_bedrock_target(metadata) {
             return false;
         }
         let level = *metadata.level();
-        level != Level::DEBUG && level != Level::TRACE
+        level == Level::WARN || level == Level::ERROR
     }
 
     fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
-        // `fetch_add` starts at 1 so the id is never 0 (which `Id::from_u64` rejects).
         let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
         span::Id::from_u64(id)
     }

--- a/bedrock/src/primitives/logger.rs
+++ b/bedrock/src/primitives/logger.rs
@@ -94,15 +94,13 @@ pub enum LogLevel {
     Error,
 }
 
-/// A [`tracing::Subscriber`] that forwards events to the foreign [`Logger`].
+/// A [`tracing::Subscriber`] that forwards events to the foreign-provided [`Logger`].
 ///
 /// This is the internal bridge between Bedrock's `tracing` instrumentation and
-/// the platform-provided logger. Spans are not recorded: Bedrock relies on the
-/// [`LogContext`] thread-local for contextual prefixes rather than span state,
-/// so span callbacks are no-ops.
+/// the Android/iOS logger. Spans are not recorded: Bedrock relies on the
+/// [`LogContext`] thread-local for contextual prefixes.
 struct ForeignLoggerSubscriber {
-    /// Monotonic source of span identifiers. Spans carry no data, but the
-    /// `tracing` contract requires a unique non-zero [`span::Id`] per span.
+    /// Monotonic source of span identifiers. `tracing` requirement
     next_span_id: AtomicU64,
 }
 

--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -126,7 +126,6 @@ impl From<SessionError> for SafeSmartAccountError {
             SessionError::Consumed => "consumed",
             SessionError::AllocationFailed { .. } => "allocation_failed",
             SessionError::ProtectionFailed { .. } => "protection_failed",
-            SessionError::LockFailed { .. } => "lock_failed",
             SessionError::CanaryCorrupted => "canary_corrupted",
             SessionError::TooManyActiveSessions => "too_many_active_sessions",
             SessionError::HandleAllocationFailed { .. } => "handle_allocation_failed",


### PR DESCRIPTION
- Moves logging to `tracing` crate as opposed to `log` to better leverage logs from other crates.
- Bumps siegel to `0.3.0` which makes `mlock` best effort (for full Android support). Enables the `tracing`	feature for this crate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Logging behavior changes globally (host vs dependency forwarding, warn-only bridge) and siegel 0.3.0 touches secure-memory/session paths; risk is moderate rather than low despite no crypto logic edits in the diff.
> 
> **Overview**
> **Bedrock logging** no longer registers a `log::Log` implementation. The `trace!` / `debug!` / `info!` / `warn!` / `error!` macros call `log_message`, which sends records straight to the UniFFI `Logger` with context prefixing and hex redaction—without requiring Bedrock to own the global `tracing` dispatcher.
> 
> On **`set_logger`**, Bedrock best-effort installs a custom `tracing` subscriber plus `tracing-log` (warn+) so **non-Bedrock** dependency output (notably **siegel** with its `tracing` feature) can reach the same host logger; Bedrock-target events are filtered out to avoid double delivery. Call sites that used `log::` in backup, Turnkey, and migration now use the `crate::` macros.
> 
> **Dependencies:** `log` is removed from `bedrock/Cargo.toml`; **`tracing`**, **`tracing-log`**, and **`siegel-uniffi` `0.3.0`** (with `features = ["tracing"]`) are added—aligned with siegel making **`mlock` best-effort** for Android. **`SessionError::LockFailed`** is dropped from the Siegel session → `SafeSmartAccountError` mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf9a86ed1504cebe2f571bd370607bcc99ecb06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->