### PR TITLE
fix: bump ruint to address RUSTSEC-2026-0220

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/deny.toml
+++ b/deny.toml
@@ -51,5 +51,4 @@ license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 ignore = [
   "RUSTSEC-2024-0436", # Unmaintained `paste` (2025-04-04)
   "RUSTSEC-2021-0127", # serde_cbor is unmaintained. We use this in AWS NSM package but just for the AttestationDocument Type
-  "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained; transitive dep via alloy -> alloy-sol-types -> alloy-sol-macro, no safe upgrade available
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only security patch for a numeric/crypto helper crate used via Alloy; no direct logic changes in this PR.
> 
> **Overview**
> Addresses **RUSTSEC-2026-0220** by updating the transitive **`ruint`** dependency in **`Cargo.lock`** from **1.19.0** to **1.20.0** (no application source changes in this diff).
> 
> **`deny.toml`** drops the **`[advisories].ignore`** entry for **RUSTSEC-2026-0173** (`proc-macro-error2` unmaintained), so `cargo-deny` will surface that advisory again unless the lockfile graph no longer needs the exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3847096b934a8dc873bbea50200e0c3da25518b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->