### PR TITLE
chore: pin all gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/version-alignment
         with:
@@ -37,9 +39,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
 
@@ -65,9 +69,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
@@ -76,7 +82,7 @@ jobs:
         run: cargo xtask swift build
 
       - name: Upload Swift build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 https://github.com/actions/upload-artifact/releases/tag/v7.0.1
         with:
           name: bedrock-swift-build
           path: |
@@ -106,19 +112,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Select Xcode ${{ matrix.xcode-version }}
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0 https://github.com/maxim-lobanov/setup-xcode/releases/tag/v1.7.0
         with:
           xcode-version: ${{ matrix.xcode-version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
 
       - name: Download Swift build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 https://github.com/actions/download-artifact/releases/tag/v8.0.1
         with:
           name: bedrock-swift-build
           path: swift
@@ -141,17 +149,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
 
       - name: Add forge to PATH
-        run: echo "FORGE_BIN=$(which forge)" >> $GITHUB_ENV
+        run: echo "FORGE_BIN=$(which forge)" >> "$GITHUB_ENV"
 
       - name: Run tests
         env:
@@ -176,9 +186,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.1.1
         with:
           command: check ${{ matrix.checks }}
           rust-version: stable
@@ -191,9 +203,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,13 +31,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      with:
+        persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6 https://github.com/github/codeql-action/releases/tag/v4.37.6
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6 https://github.com/github/codeql-action/releases/tag/v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release-swift-kotlin.yml
+++ b/.github/workflows/release-swift-kotlin.yml
@@ -15,13 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Get new version
         id: version
         run: |
           NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members[0]' | cut -d '#' -f2)
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
   build-swift:
     name: Publish Swift
@@ -32,22 +34,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }}
+          persist-credentials: false
 
       - name: Checkout swift mirror repo
-        uses: actions/checkout@v6
+        # Credentials must persist: the "Commit swift build" step below pushes to this repo.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           repository: worldcoin/bedrock-swift
           path: target-repo
           token: ${{ secrets.DEPLOY_BOT_TOKEN }}
 
       - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0 https://github.com/swift-actions/setup-swift/releases/tag/v2.4.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
@@ -60,7 +64,7 @@ jobs:
           zip -r Bedrock.xcframework.zip swift/Bedrock.xcframework
 
       - name: Create draft release in bedrock-swift & upload binaries
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2 https://github.com/softprops/action-gh-release/releases/tag/v3.0.2
         id: release
         with:
           repository: worldcoin/bedrock-swift
@@ -77,10 +81,10 @@ jobs:
         id: meta
         run: |
           ASSET_URL="${{ fromJSON(steps.release.outputs.assets)[0].url }}.zip"
-          echo "asset_url=${ASSET_URL}" >> $GITHUB_OUTPUT
+          echo "asset_url=${ASSET_URL}" >> "$GITHUB_OUTPUT"
 
           CHECKSUM=$(swift package compute-checksum Bedrock.xcframework.zip)
-          echo "checksum=${CHECKSUM}" >> $GITHUB_OUTPUT
+          echo "checksum=${CHECKSUM}" >> "$GITHUB_OUTPUT"
 
       - name: Commit swift build
         env:
@@ -100,9 +104,9 @@ jobs:
           git add .
           git commit -m "Release $NEW_VERSION"
 
-          git tag $NEW_VERSION
+          git tag "$NEW_VERSION"
           git push
-          git push origin $NEW_VERSION
+          git push origin "$NEW_VERSION"
 
       - name: Mark release as latest
         env:
@@ -131,12 +135,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }}
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
@@ -150,7 +155,7 @@ jobs:
           CROSS_NO_WARNINGS=0 cross build --target ${{ matrix.settings.target }} --release --locked
 
       - name: Upload artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 https://github.com/actions/upload-artifact/releases/tag/v7.0.1
         with:
           name: android-${{ matrix.settings.target }}
           path: ./target/${{ matrix.settings.target }}/release/libbedrock.so
@@ -166,23 +171,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }}
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
           toolchain: stable
 
       - name: Setup Java
-        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0 https://github.com/actions/setup-java/releases/tag/v5.7.0
         with:
           distribution: temurin
           java-version: 17
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 https://github.com/actions/download-artifact/releases/tag/v8.0.1
         with:
           path: .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,17 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
+        with:
+          toolchain: stable
 
       - name: Run release-plz
-        uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5.127
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131 https://github.com/release-plz/action/releases/tag/v0.5.131
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOY_BOT_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1 https://github.com/amannn/action-semantic-pull-request/releases/tag/v6.1.1
     env:
       GITHUB_TOKEN: ${{ github.token }} # granting access only to read pull requests


### PR DESCRIPTION
Resolves recommended security advisories by:
- Pinning all GH actions to specific commit hashes. 
- Setting `persist-credential: false`. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and Swift mirror push flows depend on correct checkout credential behavior; mis-pinning or wrong persist-credentials on the mirror checkout could break publishes, but application/runtime code is unchanged.
> 
> **Overview**
> Pins third-party GitHub Actions across **CI**, **CodeQL**, **release**, **Swift/Kotlin FFI release**, and **PR title validation** workflows from floating tags (`@v4`, `@stable`, etc.) to immutable commit SHAs, with inline comments noting the release version.
> 
> Most `actions/checkout` steps now set **`persist-credentials: false`** so the job does not retain a writable git credential after clone; the **bedrock-swift** mirror checkout in the release workflow is left without that flag (documented) because a later step pushes with `DEPLOY_BOT_TOKEN`.
> 
> Minor hardening in shell steps: quote `"$GITHUB_OUTPUT"` / `"$GITHUB_ENV"` and tag variables in the Swift release push script. **`release.yml`** also pins `release-plz/action` and adds an explicit `toolchain: stable` on the Rust toolchain step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f413167247d62009953a13447a4c58ef2f77cbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->