### PR TITLE
feat: turnkey migration - sync factor policy 

### DIFF
--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -310,6 +310,12 @@ impl TurnkeyApiClient {
     /// All `providers` are submitted in a **single** `CreateOauthProviders`
     /// activity, so they are added atomically.
     ///
+    /// Please note this activity only adds new providers, it does not replace or upsert. If
+    /// the same (aud,sub,iss) combination for an existing login method is used for a new one,
+    /// it will be rejected by the API.
+    ///
+    /// Reference: <https://docs.turnkey.com/features/authentication/social-logins>
+    ///
     /// # Errors
     /// Returns [`TurnkeyApiError`] on transport, stamping, activity, or parsing failures.
     pub async fn create_oauth_providers(

--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -6,9 +6,8 @@
 //! in-memory for the lifetime of a single client so that multiple migrations
 //! reading the same data do not issue duplicate calls.
 
-use std::collections::HashMap;
 use std::future::Future;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -18,12 +17,13 @@ use sha2::{Digest, Sha256};
 use turnkey_api_key_stamper::{
     Stamp, StampHeader, StamperError, API_KEY_STAMP_HEADER_NAME, SIGNATURE_SCHEME_P256,
 };
-use turnkey_client::generated::external::data::v1::User;
+use turnkey_client::generated::external::data::v1::{Policy, User};
 use turnkey_client::generated::immutable::activity::v1::{
-    CreateOauthProvidersIntentV2, OauthProviderParamsV2,
+    CreateOauthProvidersIntentV2, CreatePolicyIntentV3, DeletePolicyIntent,
+    OauthProviderParamsV2, UpdatePolicyIntentV2,
 };
 use turnkey_client::generated::services::coordinator::public::v1::{
-    GetUsersRequest, GetWhoamiRequest,
+    GetPoliciesRequest, GetUsersRequest, GetWhoamiRequest,
 };
 use turnkey_client::{RetryConfig, TurnkeyClient};
 
@@ -130,13 +130,83 @@ fn backoff_delay(attempt: u32, policy: &RetryPolicy) -> Duration {
     Duration::from_millis(rand::random::<u64>() % ceil_ms.saturating_add(1))
 }
 
+/// A cache of one query result for a **single** sub-organization.
+///
+/// A [`TurnkeyApiClient`] serves exactly one sub-organization for its lifetime (a
+/// user has exactly one), so the cache holds at most one entry. Reading it for a
+/// different sub-org is a consistency violation.
+struct OrgCache<T> {
+    /// The cached `(suborganization_id, value)`, or `None` when empty. The value is
+    /// held behind an [`Arc`] so reads share one allocation rather than deep-copying.
+    entry: Mutex<Option<(String, Arc<T>)>>,
+    /// Names this cache in the poison-recovery log.
+    label: &'static str,
+}
+
+impl<T> OrgCache<T> {
+    const fn new(label: &'static str) -> Self {
+        Self {
+            entry: Mutex::new(None),
+            label,
+        }
+    }
+
+    /// Locks the entry, recovering from poisoning by discarding its (always
+    /// reconstructible) contents.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<(String, Arc<T>)>> {
+        match self.entry.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                crate::warn!(
+                    "turnkey.cache.poisoned: discarding in-memory {} cache and recovering",
+                    self.label
+                );
+                self.entry.clear_poison();
+                let mut guard = poisoned.into_inner();
+                *guard = None;
+                guard
+            }
+        }
+    }
+
+    /// Returns a shared handle to the cached value for `suborganization_id`, if any.
+    ///
+    /// # Errors
+    /// [`TurnkeyApiError::Consistency`] if a *different* sub-organization is
+    /// cached. A client only ever serves one sub-org, so this must never happen;
+    /// it signals a critical consistency problem.
+    fn get(&self, suborganization_id: &str) -> Result<Option<Arc<T>>, TurnkeyApiError> {
+        match &*self.lock() {
+            Some((cached, value)) if cached == suborganization_id => {
+                Ok(Some(Arc::clone(value)))
+            }
+            Some(_) => Err(TurnkeyApiError::Consistency),
+            None => Ok(None),
+        }
+    }
+
+    /// Caches `value` for `suborganization_id` (replacing any previous entry) and
+    /// returns the shared handle, so the caller reuses the same allocation.
+    fn store(&self, suborganization_id: &str, value: T) -> Arc<T> {
+        let value = Arc::new(value);
+        *self.lock() = Some((suborganization_id.to_string(), Arc::clone(&value)));
+        value
+    }
+
+    /// Drops the cached entry (e.g. after a write changes the underlying data).
+    fn clear(&self) {
+        *self.lock() = None;
+    }
+}
+
 /// Turnkey API client using the Turnkey SDK plus Bedrock's retry and caching.
 ///
-/// `get_users` responses are cached for the lifetime of the client (a single
-/// `check_migrations` run), keyed by sub-organization id.
+/// Unless otherwise noted, all read operations are cached in-memory for the
+/// lifetime of this client.
 pub struct TurnkeyApiClient {
     retry: RetryPolicy,
-    users_cache: Mutex<HashMap<String, Vec<User>>>,
+    users_cache: OrgCache<Vec<User>>,
+    policies_cache: OrgCache<Vec<Policy>>,
     /// Overrides the SDK's default Turnkey base URL. `None` in production; set
     /// only in tests to point the real client at a mock HTTP server.
     base_url: Option<String>,
@@ -148,7 +218,8 @@ impl TurnkeyApiClient {
     pub fn new() -> Self {
         Self {
             retry: RetryPolicy::default(),
-            users_cache: Mutex::new(HashMap::new()),
+            users_cache: OrgCache::new("user"),
+            policies_cache: OrgCache::new("policy"),
             base_url: None,
         }
     }
@@ -209,34 +280,6 @@ impl TurnkeyApiClient {
             }
         }
     }
-
-    /// Locks the users cache, recovering from poisoning.
-    ///
-    /// A poisoned lock means a prior holder panicked and may have left the map
-    /// inconsistent. The cache is always reconstructible so discard and move on.
-    fn lock_cache(&self) -> std::sync::MutexGuard<'_, HashMap<String, Vec<User>>> {
-        match self.users_cache.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                crate::error!(
-                    "turnkey.cache.poisoned: discarding in-memory user cache and recovering"
-                );
-                self.users_cache.clear_poison();
-                let mut guard = poisoned.into_inner();
-                guard.clear();
-                guard
-            }
-        }
-    }
-
-    fn cached_users(&self, suborganization_id: &str) -> Option<Vec<User>> {
-        self.lock_cache().get(suborganization_id).cloned()
-    }
-
-    fn cache_users(&self, suborganization_id: &str, users: &[User]) {
-        self.lock_cache()
-            .insert(suborganization_id.to_string(), users.to_vec());
-    }
 }
 
 /// # Warning
@@ -272,7 +315,7 @@ impl TurnkeyApiClient {
         .await
     }
 
-    /// Lists the users of a sub-organization (stamped by the read/query signer).
+    /// Lists the users of a sub-organization.
     ///
     /// Results are cached for the lifetime of this client.
     ///
@@ -282,8 +325,8 @@ impl TurnkeyApiClient {
         &self,
         suborganization_id: &str,
         signer: SyncFactor<'_>,
-    ) -> Result<Vec<User>, TurnkeyApiError> {
-        if let Some(cached) = self.cached_users(suborganization_id) {
+    ) -> Result<Arc<Vec<User>>, TurnkeyApiError> {
+        if let Some(cached) = self.users_cache.get(suborganization_id)? {
             return Ok(cached);
         }
         let client = self.sdk_client(signer.0)?;
@@ -301,11 +344,10 @@ impl TurnkeyApiClient {
             })
             .await?;
 
-        self.cache_users(suborganization_id, &users);
-        Ok(users)
+        Ok(self.users_cache.store(suborganization_id, users))
     }
 
-    /// Creates OAuth providers on a user (stamped by the write/submit signer).
+    /// Creates OAuth providers on a user (needs a [`MainFactor`] signer).
     ///
     /// All `providers` are submitted in a **single** `CreateOauthProviders`
     /// activity, so they are added atomically.
@@ -356,7 +398,135 @@ impl TurnkeyApiClient {
         }
 
         // User has changed, remove the cache
-        self.lock_cache().remove(suborganization_id);
+        self.users_cache.clear();
+        Ok(())
+    }
+
+    /// Lists the policies of a sub-organization.
+    ///
+    /// Results are cached for the lifetime of this client; the policy writes
+    /// ([`Self::create_policy`], [`Self::update_policy`]) invalidate the cache.
+    ///
+    /// # Errors
+    /// Returns [`TurnkeyApiError`] on transport, stamping, or parsing failures.
+    pub async fn get_policies(
+        &self,
+        suborganization_id: &str,
+        signer: SyncFactor<'_>,
+    ) -> Result<Arc<Vec<Policy>>, TurnkeyApiError> {
+        if let Some(cached) = self.policies_cache.get(suborganization_id)? {
+            return Ok(cached);
+        }
+        let client = self.sdk_client(signer.0)?;
+        let request = GetPoliciesRequest {
+            organization_id: suborganization_id.to_string(),
+        };
+
+        let policies = self
+            .with_retry("get_policies", || async {
+                client
+                    .get_policies(request.clone())
+                    .await
+                    .map(|response| response.policies)
+                    .map_err(TurnkeyApiError::from)
+            })
+            .await?;
+
+        Ok(self.policies_cache.store(suborganization_id, policies))
+    }
+
+    /// Creates a policy on the sub-organization (needs a [`MainFactor`] signer).
+    ///
+    /// # Errors
+    /// Returns [`TurnkeyApiError`] on transport, stamping, activity, or parsing failures.
+    pub async fn create_policy(
+        &self,
+        suborganization_id: &str,
+        policy: CreatePolicyIntentV3,
+        signer: MainFactor<'_>,
+    ) -> Result<(), TurnkeyApiError> {
+        let client = self.sdk_client(signer.0)?;
+        let timestamp_ms = ntp_timestamp_ms()?;
+        self.with_retry("create_policy", || async {
+            client
+                .create_policy(
+                    suborganization_id.to_string(),
+                    timestamp_ms,
+                    policy.clone(),
+                )
+                .await
+                .map(|_activity| ())
+                .map_err(TurnkeyApiError::from)
+        })
+        .await?;
+
+        // Policies have changed; drop the stale cache entry.
+        self.policies_cache.clear();
+        Ok(())
+    }
+
+    /// Updates an existing policy (needs a [`MainFactor`] signer).
+    ///
+    /// Only the fields set on `params` are changed; a `None` field is left as-is.
+    ///
+    /// # Errors
+    /// Returns [`TurnkeyApiError`] on transport, stamping, activity, or parsing failures.
+    pub async fn update_policy(
+        &self,
+        suborganization_id: &str,
+        params: UpdatePolicyIntentV2,
+        signer: MainFactor<'_>,
+    ) -> Result<(), TurnkeyApiError> {
+        let client = self.sdk_client(signer.0)?;
+        let timestamp_ms = ntp_timestamp_ms()?;
+        self.with_retry("update_policy", || async {
+            client
+                .update_policy(
+                    suborganization_id.to_string(),
+                    timestamp_ms,
+                    params.clone(),
+                )
+                .await
+                .map(|_activity| ())
+                .map_err(TurnkeyApiError::from)
+        })
+        .await?;
+
+        // Policies have changed; drop the stale cache entry.
+        self.policies_cache.clear();
+        Ok(())
+    }
+
+    /// Deletes a policy from the sub-organization (needs a [`MainFactor`] signer).
+    ///
+    /// # Errors
+    /// Returns [`TurnkeyApiError`] on transport, stamping, activity, or parsing failures.
+    pub async fn delete_policy(
+        &self,
+        suborganization_id: &str,
+        policy_id: &str,
+        signer: MainFactor<'_>,
+    ) -> Result<(), TurnkeyApiError> {
+        let client = self.sdk_client(signer.0)?;
+        let intent = DeletePolicyIntent {
+            policy_id: policy_id.to_string(),
+        };
+        let timestamp_ms = ntp_timestamp_ms()?;
+        self.with_retry("delete_policy", || async {
+            client
+                .delete_policy(
+                    suborganization_id.to_string(),
+                    timestamp_ms,
+                    intent.clone(),
+                )
+                .await
+                .map(|_activity| ())
+                .map_err(TurnkeyApiError::from)
+        })
+        .await?;
+
+        // Policies have changed; drop the stale cache entry.
+        self.policies_cache.clear();
         Ok(())
     }
 }

--- a/bedrock/src/backup/turnkey/migrations/apple_audience.rs
+++ b/bedrock/src/backup/turnkey/migrations/apple_audience.rs
@@ -55,7 +55,7 @@ impl TurnkeyMigration for MigrationAppleAudience {
             .get_users(ctx.suborganization_id, ctx.sync_factor)
             .await?;
 
-        let plan = plan(users, ctx.environment)?;
+        let plan = plan(&users, ctx.environment)?;
 
         match plan {
             Plan::SkipNoAppleProvider | Plan::SkipReady => {
@@ -119,11 +119,11 @@ impl std::fmt::Display for Plan {
 /// # Errors
 /// Returns [`TurnkeyApiError::MainUserNotFound`] if `auth_user_main` is absent.
 fn plan(
-    users: Vec<User>,
+    users: &[User],
     environment: BedrockEnvironment,
 ) -> Result<Plan, TurnkeyApiError> {
     let user = users
-        .into_iter()
+        .iter()
         .find(|user| user.user_name == AUTH_USER_MAIN_USERNAME)
         .ok_or(TurnkeyApiError::MainUserNotFound)?;
 
@@ -193,7 +193,7 @@ fn plan(
         .collect();
 
     Ok(Plan::Create {
-        user_id: user.user_id,
+        user_id: user.user_id.clone(),
         providers,
     })
 }
@@ -250,7 +250,7 @@ mod tests {
         }))];
 
         assert!(matches!(
-            plan(users, BedrockEnvironment::Staging),
+            plan(&users, BedrockEnvironment::Staging),
             Ok(Plan::SkipNoAppleProvider)
         ));
     }
@@ -261,7 +261,7 @@ mod tests {
         let users = vec![main_user_with_apple(&auds, "sub-1")];
 
         assert!(matches!(
-            plan(users, BedrockEnvironment::Staging),
+            plan(&users, BedrockEnvironment::Staging),
             Ok(Plan::SkipReady)
         ));
     }
@@ -272,7 +272,7 @@ mod tests {
         let users = vec![main_user_with_apple(&["org.worldcoin.insight"], "sub-prod")];
 
         let Plan::Create { providers, .. } =
-            plan(users, BedrockEnvironment::Production).unwrap()
+            plan(&users, BedrockEnvironment::Production).unwrap()
         else {
             panic!("expected Create plan");
         };
@@ -294,7 +294,7 @@ mod tests {
         let users = vec![main_user_with_apple(&auds[..1], "sub-apple")];
 
         let Plan::Create { user_id, providers } =
-            plan(users, BedrockEnvironment::Staging).unwrap()
+            plan(&users, BedrockEnvironment::Staging).unwrap()
         else {
             panic!("expected Create plan");
         };
@@ -333,7 +333,7 @@ mod tests {
         }))];
 
         assert!(matches!(
-            plan(users, BedrockEnvironment::Staging),
+            plan(&users, BedrockEnvironment::Staging),
             Err(TurnkeyApiError::MainUserNotFound)
         ));
     }
@@ -363,7 +363,7 @@ mod tests {
         }))];
 
         assert!(matches!(
-            plan(users, BedrockEnvironment::Staging),
+            plan(&users, BedrockEnvironment::Staging),
             Err(TurnkeyApiError::Consistency)
         ));
     }
@@ -404,7 +404,7 @@ mod tests {
         }))];
 
         assert!(matches!(
-            plan(users, BedrockEnvironment::Staging),
+            plan(&users, BedrockEnvironment::Staging),
             Ok(Plan::SkipReady)
         ));
     }

--- a/bedrock/src/backup/turnkey/migrations/apple_audience.rs
+++ b/bedrock/src/backup/turnkey/migrations/apple_audience.rs
@@ -160,7 +160,7 @@ fn plan(
     let unrecognized: Vec<&str> = existing.difference(&configured).copied().collect();
     if !unrecognized.is_empty() {
         crate::warn!(
-            "auth_user_main has unrecognized Apple aduences: {}",
+            "auth_user_main has unrecognized Apple audiences: {}",
             unrecognized.join(", ")
         );
     }
@@ -174,6 +174,8 @@ fn plan(
         return Ok(Plan::SkipReady);
     }
 
+    // Please note that the [`TurnkeyApiClient::create_oauth_providers`] activity
+    // that this will result into is ADDITIVE. It doesn't replace or upsert existing configuration.
     let providers = missing
         .iter()
         .map(|audience| OauthProviderParamsV2 {

--- a/bedrock/src/backup/turnkey/migrations/apple_audience.rs
+++ b/bedrock/src/backup/turnkey/migrations/apple_audience.rs
@@ -25,8 +25,12 @@ use super::{MigrationContext, MigrationOutcome, TurnkeyMigration};
 /// NOTE that Apple assigns the same `sub` to all Apple OIDC tokens under the same developer
 /// account.
 ///
-/// If the user already has at least one Apple provider, its `subject` is reused
-/// and all remaining providers are created. If the user has no Apple provider at all, this is a no-op.
+/// If the user already has at least one Apple provider, its `subject` is reused and all remaining
+/// providers are created. If the user has no Apple provider at all, this is a no-op.
+///
+/// # Why?
+/// This migration is necessary because initially only a single client was used (World App iOS),
+/// so when registering an Apple OIDC factor only one audience was registered.
 ///
 /// # Main Factor
 /// If operations need to be executed, this migration REQUIRES a Main Factor.

--- a/bedrock/src/backup/turnkey/migrations/mod.rs
+++ b/bedrock/src/backup/turnkey/migrations/mod.rs
@@ -8,8 +8,10 @@ use super::api::{MainFactor, SyncFactor, TurnkeyApiClient};
 use super::error::TurnkeyApiError;
 
 mod apple_audience;
+mod sync_factor_deletion_policy;
 
 use apple_audience::MigrationAppleAudience;
+use sync_factor_deletion_policy::MigrationSyncFactorDeletionPolicy;
 
 /// Every Turnkey migration, in the order they are applied.
 ///
@@ -18,12 +20,16 @@ use apple_audience::MigrationAppleAudience;
 ///
 /// The list fails fast on the first error, so order first cheaper migrations, more likely
 /// to be skipped, or the ones not requiring a Main Factor.
-pub(super) const MIGRATIONS: &[&dyn TurnkeyMigration] = &[&MigrationAppleAudience];
+pub(super) const MIGRATIONS: &[&dyn TurnkeyMigration] =
+    &[&MigrationAppleAudience, &MigrationSyncFactorDeletionPolicy];
 
 // TODO Migrations:
 // 1. Ensure `auth_user_main` is the only one in the root quorum (housekeeping)
 // 2. Ensure break glass user exists and has the correct policy
-// 3. Ensure all sync factors have the right deletion policy
+// 3. Remove stale deletion policies: delete any `EFFECT_ALLOW` deletion policy whose
+//    consensus binds a user id that no longer exists as a sync factor (e.g. left behind
+//    when a sync factor was removed). Pairs with `sync_factor_deletion_policy`, which
+//    only adds/updates; this one prunes unmatched policies.
 // 4. Ensure max number of sync factor users and policies (port over from Android)
 
 /// Global result from running the entire set of migrations.

--- a/bedrock/src/backup/turnkey/migrations/mod.rs
+++ b/bedrock/src/backup/turnkey/migrations/mod.rs
@@ -8,10 +8,10 @@ use super::api::{MainFactor, SyncFactor, TurnkeyApiClient};
 use super::error::TurnkeyApiError;
 
 mod apple_audience;
-mod sync_factor_deletion_policy;
+mod sync_factor_policy;
 
 use apple_audience::MigrationAppleAudience;
-use sync_factor_deletion_policy::MigrationSyncFactorDeletionPolicy;
+use sync_factor_policy::MigrationSyncFactorPolicy;
 
 /// Every Turnkey migration, in the order they are applied.
 ///
@@ -21,16 +21,12 @@ use sync_factor_deletion_policy::MigrationSyncFactorDeletionPolicy;
 /// The list fails fast on the first error, so order first cheaper migrations, more likely
 /// to be skipped, or the ones not requiring a Main Factor.
 pub(super) const MIGRATIONS: &[&dyn TurnkeyMigration] =
-    &[&MigrationAppleAudience, &MigrationSyncFactorDeletionPolicy];
+    &[&MigrationAppleAudience, &MigrationSyncFactorPolicy];
 
 // TODO Migrations:
 // 1. Ensure `auth_user_main` is the only one in the root quorum (housekeeping)
 // 2. Ensure break glass user exists and has the correct policy
-// 3. Remove stale deletion policies: delete any `EFFECT_ALLOW` deletion policy whose
-//    consensus binds a user id that no longer exists as a sync factor (e.g. left behind
-//    when a sync factor was removed). Pairs with `sync_factor_deletion_policy`, which
-//    only adds/updates; this one prunes unmatched policies.
-// 4. Ensure max number of sync factor users and policies (port over from Android)
+// 3. Ensure max number of sync factor users and policies (port over from Android)
 
 /// Global result from running the entire set of migrations.
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]

--- a/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
+++ b/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
@@ -16,11 +16,12 @@ use super::super::policies::{
 use super::{MigrationContext, MigrationOutcome, TurnkeyMigration};
 
 /// Ensures every sync factor user in the Turnkey account has an up-to-date and
-/// correct policy, as defined in <https://docs.toolsforhumanity.com/world-app/backup/components#turnkey-user-setup>.
+/// correct policy (as defined in <https://docs.toolsforhumanity.com/world-app/backup/components#turnkey-user-setup>). This
+/// migration will also delete **ANY** stale policies.
 ///
 /// This migration will:
 /// 1. identify all sync factor users and ensure they have the right policy (either create or update).
-/// 2. identify stale sync factor policies assigned to orphaned users and remove them.
+/// 2. identify stale policies assigned to orphaned users and remove them. Targets **ALL** policies, not only Sync Factors.
 ///
 /// # Why?
 /// This migration is necessary because in the past Sync Factors were registered with
@@ -139,6 +140,7 @@ fn plan(users: &[User], policies: &[Policy]) -> Vec<PolicyAction> {
     }
 
     // Delete stale policies, i.e. policies bound to a user that no longer exists in the org
+    // NOTE: This deliberately targets all policies, orphaned policies aren't useful.
     let current_user_ids: HashSet<&str> =
         users.iter().map(|user| user.user_id.as_str()).collect();
     for policy in policies {

--- a/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
+++ b/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
@@ -105,7 +105,7 @@ enum PolicyAction {
     /// A policy exists but its condition/effect drifted; update it.
     ///
     /// This is the expected "happy path". Before ~Aug 2026, Sync Factor
-    /// user were created with a different policy.
+    /// users were created with a different policy.
     Update {
         user_name: String,
         intent: UpdatePolicyIntentV2,
@@ -168,29 +168,31 @@ fn plan_for_sync_factor(user: &User, policies: &[Policy]) -> Option<PolicyAction
         .filter(|policy| is_policy_for(policy, &user.user_id))
         .collect();
 
-    if bound.len() > 1 {
-        // Sync Factor Users should never have more than one policy assigned, this is
-        // a soft consistency issue.
-        crate::warn!(
-            "sync_factor_policy: sync factor has multiple policies; keeping all"
-        );
-    }
+    // A sync factor must have exactly one policy. With more than one we cannot effectively
+    // tell which is the managed policy, so we make no changes
+    let policy = match bound.as_slice() {
+        [] => {
+            return Some(PolicyAction::Create {
+                user_name: user.user_name.clone(),
+                intent: create_intent(&user.user_id, &consensus),
+            });
+        }
+        [policy] => *policy,
+        _ => {
+            crate::warn!(
+                "Consistency Warning! sync factor has multiple bound policies; skipping to avoid overwriting"
+            );
+            return None;
+        }
+    };
 
-    if bound.iter().any(|policy| is_up_to_date(policy)) {
+    if is_up_to_date(policy) {
         return None;
     }
-
-    let action = bound.first().map_or_else(
-        || PolicyAction::Create {
-            user_name: user.user_name.clone(),
-            intent: create_intent(&user.user_id, &consensus),
-        },
-        |policy| PolicyAction::Update {
-            user_name: user.user_name.clone(),
-            intent: update_intent(&policy.policy_id, &user.user_id, &consensus),
-        },
-    );
-    Some(action)
+    Some(PolicyAction::Update {
+        user_name: user.user_name.clone(),
+        intent: update_intent(&policy.policy_id, &user.user_id, &consensus),
+    })
 }
 
 /// Whether `policy` is the policy bound to `user_id`.
@@ -375,6 +377,21 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert!(matches!(actions[0], PolicyAction::Update { .. }));
+    }
+
+    /// More than one policy bound to a live sync factor is an unexpected
+    /// state. We don't overwrite in this case.
+    #[test]
+    fn skips_update_when_sync_factor_has_multiple_policies() {
+        let consensus = sync_factor_policy_consensus(SYNC_USER_ID).unwrap();
+        let users = vec![sync_user(SYNC_USER_ID)];
+        // Two policies bound to the same user, neither up to date.
+        let policies = vec![
+            policy_with_consensus("policy-a", &consensus),
+            policy_with_consensus("policy-b", &consensus),
+        ];
+
+        assert!(plan(&users, &policies).is_empty());
     }
 
     #[test]

--- a/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
+++ b/bedrock/src/backup/turnkey/migrations/sync_factor_policy.rs
@@ -1,0 +1,547 @@
+//! See [`MigrationSyncFactorPolicy`]
+
+use std::collections::HashSet;
+
+use turnkey_client::generated::external::data::v1::{Policy, User};
+use turnkey_client::generated::immutable::activity::v1::{
+    CreatePolicyIntentV3, UpdatePolicyIntentV2,
+};
+use turnkey_client::generated::immutable::common::v1::Effect;
+
+use super::super::error::TurnkeyApiError;
+use super::super::policies::{
+    sync_factor_policy_consensus, sync_factor_policy_name, UserRole,
+    SYNC_FACTOR_POLICY_CONDITION, SYNC_FACTOR_POLICY_NOTES,
+};
+use super::{MigrationContext, MigrationOutcome, TurnkeyMigration};
+
+/// Ensures every sync factor user in the Turnkey account has an up-to-date and
+/// correct policy, as defined in <https://docs.toolsforhumanity.com/world-app/backup/components#turnkey-user-setup>.
+///
+/// This migration will:
+/// 1. identify all sync factor users and ensure they have the right policy (either create or update).
+/// 2. identify stale sync factor policies assigned to orphaned users and remove them.
+///
+/// # Why?
+/// This migration is necessary because in the past Sync Factors were registered with
+/// a policy that lacked certain permissions (e.g. delete sub-organization) and it
+/// also used `activity.type` conditions instead of `resource` + `action`.
+///
+/// # Main Factor
+/// If operations need to be executed, this migration REQUIRES a Main Factor.
+pub(super) struct MigrationSyncFactorPolicy;
+
+#[async_trait::async_trait]
+impl TurnkeyMigration for MigrationSyncFactorPolicy {
+    fn id(&self) -> &'static str {
+        "sync_factor_policy"
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensure every sync factor has the correct policy to perform all housekeeping operations."
+    }
+
+    async fn run(
+        &self,
+        ctx: &MigrationContext<'_>,
+    ) -> Result<MigrationOutcome, TurnkeyApiError> {
+        let users = ctx
+            .api
+            .get_users(ctx.suborganization_id, ctx.sync_factor)
+            .await?;
+
+        let policies = ctx
+            .api
+            .get_policies(ctx.suborganization_id, ctx.sync_factor)
+            .await?;
+
+        let actions = plan(&users, &policies);
+        if actions.is_empty() {
+            crate::info!(
+                "sync_factor_policy skipped: all sync factors have the correct policy"
+            );
+            return Ok(MigrationOutcome::Skipped);
+        }
+
+        let Some(main_factor) = ctx.main_factor else {
+            return Ok(MigrationOutcome::MainFactorRequired);
+        };
+
+        let mut details = Vec::with_capacity(actions.len());
+        for action in actions {
+            match action {
+                PolicyAction::Create { user_name, intent } => {
+                    ctx.api
+                        .create_policy(ctx.suborganization_id, intent, main_factor)
+                        .await?;
+                    details.push(format!("created policy for {user_name}"));
+                }
+                PolicyAction::Update { user_name, intent } => {
+                    ctx.api
+                        .update_policy(ctx.suborganization_id, intent, main_factor)
+                        .await?;
+                    details.push(format!("updated policy for {user_name}"));
+                }
+                PolicyAction::Delete { policy_id } => {
+                    ctx.api
+                        .delete_policy(ctx.suborganization_id, &policy_id, main_factor)
+                        .await?;
+                    details
+                        .push(format!("deleted stale sync factor policy {policy_id}"));
+                }
+            }
+        }
+        Ok(MigrationOutcome::Applied { details })
+    }
+}
+
+/// A change needed to reconcile the sub-org's sync factor policies.
+enum PolicyAction {
+    /// No policy is bound to the user; create one.
+    Create {
+        user_name: String,
+        intent: CreatePolicyIntentV3,
+    },
+    /// A policy exists but its condition/effect drifted; update it.
+    ///
+    /// This is the expected "happy path". Before ~Aug 2026, Sync Factor
+    /// user were created with a different policy.
+    Update {
+        user_name: String,
+        intent: UpdatePolicyIntentV2,
+    },
+    /// A sync factor policy is assigned to a user that no longer exists; delete it.
+    ///
+    /// NOTE: Only sync factor user policies are targeted.
+    Delete { policy_id: String },
+}
+
+/// Computes the set of policy changes from the sub-org's users and policies (pure).
+fn plan(users: &[User], policies: &[Policy]) -> Vec<PolicyAction> {
+    let mut actions = Vec::new();
+
+    // Add or fix the policy for each sync factor user.
+    for user in users {
+        match UserRole::classify(&user.user_name) {
+            UserRole::SyncFactor => {}
+            UserRole::Main | UserRole::BreakGlass => continue,
+            UserRole::Unexpected => {
+                crate::warn!(
+                    "Consistency Warning! sub-org has a user that is not main, sync, or break-glass"
+                );
+                continue;
+            }
+        }
+
+        if let Some(action) = plan_for_sync_factor(user, policies) {
+            actions.push(action);
+        }
+    }
+
+    // Delete stale policies, i.e. policies bound to a user that no longer exists in the org
+    let current_user_ids: HashSet<&str> =
+        users.iter().map(|user| user.user_id.as_str()).collect();
+    for policy in policies {
+        if let Some(bound_user_id) = policy_bound_user(policy) {
+            if !current_user_ids.contains(bound_user_id) {
+                actions.push(PolicyAction::Delete {
+                    policy_id: policy.policy_id.clone(),
+                });
+            }
+        }
+    }
+
+    actions
+}
+
+/// Decides the change (if any) for a single sync factor user.
+fn plan_for_sync_factor(user: &User, policies: &[Policy]) -> Option<PolicyAction> {
+    let Some(consensus) = sync_factor_policy_consensus(&user.user_id) else {
+        crate::error!(
+            "sync_factor_policy: sync factor has a malformed user_id; skipping to avoid policy-language injection"
+        );
+        return None;
+    };
+
+    let bound: Vec<&Policy> = policies
+        .iter()
+        .filter(|policy| is_policy_for(policy, &user.user_id))
+        .collect();
+
+    if bound.len() > 1 {
+        // Sync Factor Users should never have more than one policy assigned, this is
+        // a soft consistency issue.
+        crate::warn!(
+            "sync_factor_policy: sync factor has multiple policies; keeping all"
+        );
+    }
+
+    if bound.iter().any(|policy| is_up_to_date(policy)) {
+        return None;
+    }
+
+    let action = bound.first().map_or_else(
+        || PolicyAction::Create {
+            user_name: user.user_name.clone(),
+            intent: create_intent(&user.user_id, &consensus),
+        },
+        |policy| PolicyAction::Update {
+            user_name: user.user_name.clone(),
+            intent: update_intent(&policy.policy_id, &user.user_id, &consensus),
+        },
+    );
+    Some(action)
+}
+
+/// Whether `policy` is the policy bound to `user_id`.
+fn is_policy_for(policy: &Policy, user_id: &str) -> bool {
+    policy_bound_user(policy) == Some(user_id)
+}
+
+/// Determines if a Turnkey's [`Policy`] consensus matches **exactly** for a single user,
+/// regardless of the effect or any other conditions which the policy would apply.
+///
+/// The match is strict: any other consensus shape is ignored.
+fn policy_bound_user(policy: &Policy) -> Option<&str> {
+    const PREFIX: &str = "approvers.any(user, user.id == '";
+    const SUFFIX: &str = "')";
+
+    let consensus = policy.consensus.as_deref()?;
+    let inner = consensus.strip_prefix(PREFIX)?.strip_suffix(SUFFIX)?;
+    // A well-formed id has no additional quotes, rejecting quotes rules out
+    // anything with more clauses
+    if inner.contains('\'') {
+        return None;
+    }
+    Some(inner)
+}
+
+/// Whether an existing bound policy already matches the desired state.
+///
+/// NOTE: The policy name is ignored as it's only a convenience label, i.e.
+/// a wrong label will not trigger a policy update.
+fn is_up_to_date(policy: &Policy) -> bool {
+    policy.effect == Effect::Allow
+        && policy.condition.as_deref() == Some(SYNC_FACTOR_POLICY_CONDITION)
+}
+
+fn create_intent(user_id: &str, consensus: &str) -> CreatePolicyIntentV3 {
+    CreatePolicyIntentV3 {
+        policy_name: sync_factor_policy_name(user_id),
+        effect: Effect::Allow,
+        condition: Some(SYNC_FACTOR_POLICY_CONDITION.to_string()),
+        consensus: Some(consensus.to_string()),
+        notes: SYNC_FACTOR_POLICY_NOTES.to_string(),
+    }
+}
+
+fn update_intent(
+    policy_id: &str,
+    user_id: &str,
+    consensus: &str,
+) -> UpdatePolicyIntentV2 {
+    UpdatePolicyIntentV2 {
+        policy_id: policy_id.to_string(),
+        policy_name: Some(sync_factor_policy_name(user_id)),
+        policy_effect: Some(Effect::Allow),
+        policy_condition: Some(SYNC_FACTOR_POLICY_CONDITION.to_string()),
+        policy_consensus: Some(consensus.to_string()),
+        policy_notes: Some(SYNC_FACTOR_POLICY_NOTES.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::turnkey::policies::{
+        AUTH_USER_MAIN_USERNAME, BREAK_GLASS_USERNAME, SYNC_FACTOR_USERNAME_PREFIX,
+    };
+    use serde_json::json;
+
+    /// A valid Turnkey-style user id (UUID).
+    const SYNC_USER_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn user_from_json(value: serde_json::Value) -> User {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn policy_from_json(value: serde_json::Value) -> Policy {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn sync_user(user_id: &str) -> User {
+        user_from_json(json!({
+            "userId": user_id,
+            "userName": format!("{SYNC_FACTOR_USERNAME_PREFIX}abcd1234"),
+        }))
+    }
+
+    /// A bound policy for `user_id` carrying an arbitrary `condition`.
+    fn user_policy(user_id: &str, condition: &str) -> Policy {
+        policy_from_json(json!({
+            "policyId": format!("policy-{user_id}"),
+            "policyName": sync_factor_policy_name(user_id),
+            "effect": "EFFECT_ALLOW",
+            "notes": "",
+            "consensus": sync_factor_policy_consensus(user_id)
+                .expect("test user id is valid"),
+            "condition": condition,
+        }))
+    }
+
+    #[test]
+    fn creates_policy_when_sync_factor_has_none() {
+        let users = vec![sync_user(SYNC_USER_ID)];
+
+        let actions = plan(&users, &[]);
+
+        assert_eq!(actions.len(), 1);
+        let PolicyAction::Create { intent, .. } = &actions[0] else {
+            panic!("expected Create, got a different action");
+        };
+        assert_eq!(intent.effect, Effect::Allow);
+        assert_eq!(
+            intent.condition.as_deref(),
+            Some(SYNC_FACTOR_POLICY_CONDITION)
+        );
+        assert_eq!(intent.consensus, sync_factor_policy_consensus(SYNC_USER_ID));
+    }
+
+    /// A real legacy policy (bound to the user, `EFFECT_ALLOW`) whose condition uses
+    /// version-specific `activity.type == …` clauses must be reconciled to the
+    /// canonical `resource` + `action` policy — updated in place, never duplicated.
+    ///
+    /// The expected result is hardcoded (not derived from the constants) so a stray
+    /// change to the canonical policy is caught here.
+    #[test]
+    fn updates_policy_with_legacy_activity_type_condition() {
+        let legacy_condition =
+            "activity.type == 'ACTIVITY_TYPE_DELETE_AUTHENTICATORS' \
+             || activity.type == 'ACTIVITY_TYPE_DELETE_PRIVATE_KEYS' \
+             || activity.type == 'ACTIVITY_TYPE_DELETE_OAUTH_PROVIDERS' \
+             || activity.type == 'ACTIVITY_TYPE_DELETE_API_KEYS' \
+             || activity.type == 'ACTIVITY_TYPE_DELETE_SUB_ORGANIZATION' \
+             || activity.type == 'ACTIVITY_TYPE_DELETE_USERS'";
+        let users = vec![sync_user(SYNC_USER_ID)];
+        let policies = vec![user_policy(SYNC_USER_ID, legacy_condition)];
+
+        let actions = plan(&users, &policies);
+
+        assert_eq!(actions.len(), 1);
+        let PolicyAction::Update { intent, .. } = &actions[0] else {
+            panic!("expected Update, got a different action");
+        };
+        assert_eq!(
+            intent.policy_id,
+            "policy-11111111-2222-3333-4444-555555555555"
+        );
+        assert_eq!(
+            intent.policy_name.as_deref(),
+            Some("sync_factor_policy_11111111-2222-3333-4444-555555555555")
+        );
+        assert_eq!(intent.policy_effect, Some(Effect::Allow));
+        assert_eq!(
+            intent.policy_condition.as_deref(),
+            Some(
+                "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL' \
+                 || activity.resource == 'PRIVATE_KEY' || activity.resource == \
+                 'ORGANIZATION' || activity.resource == 'USER')"
+            )
+        );
+        assert_eq!(
+            intent.policy_consensus.as_deref(),
+            Some(
+                "approvers.any(user, user.id == \
+                 '11111111-2222-3333-4444-555555555555')"
+            )
+        );
+    }
+
+    #[test]
+    fn skips_when_policy_is_already_correct() {
+        let users = vec![sync_user(SYNC_USER_ID)];
+        let policies = vec![user_policy(SYNC_USER_ID, SYNC_FACTOR_POLICY_CONDITION)];
+
+        assert!(plan(&users, &policies).is_empty());
+    }
+
+    #[test]
+    fn flips_effect_when_policy_denies() {
+        let users = vec![sync_user(SYNC_USER_ID)];
+        let mut denying = user_policy(SYNC_USER_ID, SYNC_FACTOR_POLICY_CONDITION);
+        denying.effect = Effect::Deny;
+
+        let actions = plan(&users, &[denying]);
+
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0], PolicyAction::Update { .. }));
+    }
+
+    #[test]
+    fn ignores_main_and_break_glass_users() {
+        let users = vec![
+            user_from_json(json!({
+                "userId": "22222222-2222-2222-2222-222222222222",
+                "userName": AUTH_USER_MAIN_USERNAME,
+            })),
+            user_from_json(json!({
+                "userId": "33333333-3333-3333-3333-333333333333",
+                "userName": BREAK_GLASS_USERNAME,
+            })),
+        ];
+
+        assert!(plan(&users, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_unexpected_user() {
+        let users = vec![user_from_json(json!({
+            "userId": "44444444-4444-4444-4444-444444444444",
+            "userName": "some_unexpected_user",
+        }))];
+
+        assert!(plan(&users, &[]).is_empty());
+    }
+
+    /// A malformed user id must never be embedded in a policy: injecting a quote
+    /// could break out of the consensus string literal.
+    #[test]
+    fn skips_sync_factor_with_malformed_user_id() {
+        let users = vec![sync_user("bad' || approvers.any(user, true) || 'x")];
+
+        assert!(plan(&users, &[]).is_empty());
+    }
+
+    #[test]
+    fn matches_only_the_users_own_policy() {
+        // A correct policy exists, but it is bound to a *different* (existing) user,
+        // so it neither satisfies SYNC_USER_ID nor counts as stale.
+        let other = "99999999-9999-9999-9999-999999999999";
+        let users = vec![sync_user(SYNC_USER_ID), sync_user(other)];
+        let policies = vec![user_policy(other, SYNC_FACTOR_POLICY_CONDITION)];
+
+        let actions = plan(&users, &policies);
+
+        // Only SYNC_USER_ID needs a policy; `other`'s is correct and not stale.
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0], PolicyAction::Create { .. }));
+    }
+
+    #[test]
+    fn plans_each_sync_factor_independently() {
+        let second = "66666666-7777-8888-9999-000000000000";
+        let users = vec![sync_user(SYNC_USER_ID), sync_user(second)];
+        // Only the first user already has a correct policy.
+        let policies = vec![user_policy(SYNC_USER_ID, SYNC_FACTOR_POLICY_CONDITION)];
+
+        let actions = plan(&users, &policies);
+
+        assert_eq!(actions.len(), 1);
+        let PolicyAction::Create { intent, .. } = &actions[0] else {
+            panic!("expected Create for the second sync factor");
+        };
+        assert_eq!(intent.consensus, sync_factor_policy_consensus(second));
+    }
+
+    #[test]
+    fn prunes_policy_bound_to_absent_user() {
+        // A live sync factor with a correct policy, plus a leftover policy bound to
+        // a user id no longer in the org.
+        let gone = "99999999-9999-9999-9999-999999999999";
+        let users = vec![sync_user(SYNC_USER_ID)];
+        let policies = vec![
+            user_policy(SYNC_USER_ID, SYNC_FACTOR_POLICY_CONDITION),
+            user_policy(gone, SYNC_FACTOR_POLICY_CONDITION),
+        ];
+
+        let actions = plan(&users, &policies);
+
+        assert_eq!(actions.len(), 1);
+        let PolicyAction::Delete { policy_id } = &actions[0] else {
+            panic!("expected Delete, got a different action");
+        };
+        assert_eq!(policy_id, &format!("policy-{gone}"));
+    }
+
+    #[test]
+    fn keeps_policy_bound_to_existing_non_sync_user() {
+        // A policy bound to the main user (which exists) is not pruned, even though
+        // main is not a sync factor.
+        let main_id = "22222222-2222-2222-2222-222222222222";
+        let users = vec![user_from_json(json!({
+            "userId": main_id,
+            "userName": AUTH_USER_MAIN_USERNAME,
+        }))];
+        let policies = vec![user_policy(main_id, SYNC_FACTOR_POLICY_CONDITION)];
+
+        assert!(plan(&users, &policies).is_empty());
+    }
+
+    /// A policy carrying an arbitrary `consensus`, for exercising consensus
+    /// matching in isolation (condition/effect are irrelevant to the match).
+    fn policy_with_consensus(policy_id: &str, consensus: &str) -> Policy {
+        policy_from_json(json!({
+            "policyId": policy_id,
+            "policyName": "some-policy",
+            "effect": "EFFECT_ALLOW",
+            "notes": "",
+            "consensus": consensus,
+            "condition": "activity.action == 'DELETE'",
+        }))
+    }
+
+    /// The migration only treats a policy as a sync factor's when its consensus is
+    /// *exactly* `approvers.any(user, user.id == '<id>')`. Every other shape in the
+    /// Turnkey policy language must be ignored, so we never update or prune an
+    /// unrelated policy. See <https://docs.turnkey.com/features/policies/language>.
+    #[test]
+    fn policy_bound_user_matches_only_the_exact_single_user_consensus() {
+        let ours = policy_with_consensus(
+            "p",
+            "approvers.any(user, user.id == '4b894565-fa11-42fc-b813-5bf4ea3d53f9')",
+        );
+        assert_eq!(
+            policy_bound_user(&ours),
+            Some("4b894565-fa11-42fc-b813-5bf4ea3d53f9")
+        );
+
+        for consensus in [
+            // Tag-based membership.
+            "approvers.any(user, user.tags.contains('some-tag'))",
+            // Threshold / count.
+            "approvers.count() >= 2",
+            // Two users OR-ed (opens with our prefix but is not a lone user).
+            "approvers.any(user, user.id == 'a') || approvers.any(user, user.id == 'b')",
+            // Credential-based.
+            "credentials.any(credential, credential.type == 'CREDENTIAL_TYPE_API_KEY')",
+            // Negation of our form.
+            "!approvers.any(user, user.id == 'a')",
+            // Our form with an extra trailing clause.
+            "approvers.any(user, user.id == 'a') && approvers.count() >= 1",
+            // Filter rather than any.
+            "approvers.filter(user, user.id == 'a').count() >= 1",
+        ] {
+            assert_eq!(
+                policy_bound_user(&policy_with_consensus("p", consensus)),
+                None,
+                "unexpectedly matched consensus: {consensus}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_touch_policy_with_unrecognized_consensus() {
+        // A live sync factor (already correct) plus a policy whose consensus is not
+        // one of ours. The latter must be neither updated nor pruned.
+        let users = vec![sync_user(SYNC_USER_ID)];
+        let policies = vec![
+            user_policy(SYNC_USER_ID, SYNC_FACTOR_POLICY_CONDITION),
+            policy_with_consensus(
+                "p-tag",
+                "approvers.any(user, user.tags.contains('some-tag'))",
+            ),
+        ];
+
+        assert!(plan(&users, &policies).is_empty());
+    }
+}

--- a/bedrock/src/backup/turnkey/policies.rs
+++ b/bedrock/src/backup/turnkey/policies.rs
@@ -70,8 +70,9 @@ pub(super) const SYNC_FACTOR_POLICY_NOTES: &str =
 /// # Resources
 /// - `USER` allows the sync factor to remove itself (e.g. on logout) and
 ///   other stale Sync Factor users. It cannot remove [`AUTH_USER_MAIN_USERNAME`] because of Root Quorum validation.
-/// - `CREDENTIAL` allows removal of OIDC providers, authenticators, API keys, lets the user
-///   delete factors without needing to do a full re-authentication flow.
+/// - `CREDENTIAL` allows removal of OIDC providers, authenticators, API keys, would let the user
+///   conceptually delete factors without needing to do a full re-authentication flow. Currently not in active use,
+///   as Turnkey has a restriction on non-root users updating root users, even if they have the right policy.
 /// - `ORGANIZATION` allows removal of the entire sub-org (e.g. when deleting the entire backup).
 /// - `PRIVATE_KEY` allows removing the imported factor secret. Currently not in active use.
 ///

--- a/bedrock/src/backup/turnkey/policies.rs
+++ b/bedrock/src/backup/turnkey/policies.rs
@@ -78,6 +78,8 @@ pub(super) const SYNC_FACTOR_POLICY_NOTES: &str =
 /// # Historical Considerations
 /// The initial policy targeted `activity.type` but this was updated because those are version
 /// sensitive. Further, not all resources were covered in initial policies.
+/// - The permission to delete the sub-org was added in #4485 on iOS and #5743 on Android.
+/// - the permission to delete users was addedin #4692 on iOS.
 pub(super) const SYNC_FACTOR_POLICY_CONDITION: &str = concat!(
     "activity.action == 'DELETE' && (",
     "activity.resource == 'CREDENTIAL' || ",

--- a/bedrock/src/backup/turnkey/policies.rs
+++ b/bedrock/src/backup/turnkey/policies.rs
@@ -23,11 +23,42 @@ pub(super) const BREAK_GLASS_USERNAME: &str = "break_glass_user";
 /// `userName` starts with this prefix is a device-local sync factor.
 pub(super) const SYNC_FACTOR_USERNAME_PREFIX: &str = "sync_factor_user_";
 
+/// The typed role of each user in a user's Turnkey account (sub-organization). We
+/// rely on the user name to determine it.
+///
+/// Reference: <https://docs.toolsforhumanity.com/world-app/backup/components#turnkey-user-setup>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UserRole {
+    /// The main user ([`AUTH_USER_MAIN_USERNAME`]), holder of the root quorum.
+    Main,
+    /// A device-local sync factor ([`SYNC_FACTOR_USERNAME_PREFIX`]).
+    SyncFactor,
+    /// The break-glass recovery user ([`BREAK_GLASS_USERNAME`]).
+    BreakGlass,
+    /// A `userName` matching none of the known roles. This is unexpected behavior.
+    Unexpected,
+}
+
+impl UserRole {
+    /// Classifies a Turnkey user by its `user_name`.
+    pub(super) fn classify(user_name: &str) -> Self {
+        if user_name == AUTH_USER_MAIN_USERNAME {
+            Self::Main
+        } else if user_name.starts_with(SYNC_FACTOR_USERNAME_PREFIX) {
+            Self::SyncFactor
+        } else if user_name == BREAK_GLASS_USERNAME {
+            Self::BreakGlass
+        } else {
+            Self::Unexpected
+        }
+    }
+}
+
 /// The Apple Sign In OIDC issuer.
 pub const APPLE_ISSUER: &str = "https://appleid.apple.com";
 
-/// Notes stored on the sync factor deletion policy
-pub(super) const SYNC_FACTOR_DELETION_POLICY_NOTES: &str =
+/// Notes stored on the sync factor policy
+pub(super) const SYNC_FACTOR_POLICY_NOTES: &str =
     "Allows a sync factor to perform deletion operations. Configured by Bedrock.";
 
 /// The conditions on the policy assigned to all Sync Factors.
@@ -47,7 +78,7 @@ pub(super) const SYNC_FACTOR_DELETION_POLICY_NOTES: &str =
 /// # Historical Considerations
 /// The initial policy targeted `activity.type` but this was updated because those are version
 /// sensitive. Further, not all resources were covered in initial policies.
-pub(super) const SYNC_FACTOR_DELETION_POLICY_CONDITION: &str = concat!(
+pub(super) const SYNC_FACTOR_POLICY_CONDITION: &str = concat!(
     "activity.action == 'DELETE' && (",
     "activity.resource == 'CREDENTIAL' || ",
     "activity.resource == 'PRIVATE_KEY' || ",
@@ -55,19 +86,27 @@ pub(super) const SYNC_FACTOR_DELETION_POLICY_CONDITION: &str = concat!(
     "activity.resource == 'USER')"
 );
 
-/// The consensus expression binding a sync factor deletion policy to exactly one
-/// user (the sync factor itself, identified by its Turnkey `user_id`).
+/// Builds the consensus expression binding a sync factor policy to
+/// exactly one user (the sync factor itself).
 ///
-/// `user_id` is a Turnkey UUID; callers MUST validate it contains no quote
-/// characters before building the expression, so it cannot break out of the
-/// policy-language string literal.
-pub(super) fn sync_factor_deletion_consensus(user_id: &str) -> String {
-    format!("approvers.any(user, user.id == '{user_id}')")
+/// Returns `None` if `user_id` is NOT a well-formed identifier.
+pub(super) fn sync_factor_policy_consensus(user_id: &str) -> Option<String> {
+    is_turnkey_user_id(user_id)
+        .then(|| format!("approvers.any(user, user.id == '{user_id}')"))
 }
 
-/// Deterministic, human-readable name for a sync factor's deletion policy.
-pub(super) fn sync_factor_deletion_policy_name(user_id: &str) -> String {
-    format!("sync_factor_deletion_{user_id}")
+/// Whether `user_id` is a well-formed Turnkey identifier (UUID characters only),
+/// so it is safe to embed inside a policy-language string literal.
+fn is_turnkey_user_id(user_id: &str) -> bool {
+    !user_id.is_empty()
+        && user_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+}
+
+/// Deterministic, human-readable name for a sync factor's policy.
+pub(super) fn sync_factor_policy_name(user_id: &str) -> String {
+    format!("sync_factor_policy_{user_id}")
 }
 
 impl BedrockEnvironment {
@@ -187,9 +226,9 @@ mod tests {
     /// pin its exact text. Update deliberately if the policy scope changes.
     #[test]
     fn sync_factor_deletion_condition_is_pinned() {
-        // The parenthesis is particularly critical here!
+        // The parentheses is particularly critical here!
         assert_eq!(
-            SYNC_FACTOR_DELETION_POLICY_CONDITION,
+            SYNC_FACTOR_POLICY_CONDITION,
             "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL' || \
              activity.resource == 'PRIVATE_KEY' || activity.resource == 'ORGANIZATION' \
              || activity.resource == 'USER')"
@@ -197,11 +236,34 @@ mod tests {
     }
 
     #[test]
-    fn sync_factor_deletion_consensus_binds_single_user() {
+    fn sync_factor_policy_consensus_binds_single_user() {
         assert_eq!(
-            sync_factor_deletion_consensus("11111111-2222-3333-4444-555555555555"),
-            "approvers.any(user, user.id == '11111111-2222-3333-4444-555555555555')"
+            sync_factor_policy_consensus("11111111-2222-3333-4444-555555555555")
+                .as_deref(),
+            Some("approvers.any(user, user.id == '11111111-2222-3333-4444-555555555555')")
         );
+    }
+
+    #[test]
+    fn user_role_classify_maps_each_known_username() {
+        assert_eq!(UserRole::classify("auth_user_main"), UserRole::Main);
+        assert_eq!(UserRole::classify("break_glass_user"), UserRole::BreakGlass);
+        assert_eq!(
+            UserRole::classify("sync_factor_user_abc123"),
+            UserRole::SyncFactor
+        );
+        assert_eq!(UserRole::classify("something_else"), UserRole::Unexpected);
+    }
+
+    /// Important to prevent breaking out of the policy syntax
+    #[test]
+    fn sync_factor_policy_consensus_rejects_malformed_user_id() {
+        assert_eq!(sync_factor_policy_consensus(""), None);
+        assert_eq!(
+            sync_factor_policy_consensus("bad' || approvers.any(user, true) || 'x"),
+            None
+        );
+        assert_eq!(sync_factor_policy_consensus("has space"), None);
     }
 
     #[test]

--- a/bedrock/src/backup/turnkey/policies.rs
+++ b/bedrock/src/backup/turnkey/policies.rs
@@ -95,13 +95,12 @@ pub(super) fn sync_factor_policy_consensus(user_id: &str) -> Option<String> {
         .then(|| format!("approvers.any(user, user.id == '{user_id}')"))
 }
 
-/// Whether `user_id` is a well-formed Turnkey identifier (UUID characters only),
-/// so it is safe to embed inside a policy-language string literal.
-fn is_turnkey_user_id(user_id: &str) -> bool {
-    !user_id.is_empty()
-        && user_id
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+/// Whether `user_id` is a well-formed Turnkey identifier (a UUID).
+///
+/// Turnkey ids are always UUIDs. Validating the shape ensures there
+/// aren't extraneous characters that could change the policy's effect.
+const fn is_turnkey_user_id(user_id: &str) -> bool {
+    uuid::Uuid::try_parse(user_id).is_ok()
 }
 
 /// Deterministic, human-readable name for a sync factor's policy.
@@ -255,7 +254,8 @@ mod tests {
         assert_eq!(UserRole::classify("something_else"), UserRole::Unexpected);
     }
 
-    /// Important to prevent breaking out of the policy syntax
+    /// Important to prevent breaking out of the policy syntax, and to reject ids
+    /// that are not real Turnkey UUIDs.
     #[test]
     fn sync_factor_policy_consensus_rejects_malformed_user_id() {
         assert_eq!(sync_factor_policy_consensus(""), None);
@@ -264,6 +264,18 @@ mod tests {
             None
         );
         assert_eq!(sync_factor_policy_consensus("has space"), None);
+        // Hex/hyphen characters but not a UUID layout.
+        assert_eq!(sync_factor_policy_consensus("deadbeef"), None);
+        assert_eq!(sync_factor_policy_consensus("----"), None);
+        assert_eq!(
+            sync_factor_policy_consensus("11111111-2222-3333-4444-5555555555"),
+            None
+        );
+        // A well-formed UUID is accepted.
+        assert!(
+            sync_factor_policy_consensus("11111111-2222-3333-4444-555555555555")
+                .is_some()
+        );
     }
 
     #[test]

--- a/bedrock/src/backup/turnkey/policies.rs
+++ b/bedrock/src/backup/turnkey/policies.rs
@@ -7,11 +7,68 @@ use crate::primitives::config::BedrockEnvironment;
 /// Turnkey's `userName` of the primary user who holds all the Main Factors. Sole
 /// member of the root quorum.
 ///
-/// MUST be a precise name. Do not change this! Bad things could happen.
+/// MUST be a precise name. Changing this without migrations would break existing accounts
+/// and lead to diverging states.
 pub const AUTH_USER_MAIN_USERNAME: &str = "auth_user_main";
+
+/// The break-glass user's Turnkey `userName`.
+///
+/// MUST be a precise name. Changing this without migrations would break existing accounts
+/// and lead to diverging states.
+pub(super) const BREAK_GLASS_USERNAME: &str = "break_glass_user";
+
+/// Prefix of a sync factor user's Turnkey `userName`.
+///
+/// Sync factor users are named `sync_factor_user_<suffix>`; any Turnkey user whose
+/// `userName` starts with this prefix is a device-local sync factor.
+pub(super) const SYNC_FACTOR_USERNAME_PREFIX: &str = "sync_factor_user_";
 
 /// The Apple Sign In OIDC issuer.
 pub const APPLE_ISSUER: &str = "https://appleid.apple.com";
+
+/// Notes stored on the sync factor deletion policy
+pub(super) const SYNC_FACTOR_DELETION_POLICY_NOTES: &str =
+    "Allows a sync factor to perform deletion operations. Configured by Bedrock.";
+
+/// The conditions on the policy assigned to all Sync Factors.
+///
+/// The policy permits specific **deletion-only** activities (see `activity.action`).
+///
+/// Reference: <https://docs.toolsforhumanity.com/world-app/backup/components#turnkey-user-setup>
+///
+/// # Resources
+/// - `USER` allows the sync factor to remove itself (e.g. on logout) and
+///   other stale Sync Factor users. It cannot remove [`AUTH_USER_MAIN_USERNAME`] because of Root Quorum validation.
+/// - `CREDENTIAL` allows removal of OIDC providers, authenticators, API keys, lets the user
+///   delete factors without needing to do a full re-authentication flow.
+/// - `ORGANIZATION` allows removal of the entire sub-org (e.g. when deleting the entire backup).
+/// - `PRIVATE_KEY` allows removing the imported factor secret. Currently not in active use.
+///
+/// # Historical Considerations
+/// The initial policy targeted `activity.type` but this was updated because those are version
+/// sensitive. Further, not all resources were covered in initial policies.
+pub(super) const SYNC_FACTOR_DELETION_POLICY_CONDITION: &str = concat!(
+    "activity.action == 'DELETE' && (",
+    "activity.resource == 'CREDENTIAL' || ",
+    "activity.resource == 'PRIVATE_KEY' || ",
+    "activity.resource == 'ORGANIZATION' || ",
+    "activity.resource == 'USER')"
+);
+
+/// The consensus expression binding a sync factor deletion policy to exactly one
+/// user (the sync factor itself, identified by its Turnkey `user_id`).
+///
+/// `user_id` is a Turnkey UUID; callers MUST validate it contains no quote
+/// characters before building the expression, so it cannot break out of the
+/// policy-language string literal.
+pub(super) fn sync_factor_deletion_consensus(user_id: &str) -> String {
+    format!("approvers.any(user, user.id == '{user_id}')")
+}
+
+/// Deterministic, human-readable name for a sync factor's deletion policy.
+pub(super) fn sync_factor_deletion_policy_name(user_id: &str) -> String {
+    format!("sync_factor_deletion_{user_id}")
+}
 
 impl BedrockEnvironment {
     /// Parent Turnkey organization id (i.e. TFH)
@@ -123,6 +180,27 @@ mod tests {
                 ("APPLE-WID", "org.world.id"),
                 ("APPLE-WEB", "app.world.apple"),
             ]
+        );
+    }
+
+    /// Hardcoded literal matching: the deletion condition is security-critical, so
+    /// pin its exact text. Update deliberately if the policy scope changes.
+    #[test]
+    fn sync_factor_deletion_condition_is_pinned() {
+        // The parenthesis is particularly critical here!
+        assert_eq!(
+            SYNC_FACTOR_DELETION_POLICY_CONDITION,
+            "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL' || \
+             activity.resource == 'PRIVATE_KEY' || activity.resource == 'ORGANIZATION' \
+             || activity.resource == 'USER')"
+        );
+    }
+
+    #[test]
+    fn sync_factor_deletion_consensus_binds_single_user() {
+        assert_eq!(
+            sync_factor_deletion_consensus("11111111-2222-3333-4444-555555555555"),
+            "approvers.any(user, user.id == '11111111-2222-3333-4444-555555555555')"
         );
     }
 

--- a/bedrock/src/backup/turnkey/test.rs
+++ b/bedrock/src/backup/turnkey/test.rs
@@ -111,7 +111,7 @@ mod integration_tests {
 
 /// Full coverage of the entire migration run process (`run_migration_list`) with
 /// mocked API calls to Turnkey (follows same mocking patterns as Turnkey's SDK).
-mod migration_functional_tests {
+mod functional_tests {
     use super::TestSigner;
     use crate::backup::turnkey::api::{MainFactor, SyncFactor, TurnkeyApiClient};
     use crate::backup::turnkey::migrations::{
@@ -283,447 +283,459 @@ mod migration_functional_tests {
         })
     }
 
-    #[tokio::test]
-    async fn apple_audiences_creates_missing_audiences_with_main_factor() {
-        let server = MockServer::start().await;
-        // Only the first staging audience present → the other three missing.
-        mount_reads(
-            &server,
-            vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
-            vec![],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(CREATE_OAUTH_PATH))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(completed_create(&["n1", "n2", "n3"])),
+    /// Functional tests for the `apple_audience` migration.
+    mod apple_audiences {
+        use super::*;
+
+        #[tokio::test]
+        async fn apple_audiences_creates_missing_audiences_with_main_factor() {
+            let server = MockServer::start().await;
+            // Only the first staging audience present → the other three missing.
+            mount_reads(
+                &server,
+                vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
+                vec![],
             )
-            .expect(1)
-            .mount(&server)
             .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
-
-        // The create request carried exactly the missing staging audiences and
-        // reused the existing subject.
-        let requests = server.received_requests().await.unwrap();
-        let create = requests
-            .iter()
-            .find(|request| request.url.path() == CREATE_OAUTH_PATH)
-            .expect("create request was sent");
-        let body = String::from_utf8_lossy(&create.body);
-        for aud in [
-            "org.world.staging.id",
-            "org.world.sandbox.id",
-            "app.world.apple.staging",
-        ] {
-            assert!(body.contains(aud), "create body missing audience {aud}");
-        }
-        assert!(body.contains("sub-apple"), "create body missing subject");
-        assert!(
-            !body.contains("org.worldcoin.insight.staging"),
-            "create body should not re-add the already-present audience"
-        );
-    }
-
-    #[tokio::test]
-    async fn apple_audiences_skips_when_all_audiences_present() {
-        let server = MockServer::start().await;
-        mount_reads(
-            &server,
-            vec![main_user(
-                &[
-                    "org.worldcoin.insight.staging",
-                    "org.world.staging.id",
-                    "org.world.sandbox.id",
-                    "app.world.apple.staging",
-                ],
-                "sub-apple",
-            )],
-            vec![],
-        )
-        .await;
-        // Any create call is a bug.
-        Mock::given(method("POST"))
-            .and(path(CREATE_OAUTH_PATH))
-            .respond_with(ResponseTemplate::new(500))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
-    }
-
-    #[tokio::test]
-    async fn apple_audiences_defers_without_main_factor_and_never_writes() {
-        let server = MockServer::start().await;
-        mount_reads(
-            &server,
-            vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
-            vec![],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(CREATE_OAUTH_PATH))
-            .respond_with(ResponseTemplate::new(500))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            None,
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        let TurnkeyMigrationOutcome::MainFactorRequired { pending } = outcome else {
-            panic!("expected MainFactorRequired, got {outcome:?}");
-        };
-        assert_eq!(pending.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn sync_factor_policy_creates_policy_when_missing() {
-        let server = MockServer::start().await;
-        mount_reads(
-            &server,
-            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
-            vec![],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(CREATE_POLICY_PATH))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(completed_create_policy("new-policy")),
-            )
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
-
-        // The create request carried the canonical condition bound to this user.
-        let requests = server.received_requests().await.unwrap();
-        let create = requests
-            .iter()
-            .find(|request| request.url.path() == CREATE_POLICY_PATH)
-            .expect("create_policy request was sent");
-        let body = String::from_utf8_lossy(&create.body);
-        assert!(
-            body.contains(SYNC_FACTOR_POLICY_CONDITION),
-            "create body missing the canonical condition"
-        );
-        let consensus =
-            sync_factor_policy_consensus(SYNC_ID).expect("SYNC_ID is valid");
-        assert!(
-            body.contains(&consensus),
-            "create body missing the per-user consensus"
-        );
-    }
-
-    #[tokio::test]
-    async fn sync_factor_policy_updates_outdated_policy() {
-        let server = MockServer::start().await;
-        // A narrower condition from before ORGANIZATION/USER deletions were granted.
-        let outdated =
-            "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL')";
-        mount_reads(
-            &server,
-            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
-            vec![user_policy_record("policy-old", SYNC_ID, outdated)],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(UPDATE_POLICY_PATH))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(completed_update_policy("policy-old")),
-            )
-            .expect(1)
-            .mount(&server)
-            .await;
-        // Creating a fresh policy would be a bug: the existing one must be updated.
-        Mock::given(method("POST"))
-            .and(path(CREATE_POLICY_PATH))
-            .respond_with(ResponseTemplate::new(500))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
-
-        let requests = server.received_requests().await.unwrap();
-        let update = requests
-            .iter()
-            .find(|request| request.url.path() == UPDATE_POLICY_PATH)
-            .expect("update_policy request was sent");
-        let body = String::from_utf8_lossy(&update.body);
-        assert!(
-            body.contains("policy-old"),
-            "update targeted the wrong policy"
-        );
-        assert!(
-            body.contains(SYNC_FACTOR_POLICY_CONDITION),
-            "update body missing the canonical condition"
-        );
-    }
-
-    #[tokio::test]
-    async fn sync_factor_policy_defers_without_main_factor() {
-        let server = MockServer::start().await;
-        mount_reads(
-            &server,
-            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
-            vec![],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(CREATE_POLICY_PATH))
-            .respond_with(ResponseTemplate::new(500))
-            .expect(0)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            None,
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        // Apple skips (no provider); only the policy migration defers.
-        let TurnkeyMigrationOutcome::MainFactorRequired { pending } = outcome else {
-            panic!("expected MainFactorRequired, got {outcome:?}");
-        };
-        assert_eq!(pending.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn sync_factor_policy_skips_when_policy_correct() {
-        let server = MockServer::start().await;
-        mount_reads(
-            &server,
-            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
-            vec![user_policy_record(
-                "policy-ok",
-                SYNC_ID,
-                SYNC_FACTOR_POLICY_CONDITION,
-            )],
-        )
-        .await;
-        // Any write is a bug when the policy already matches.
-        for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
             Mock::given(method("POST"))
-                .and(path(write_path))
+                .and(path(CREATE_OAUTH_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(completed_create(&["n1", "n2", "n3"])),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+            // The create request carried exactly the missing staging audiences and
+            // reused the existing subject.
+            let requests = server.received_requests().await.unwrap();
+            let create = requests
+                .iter()
+                .find(|request| request.url.path() == CREATE_OAUTH_PATH)
+                .expect("create request was sent");
+            let body = String::from_utf8_lossy(&create.body);
+            for aud in [
+                "org.world.staging.id",
+                "org.world.sandbox.id",
+                "app.world.apple.staging",
+            ] {
+                assert!(body.contains(aud), "create body missing audience {aud}");
+            }
+            assert!(body.contains("sub-apple"), "create body missing subject");
+            assert!(
+                !body.contains("org.worldcoin.insight.staging"),
+                "create body should not re-add the already-present audience"
+            );
+        }
+
+        #[tokio::test]
+        async fn apple_audiences_skips_when_all_audiences_present() {
+            let server = MockServer::start().await;
+            mount_reads(
+                &server,
+                vec![main_user(
+                    &[
+                        "org.worldcoin.insight.staging",
+                        "org.world.staging.id",
+                        "org.world.sandbox.id",
+                        "app.world.apple.staging",
+                    ],
+                    "sub-apple",
+                )],
+                vec![],
+            )
+            .await;
+            // Any create call is a bug.
+            Mock::given(method("POST"))
+                .and(path(CREATE_OAUTH_PATH))
                 .respond_with(ResponseTemplate::new(500))
                 .expect(0)
                 .mount(&server)
                 .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
         }
 
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
-    }
-
-    #[tokio::test]
-    async fn get_policies_is_cached_within_a_client() {
-        let server = MockServer::start().await;
-        // `.expect(1)` fails if a second call reaches the server instead of the cache.
-        Mock::given(method("POST"))
-            .and(path(LIST_POLICIES_PATH))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+        #[tokio::test]
+        async fn apple_audiences_defers_without_main_factor_and_never_writes() {
+            let server = MockServer::start().await;
+            mount_reads(
+                &server,
+                vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
+                vec![],
             )
-            .expect(1)
-            .mount(&server)
             .await;
+            Mock::given(method("POST"))
+                .and(path(CREATE_OAUTH_PATH))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
 
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        api.get_policies("suborg-1", SyncFactor(&sync))
-            .await
-            .unwrap();
-        api.get_policies("suborg-1", SyncFactor(&sync))
-            .await
-            .unwrap();
-    }
-
-    /// A client serves exactly one sub-organization. Querying a second one is a
-    /// consistency violation, caught from the cache without a second network call.
-    #[tokio::test]
-    async fn get_policies_rejects_a_second_sub_org() {
-        use crate::backup::turnkey::error::TurnkeyApiError;
-
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path(LIST_POLICIES_PATH))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                None,
+                &api,
+                BedrockEnvironment::Staging,
             )
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        api.get_policies("suborg-1", SyncFactor(&sync))
             .await
             .unwrap();
-        let error = api
-            .get_policies("suborg-2", SyncFactor(&sync))
-            .await
-            .expect_err("a different sub-org must be rejected");
-        assert!(matches!(error, TurnkeyApiError::Consistency));
+
+            let TurnkeyMigrationOutcome::MainFactorRequired { pending } = outcome
+            else {
+                panic!("expected MainFactorRequired, got {outcome:?}");
+            };
+            assert_eq!(pending.len(), 1);
+        }
     }
 
-    #[tokio::test]
-    async fn sync_factor_policy_prunes_stale_policy() {
-        let server = MockServer::start().await;
-        let gone_user = "99999999-9999-9999-9999-999999999999";
-        mount_reads(
-            &server,
-            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
-            vec![
-                // The live sync factor's policy is already correct.
-                user_policy_record(
-                    "policy-live",
+    /// Functional tests for the `sync_factor` migration.
+    mod sync_factor {
+        use super::*;
+
+        #[tokio::test]
+        async fn sync_factor_policy_creates_policy_when_missing() {
+            let server = MockServer::start().await;
+            mount_reads(
+                &server,
+                vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+                vec![],
+            )
+            .await;
+            Mock::given(method("POST"))
+                .and(path(CREATE_POLICY_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(completed_create_policy("new-policy")),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+            // The create request carried the canonical condition bound to this user.
+            let requests = server.received_requests().await.unwrap();
+            let create = requests
+                .iter()
+                .find(|request| request.url.path() == CREATE_POLICY_PATH)
+                .expect("create_policy request was sent");
+            let body = String::from_utf8_lossy(&create.body);
+            assert!(
+                body.contains(SYNC_FACTOR_POLICY_CONDITION),
+                "create body missing the canonical condition"
+            );
+            let consensus =
+                sync_factor_policy_consensus(SYNC_ID).expect("SYNC_ID is valid");
+            assert!(
+                body.contains(&consensus),
+                "create body missing the per-user consensus"
+            );
+        }
+
+        #[tokio::test]
+        async fn sync_factor_policy_updates_outdated_policy() {
+            let server = MockServer::start().await;
+            // A narrower condition from before ORGANIZATION/USER deletions were granted.
+            let outdated =
+                "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL')";
+            mount_reads(
+                &server,
+                vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+                vec![user_policy_record("policy-old", SYNC_ID, outdated)],
+            )
+            .await;
+            Mock::given(method("POST"))
+                .and(path(UPDATE_POLICY_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(completed_update_policy("policy-old")),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            // Creating a fresh policy would be a bug: the existing one must be updated.
+            Mock::given(method("POST"))
+                .and(path(CREATE_POLICY_PATH))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+            let requests = server.received_requests().await.unwrap();
+            let update = requests
+                .iter()
+                .find(|request| request.url.path() == UPDATE_POLICY_PATH)
+                .expect("update_policy request was sent");
+            let body = String::from_utf8_lossy(&update.body);
+            assert!(
+                body.contains("policy-old"),
+                "update targeted the wrong policy"
+            );
+            assert!(
+                body.contains(SYNC_FACTOR_POLICY_CONDITION),
+                "update body missing the canonical condition"
+            );
+        }
+
+        #[tokio::test]
+        async fn sync_factor_policy_defers_without_main_factor() {
+            let server = MockServer::start().await;
+            mount_reads(
+                &server,
+                vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+                vec![],
+            )
+            .await;
+            Mock::given(method("POST"))
+                .and(path(CREATE_POLICY_PATH))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                None,
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            // Apple skips (no provider); only the policy migration defers.
+            let TurnkeyMigrationOutcome::MainFactorRequired { pending } = outcome
+            else {
+                panic!("expected MainFactorRequired, got {outcome:?}");
+            };
+            assert_eq!(pending.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn sync_factor_policy_skips_when_policy_correct() {
+            let server = MockServer::start().await;
+            mount_reads(
+                &server,
+                vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+                vec![user_policy_record(
+                    "policy-ok",
                     SYNC_ID,
                     SYNC_FACTOR_POLICY_CONDITION,
-                ),
-                // A leftover policy bound to a user no longer in the org.
-                user_policy_record(
-                    "policy-stale",
-                    gone_user,
-                    SYNC_FACTOR_POLICY_CONDITION,
-                ),
-            ],
-        )
-        .await;
-        Mock::given(method("POST"))
-            .and(path(DELETE_POLICY_PATH))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(completed_delete_policy("policy-stale")),
+                )],
             )
-            .expect(1)
-            .mount(&server)
             .await;
-        // No create/update: the live sync factor is already correct.
-        for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
-            Mock::given(method("POST"))
-                .and(path(write_path))
-                .respond_with(ResponseTemplate::new(500))
-                .expect(0)
-                .mount(&server)
-                .await;
+            // Any write is a bug when the policy already matches.
+            for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
+                Mock::given(method("POST"))
+                    .and(path(write_path))
+                    .respond_with(ResponseTemplate::new(500))
+                    .expect(0)
+                    .mount(&server)
+                    .await;
+            }
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
         }
 
-        let api = TurnkeyApiClient::with_base_url(server.uri());
-        let sync = signer();
-        let main = signer();
-        let outcome = run_migration_list(
-            MIGRATIONS,
-            "suborg-1",
-            SyncFactor(&sync),
-            Some(MainFactor(&main)),
-            &api,
-            BedrockEnvironment::Staging,
-        )
-        .await
-        .unwrap();
+        #[tokio::test]
+        async fn get_policies_is_cached_within_a_client() {
+            let server = MockServer::start().await;
+            // `.expect(1)` fails if a second call reaches the server instead of the cache.
+            Mock::given(method("POST"))
+                .and(path(LIST_POLICIES_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
 
-        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            api.get_policies("suborg-1", SyncFactor(&sync))
+                .await
+                .unwrap();
+            api.get_policies("suborg-1", SyncFactor(&sync))
+                .await
+                .unwrap();
+        }
 
-        let requests = server.received_requests().await.unwrap();
-        let delete = requests
-            .iter()
-            .find(|request| request.url.path() == DELETE_POLICY_PATH)
-            .expect("delete_policy request was sent");
-        let body = String::from_utf8_lossy(&delete.body);
-        assert!(body.contains("policy-stale"), "deleted the wrong policy");
+        /// A client serves exactly one sub-organization. Querying a second one is a
+        /// consistency violation, caught from the cache without a second network call.
+        #[tokio::test]
+        async fn get_policies_rejects_a_second_sub_org() {
+            use crate::backup::turnkey::error::TurnkeyApiError;
+
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path(LIST_POLICIES_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            api.get_policies("suborg-1", SyncFactor(&sync))
+                .await
+                .unwrap();
+            let error = api
+                .get_policies("suborg-2", SyncFactor(&sync))
+                .await
+                .expect_err("a different sub-org must be rejected");
+            assert!(matches!(error, TurnkeyApiError::Consistency));
+        }
+
+        #[tokio::test]
+        async fn sync_factor_policy_prunes_stale_policy() {
+            let server = MockServer::start().await;
+            let gone_user = "99999999-9999-9999-9999-999999999999";
+            mount_reads(
+                &server,
+                vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+                vec![
+                    // The live sync factor's policy is already correct.
+                    user_policy_record(
+                        "policy-live",
+                        SYNC_ID,
+                        SYNC_FACTOR_POLICY_CONDITION,
+                    ),
+                    // A leftover policy bound to a user no longer in the org.
+                    user_policy_record(
+                        "policy-stale",
+                        gone_user,
+                        SYNC_FACTOR_POLICY_CONDITION,
+                    ),
+                ],
+            )
+            .await;
+            Mock::given(method("POST"))
+                .and(path(DELETE_POLICY_PATH))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(completed_delete_policy("policy-stale")),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            // No create/update: the live sync factor is already correct.
+            for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
+                Mock::given(method("POST"))
+                    .and(path(write_path))
+                    .respond_with(ResponseTemplate::new(500))
+                    .expect(0)
+                    .mount(&server)
+                    .await;
+            }
+
+            let api = TurnkeyApiClient::with_base_url(server.uri());
+            let sync = signer();
+            let main = signer();
+            let outcome = run_migration_list(
+                MIGRATIONS,
+                "suborg-1",
+                SyncFactor(&sync),
+                Some(MainFactor(&main)),
+                &api,
+                BedrockEnvironment::Staging,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+            let requests = server.received_requests().await.unwrap();
+            let delete = requests
+                .iter()
+                .find(|request| request.url.path() == DELETE_POLICY_PATH)
+                .expect("delete_policy request was sent");
+            let body = String::from_utf8_lossy(&delete.body);
+            assert!(body.contains("policy-stale"), "deleted the wrong policy");
+        }
     }
 }

--- a/bedrock/src/backup/turnkey/test.rs
+++ b/bedrock/src/backup/turnkey/test.rs
@@ -117,7 +117,11 @@ mod migration_functional_tests {
     use crate::backup::turnkey::migrations::{
         run_migration_list, TurnkeyMigrationOutcome, MIGRATIONS,
     };
-    use crate::backup::turnkey::policies::{APPLE_ISSUER, AUTH_USER_MAIN_USERNAME};
+    use crate::backup::turnkey::policies::{
+        sync_factor_policy_consensus, sync_factor_policy_name, APPLE_ISSUER,
+        AUTH_USER_MAIN_USERNAME, SYNC_FACTOR_POLICY_CONDITION,
+        SYNC_FACTOR_USERNAME_PREFIX,
+    };
     use crate::primitives::config::BedrockEnvironment;
     use crate::primitives::P256Signer;
     use serde_json::json;
@@ -127,6 +131,13 @@ mod migration_functional_tests {
 
     const LIST_USERS_PATH: &str = "/public/v1/query/list_users";
     const CREATE_OAUTH_PATH: &str = "/public/v1/submit/create_oauth_providers";
+    const LIST_POLICIES_PATH: &str = "/public/v1/query/list_policies";
+    const CREATE_POLICY_PATH: &str = "/public/v1/submit/create_policy";
+    const UPDATE_POLICY_PATH: &str = "/public/v1/submit/update_policy";
+    const DELETE_POLICY_PATH: &str = "/public/v1/submit/delete_policy";
+
+    /// A sync factor user id (UUID) used across the policy tests.
+    const SYNC_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
     fn signer() -> P256Signer {
         P256Signer::verify(Arc::new(TestSigner::new())).expect("valid test signer")
@@ -153,11 +164,26 @@ mod migration_functional_tests {
         })
     }
 
-    async fn mount_list_users(server: &MockServer, user: serde_json::Value) {
+    /// Mounts both read endpoints the migration list depends on: `list_users` and
+    /// `list_policies`. Every functional test needs both, since the run executes the
+    /// full [`MIGRATIONS`] list.
+    async fn mount_reads(
+        server: &MockServer,
+        users: Vec<serde_json::Value>,
+        policies: Vec<serde_json::Value>,
+    ) {
         Mock::given(method("POST"))
             .and(path(LIST_USERS_PATH))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "users": [user] })),
+                ResponseTemplate::new(200).set_body_json(json!({ "users": users })),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(LIST_POLICIES_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "policies": policies })),
             )
             .mount(server)
             .await;
@@ -179,13 +205,92 @@ mod migration_functional_tests {
         })
     }
 
+    /// `auth_user_main` with no OAuth providers, so the Apple migration is a no-op
+    /// and the policy migration is exercised in isolation.
+    fn main_user_without_apple() -> serde_json::Value {
+        json!({
+            "userId": "user-main",
+            "userName": AUTH_USER_MAIN_USERNAME,
+            "oauthProviders": [],
+        })
+    }
+
+    /// A sync factor user named `sync_factor_user_<user_id>`.
+    fn sync_factor_user(user_id: &str) -> serde_json::Value {
+        json!({
+            "userId": user_id,
+            "userName": format!("{SYNC_FACTOR_USERNAME_PREFIX}{user_id}"),
+        })
+    }
+
+    /// A sync factor policy record for `list_policies`, bound to `user_id`
+    /// with an arbitrary `condition` (to model an outdated one).
+    fn user_policy_record(
+        policy_id: &str,
+        user_id: &str,
+        condition: &str,
+    ) -> serde_json::Value {
+        json!({
+            "policyId": policy_id,
+            "policyName": sync_factor_policy_name(user_id),
+            "effect": "EFFECT_ALLOW",
+            "notes": "",
+            "consensus": sync_factor_policy_consensus(user_id)
+                .expect("test user id is valid"),
+            "condition": condition,
+        })
+    }
+
+    /// A COMPLETED `CreatePolicy` activity response returning `policy_id`.
+    fn completed_create_policy(policy_id: &str) -> serde_json::Value {
+        json!({
+            "activity": {
+                "id": "act-create-policy",
+                "organizationId": "suborg-1",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_CREATE_POLICY_V3",
+                "fingerprint": "fp-create-policy",
+                "result": { "createPolicyResult": { "policyId": policy_id } }
+            }
+        })
+    }
+
+    /// A COMPLETED `UpdatePolicy` activity response returning `policy_id`.
+    fn completed_update_policy(policy_id: &str) -> serde_json::Value {
+        json!({
+            "activity": {
+                "id": "act-update-policy",
+                "organizationId": "suborg-1",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_UPDATE_POLICY_V2",
+                "fingerprint": "fp-update-policy",
+                "result": { "updatePolicyResultV2": { "policyId": policy_id } }
+            }
+        })
+    }
+
+    /// A COMPLETED `DeletePolicy` activity response returning `policy_id`.
+    fn completed_delete_policy(policy_id: &str) -> serde_json::Value {
+        json!({
+            "activity": {
+                "id": "act-delete-policy",
+                "organizationId": "suborg-1",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_DELETE_POLICY",
+                "fingerprint": "fp-delete-policy",
+                "result": { "deletePolicyResult": { "policyId": policy_id } }
+            }
+        })
+    }
+
     #[tokio::test]
     async fn apple_audiences_creates_missing_audiences_with_main_factor() {
         let server = MockServer::start().await;
         // Only the first staging audience present → the other three missing.
-        mount_list_users(
+        mount_reads(
             &server,
-            main_user(&["org.worldcoin.insight.staging"], "sub-apple"),
+            vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
+            vec![],
         )
         .await;
         Mock::given(method("POST"))
@@ -239,9 +344,9 @@ mod migration_functional_tests {
     #[tokio::test]
     async fn apple_audiences_skips_when_all_audiences_present() {
         let server = MockServer::start().await;
-        mount_list_users(
+        mount_reads(
             &server,
-            main_user(
+            vec![main_user(
                 &[
                     "org.worldcoin.insight.staging",
                     "org.world.staging.id",
@@ -249,7 +354,8 @@ mod migration_functional_tests {
                     "app.world.apple.staging",
                 ],
                 "sub-apple",
-            ),
+            )],
+            vec![],
         )
         .await;
         // Any create call is a bug.
@@ -280,9 +386,10 @@ mod migration_functional_tests {
     #[tokio::test]
     async fn apple_audiences_defers_without_main_factor_and_never_writes() {
         let server = MockServer::start().await;
-        mount_list_users(
+        mount_reads(
             &server,
-            main_user(&["org.worldcoin.insight.staging"], "sub-apple"),
+            vec![main_user(&["org.worldcoin.insight.staging"], "sub-apple")],
+            vec![],
         )
         .await;
         Mock::given(method("POST"))
@@ -309,5 +416,314 @@ mod migration_functional_tests {
             panic!("expected MainFactorRequired, got {outcome:?}");
         };
         assert_eq!(pending.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sync_factor_policy_creates_policy_when_missing() {
+        let server = MockServer::start().await;
+        mount_reads(
+            &server,
+            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+            vec![],
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path(CREATE_POLICY_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(completed_create_policy("new-policy")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        let main = signer();
+        let outcome = run_migration_list(
+            MIGRATIONS,
+            "suborg-1",
+            SyncFactor(&sync),
+            Some(MainFactor(&main)),
+            &api,
+            BedrockEnvironment::Staging,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+        // The create request carried the canonical condition bound to this user.
+        let requests = server.received_requests().await.unwrap();
+        let create = requests
+            .iter()
+            .find(|request| request.url.path() == CREATE_POLICY_PATH)
+            .expect("create_policy request was sent");
+        let body = String::from_utf8_lossy(&create.body);
+        assert!(
+            body.contains(SYNC_FACTOR_POLICY_CONDITION),
+            "create body missing the canonical condition"
+        );
+        let consensus =
+            sync_factor_policy_consensus(SYNC_ID).expect("SYNC_ID is valid");
+        assert!(
+            body.contains(&consensus),
+            "create body missing the per-user consensus"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_factor_policy_updates_outdated_policy() {
+        let server = MockServer::start().await;
+        // A narrower condition from before ORGANIZATION/USER deletions were granted.
+        let outdated =
+            "activity.action == 'DELETE' && (activity.resource == 'CREDENTIAL')";
+        mount_reads(
+            &server,
+            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+            vec![user_policy_record("policy-old", SYNC_ID, outdated)],
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path(UPDATE_POLICY_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(completed_update_policy("policy-old")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Creating a fresh policy would be a bug: the existing one must be updated.
+        Mock::given(method("POST"))
+            .and(path(CREATE_POLICY_PATH))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        let main = signer();
+        let outcome = run_migration_list(
+            MIGRATIONS,
+            "suborg-1",
+            SyncFactor(&sync),
+            Some(MainFactor(&main)),
+            &api,
+            BedrockEnvironment::Staging,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+        let requests = server.received_requests().await.unwrap();
+        let update = requests
+            .iter()
+            .find(|request| request.url.path() == UPDATE_POLICY_PATH)
+            .expect("update_policy request was sent");
+        let body = String::from_utf8_lossy(&update.body);
+        assert!(
+            body.contains("policy-old"),
+            "update targeted the wrong policy"
+        );
+        assert!(
+            body.contains(SYNC_FACTOR_POLICY_CONDITION),
+            "update body missing the canonical condition"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_factor_policy_defers_without_main_factor() {
+        let server = MockServer::start().await;
+        mount_reads(
+            &server,
+            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+            vec![],
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path(CREATE_POLICY_PATH))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        let outcome = run_migration_list(
+            MIGRATIONS,
+            "suborg-1",
+            SyncFactor(&sync),
+            None,
+            &api,
+            BedrockEnvironment::Staging,
+        )
+        .await
+        .unwrap();
+
+        // Apple skips (no provider); only the policy migration defers.
+        let TurnkeyMigrationOutcome::MainFactorRequired { pending } = outcome else {
+            panic!("expected MainFactorRequired, got {outcome:?}");
+        };
+        assert_eq!(pending.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sync_factor_policy_skips_when_policy_correct() {
+        let server = MockServer::start().await;
+        mount_reads(
+            &server,
+            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+            vec![user_policy_record(
+                "policy-ok",
+                SYNC_ID,
+                SYNC_FACTOR_POLICY_CONDITION,
+            )],
+        )
+        .await;
+        // Any write is a bug when the policy already matches.
+        for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
+            Mock::given(method("POST"))
+                .and(path(write_path))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+        }
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        let main = signer();
+        let outcome = run_migration_list(
+            MIGRATIONS,
+            "suborg-1",
+            SyncFactor(&sync),
+            Some(MainFactor(&main)),
+            &api,
+            BedrockEnvironment::Staging,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+    }
+
+    #[tokio::test]
+    async fn get_policies_is_cached_within_a_client() {
+        let server = MockServer::start().await;
+        // `.expect(1)` fails if a second call reaches the server instead of the cache.
+        Mock::given(method("POST"))
+            .and(path(LIST_POLICIES_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        api.get_policies("suborg-1", SyncFactor(&sync))
+            .await
+            .unwrap();
+        api.get_policies("suborg-1", SyncFactor(&sync))
+            .await
+            .unwrap();
+    }
+
+    /// A client serves exactly one sub-organization. Querying a second one is a
+    /// consistency violation, caught from the cache without a second network call.
+    #[tokio::test]
+    async fn get_policies_rejects_a_second_sub_org() {
+        use crate::backup::turnkey::error::TurnkeyApiError;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(LIST_POLICIES_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "policies": [] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        api.get_policies("suborg-1", SyncFactor(&sync))
+            .await
+            .unwrap();
+        let error = api
+            .get_policies("suborg-2", SyncFactor(&sync))
+            .await
+            .expect_err("a different sub-org must be rejected");
+        assert!(matches!(error, TurnkeyApiError::Consistency));
+    }
+
+    #[tokio::test]
+    async fn sync_factor_policy_prunes_stale_policy() {
+        let server = MockServer::start().await;
+        let gone_user = "99999999-9999-9999-9999-999999999999";
+        mount_reads(
+            &server,
+            vec![main_user_without_apple(), sync_factor_user(SYNC_ID)],
+            vec![
+                // The live sync factor's policy is already correct.
+                user_policy_record(
+                    "policy-live",
+                    SYNC_ID,
+                    SYNC_FACTOR_POLICY_CONDITION,
+                ),
+                // A leftover policy bound to a user no longer in the org.
+                user_policy_record(
+                    "policy-stale",
+                    gone_user,
+                    SYNC_FACTOR_POLICY_CONDITION,
+                ),
+            ],
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path(DELETE_POLICY_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(completed_delete_policy("policy-stale")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        // No create/update: the live sync factor is already correct.
+        for write_path in [CREATE_POLICY_PATH, UPDATE_POLICY_PATH] {
+            Mock::given(method("POST"))
+                .and(path(write_path))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+        }
+
+        let api = TurnkeyApiClient::with_base_url(server.uri());
+        let sync = signer();
+        let main = signer();
+        let outcome = run_migration_list(
+            MIGRATIONS,
+            "suborg-1",
+            SyncFactor(&sync),
+            Some(MainFactor(&main)),
+            &api,
+            BedrockEnvironment::Staging,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TurnkeyMigrationOutcome::Completed);
+
+        let requests = server.received_requests().await.unwrap();
+        let delete = requests
+            .iter()
+            .find(|request| request.url.path() == DELETE_POLICY_PATH)
+            .expect("delete_policy request was sent");
+        let body = String::from_utf8_lossy(&delete.body);
+        assert!(body.contains("policy-stale"), "deleted the wrong policy");
     }
 }


### PR DESCRIPTION
### Changes
1. Introduces the sync factor policy migration. Rationale and functionality is documented in the code but at a high level this ensures each sync factor has the right policy. Previously users where created with a different policy, the Turnkey team advised against using `activity.type` for these policies. All with its relevant unit and functional tests.
2. Refactors the Turnkey API cache to more generically serve different resources vs. just users, and most importantly flag consistency issues if different sub-org IDs are used during a single migration process.
3. Addresses the outstanding comments from #392
4. **Non-change**. The apple audiences functional tests were moved to a new sub-module to have a clear separation between each test suite. No changes are introduced.


### Real Testing

I tested all the changes in this PR with the real Turnkey API using the `run_migrations_against_real_turnkey` test:
1. I ran the test with an account created from the iOS app. These were the results (as expected),
	```
	running 1 test
	[bedrock][Debug] [Bedrock][TurnkeyManager] run_migrations start is_suborg_provided=false
	[bedrock][Info] [Bedrock][TurnkeyManager] apple_audience skipped: skip: all providers are already configured
	[bedrock][Info] [Bedrock][TurnkeyManager] turnkey.migration.applied migration=sync_factor_policy changes=[updated policy for sync_factor_user_yK3SxF]
	[bedrock][Debug] [Bedrock][TurnkeyManager] run_migrations completed successfully
	run_migrations outcome: Completed
	test backup::turnkey::test::integration_tests::run_migrations_against_real_turnkey ... ok
	```
	- You can see the policy for my Sync Factor user **before** the migration
		<img width="560" height="157" src="https://github.com/user-attachments/assets/cce3dd48-614d-4a88-b92a-0a4c0e898e2a" />
    - ....and after the migration:
	<img width="621" height="147"  src="https://github.com/user-attachments/assets/6fb99a25-bc29-4e02-8e6c-28bff237333c" />
	- furthermore, you can see the activity was properly executed in Turnkey
	<img width="708" height="414" src="https://github.com/user-attachments/assets/47e51ee1-ee0e-4f5b-9885-f2d035cc85a8" />
2. Afterwards I ran the migration again and as expected, no more changes.
	```
	running 1 test
	[bedrock][Debug] [Bedrock][TurnkeyManager] run_migrations start is_suborg_provided=false
	[bedrock][Info] [Bedrock][TurnkeyManager] apple_audience skipped: skip: all providers are already configured
	[bedrock][Info] [Bedrock][TurnkeyManager] sync_factor_policy skipped: all sync factors have the correct policy
	[bedrock][Debug] [Bedrock][TurnkeyManager] run_migrations completed successfully
	run_migrations outcome: Completed
	test backup::turnkey::test::integration_tests::run_migrations_against_real_turnkey ... ok
	```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live Turnkey authorization policies and can delete policies; mistakes could weaken deletion permissions or remove needed policies, though guards (exact consensus matching, skip multi-policy users, UUID validation) limit blast radius.
> 
> **Overview**
> Adds **`MigrationSyncFactorPolicy`** to the Turnkey migration pipeline so each sync-factor user gets the canonical **DELETE** policy (`resource` + `action`, not legacy `activity.type`), with create/update when drifted and **delete** for policies bound to users no longer in the sub-org. Canonical policy text, user-role classification, and UUID-safe consensus strings live in **`policies.rs`**.
> 
> **`TurnkeyApiClient`** replaces the per-sub-org `HashMap` user cache with **`OrgCache`** (single sub-org per client, `Arc` shared reads, consistency error on sub-org mismatch), returns **`Arc<Vec<User>>`**, and adds cached **`get_policies`** plus **`create_policy` / `update_policy` / `delete_policy`** with cache invalidation on writes. **`apple_audience`** is adjusted for borrowed users and minor docs; functional tests are split by migration with shared read mocks for users + policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3d54b185809a57d8f29c961e393019de2c7c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->