### PR TITLE
fix: normalize low-s signature for KeypairSigner

### DIFF
--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -74,7 +74,7 @@ impl Stamp for KeypairSignerStamper {
             .map_err(|e| StamperError::InvalidPrivateKeyBytes(e.to_string()))?;
         let stamp = ApiStamp {
             public_key: self.signer.public_key_hex().to_string(),
-            signature: hex::encode(signature),
+            signature: hex::encode(signature.to_der()),
             scheme: SIGNATURE_SCHEME_P256.to_string(),
         };
         let json = serde_json::to_string(&stamp).map_err(|e| {

--- a/bedrock/src/migration/processors/safe_4337_module_processor.rs
+++ b/bedrock/src/migration/processors/safe_4337_module_processor.rs
@@ -193,7 +193,8 @@ impl MigrationProcessor for Safe4337ModuleProcessor {
 
         crate::info!(
             "Relayed Safe 4337 repair (enable_module={}, set_fallback_handler={})",
-            repairs.enable_module, repairs.set_fallback_handler
+            repairs.enable_module,
+            repairs.set_fallback_handler
         );
 
         // Not done yet: the relayed transaction may not have mined. Stay

--- a/bedrock/src/primitives/signer.rs
+++ b/bedrock/src/primitives/signer.rs
@@ -30,7 +30,7 @@ pub trait KeypairSigner: Send + Sync {
     /// Returns [`KeypairSignerError`] if the key material is unavailable or invalid.
     fn public_key(&self) -> Result<Vec<u8>, KeypairSignerError>;
 
-    /// Signs a pre-computed digest with the private key. Signature MUST be normalized (low S).
+    /// Signs a pre-computed digest with the private key.
     ///
     /// # Errors
     /// Returns [`KeypairSignerError`] if signing is rejected or the key is unavailable.

--- a/bedrock/src/primitives/signer.rs
+++ b/bedrock/src/primitives/signer.rs
@@ -150,6 +150,7 @@ impl P256Signer {
 #[cfg(test)]
 mod p256_signer_tests {
     use super::*;
+    use hex_literal::hex;
     use p256::ecdsa::signature::hazmat::PrehashSigner;
     use p256::elliptic_curve::sec1::ToEncodedPoint;
     use p256::elliptic_curve::PrimeField;
@@ -260,6 +261,30 @@ mod p256_signer_tests {
 
         assert_eq!(signature, expected);
         assert!(signature.normalize_s().is_none());
+    }
+
+    /// Tests the low-s normalization with a static test vector for a signature.
+    ///
+    /// The test vector is obtained from [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) §A.2.5
+    /// (With SHA-256, message = "sample")
+    #[test]
+    fn normalizes_deterministic_high_s_signature() {
+        let s =
+            hex!("F7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8");
+        let r =
+            hex!("EFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716");
+        let signature = p256::ecdsa::Signature::from_scalars(r, s).unwrap();
+        let sig_der = signature.to_der().as_bytes().to_vec();
+
+        let signature = signer_returning(sig_der.clone())
+            .sign_digest(DIGEST.to_vec())
+            .unwrap();
+
+        assert_ne!(
+            signature.to_der().as_bytes(),
+            &sig_der,
+            "normalized signature MUST differ"
+        );
     }
 
     #[test]

--- a/bedrock/src/primitives/signer.rs
+++ b/bedrock/src/primitives/signer.rs
@@ -47,6 +47,9 @@ pub enum KeypairSignerError {
     /// The key material is malformed or of an unexpected type.
     #[error("invalid signing key material")]
     InvalidKey,
+    /// The trait implementation provided an invalid signature for the specific curve.
+    #[error("invalid signature received")]
+    InvalidSignature,
     /// The public key returned by the signer is malformed: wrong length, not a
     /// valid compressed SEC1 encoding, or not a point on the P-256 curve.
     #[error("invalid public key: {error_message}")]
@@ -126,25 +129,37 @@ impl P256Signer {
         &self.public_key_hex
     }
 
-    /// Signs a pre-computed 32-byte digest with the underlying signer.
+    /// Signs a pre-computed 32-byte digest with the underlying signer. Will
+    /// perform low-s normalization on all signatures.
     ///
     /// # Errors
-    /// Returns [`KeypairSignerError`] if signing is rejected or the key is
-    /// unavailable.
-    pub fn sign_digest(&self, digest: Vec<u8>) -> Result<Vec<u8>, KeypairSignerError> {
-        self.signer.sign_digest(digest)
+    /// Returns [`KeypairSignerError`] if signing is rejected, an invalid signature
+    /// is provided by the implementer, or the key is unavailable.
+    pub fn sign_digest(
+        &self,
+        digest: Vec<u8>,
+    ) -> Result<p256::ecdsa::Signature, KeypairSignerError> {
+        let signature = self.signer.sign_digest(digest)?;
+        let signature = p256::ecdsa::Signature::from_der(&signature)
+            .map_err(|_| KeypairSignerError::InvalidSignature)?;
+
+        Ok(signature.normalize_s().unwrap_or(signature))
     }
 }
 
 #[cfg(test)]
 mod p256_signer_tests {
     use super::*;
+    use p256::ecdsa::signature::hazmat::PrehashSigner;
     use p256::elliptic_curve::sec1::ToEncodedPoint;
+    use p256::elliptic_curve::PrimeField;
 
-    /// A signer that returns canned public-key bytes, for exercising validation
-    /// paths. `None` makes [`KeypairSigner::public_key`] fail.
+    const DIGEST: [u8; 32] = [0x42; 32];
+
+    #[derive(Default)]
     struct MockSigner {
         public_key: Option<Vec<u8>>,
+        signature: Vec<u8>,
     }
 
     impl KeypairSigner for MockSigner {
@@ -154,7 +169,7 @@ mod p256_signer_tests {
                 .ok_or(KeypairSignerError::Unavailable)
         }
         fn sign_digest(&self, _digest: Vec<u8>) -> Result<Vec<u8>, KeypairSignerError> {
-            Ok(Vec::new())
+            Ok(self.signature.clone())
         }
     }
 
@@ -167,11 +182,34 @@ mod p256_signer_tests {
             .to_vec()
     }
 
+    /// A [`P256Signer`] whose underlying signer always returns `signature`.
+    fn signer_returning(signature: Vec<u8>) -> P256Signer {
+        P256Signer::verify(Arc::new(MockSigner {
+            public_key: Some(valid_compressed_key()),
+            signature,
+        }))
+        .unwrap()
+    }
+
+    /// A valid, low-S signature over [`DIGEST`].
+    fn low_s_signature() -> p256::ecdsa::Signature {
+        let key = p256::ecdsa::SigningKey::from_slice(&[1u8; 32]).unwrap();
+        let signature: p256::ecdsa::Signature = key.sign_prehash(&DIGEST).unwrap();
+        signature.normalize_s().unwrap_or(signature)
+    }
+
+    fn to_high_s(signature: &p256::ecdsa::Signature) -> p256::ecdsa::Signature {
+        let (r, _) = signature.split_bytes();
+        let s = -*signature.s().as_ref();
+        p256::ecdsa::Signature::from_scalars(r, s.to_repr()).expect("non-zero scalars")
+    }
+
     #[test]
     fn accepts_valid_compressed_key() {
         let key = valid_compressed_key();
         let verified = P256Signer::verify(Arc::new(MockSigner {
             public_key: Some(key.clone()),
+            ..MockSigner::default()
         }))
         .unwrap();
         assert_eq!(verified.public_key_hex(), hex::encode(&key));
@@ -181,6 +219,7 @@ mod p256_signer_tests {
     fn rejects_wrong_length_key() {
         let result = P256Signer::verify(Arc::new(MockSigner {
             public_key: Some(vec![0x02; 32]),
+            ..MockSigner::default()
         }));
         assert!(matches!(
             result,
@@ -195,6 +234,7 @@ mod p256_signer_tests {
         key[0] = 0x01;
         let result = P256Signer::verify(Arc::new(MockSigner {
             public_key: Some(key),
+            ..MockSigner::default()
         }));
         assert!(matches!(
             result,
@@ -204,7 +244,40 @@ mod p256_signer_tests {
 
     #[test]
     fn propagates_public_key_error() {
-        let result = P256Signer::verify(Arc::new(MockSigner { public_key: None }));
+        let result = P256Signer::verify(Arc::new(MockSigner::default()));
         assert!(matches!(result, Err(KeypairSignerError::Unavailable)));
+    }
+
+    #[test]
+    fn normalizes_high_s_signature() {
+        let expected = low_s_signature();
+        let high_s = to_high_s(&expected);
+        assert_ne!(high_s, expected);
+
+        let signature = signer_returning(high_s.to_der().as_bytes().to_vec())
+            .sign_digest(DIGEST.to_vec())
+            .unwrap();
+
+        assert_eq!(signature, expected);
+        assert!(signature.normalize_s().is_none());
+    }
+
+    #[test]
+    fn preserves_low_s_signature() {
+        let expected = low_s_signature();
+
+        let signature = signer_returning(expected.to_der().as_bytes().to_vec())
+            .sign_digest(DIGEST.to_vec())
+            .unwrap();
+
+        assert_eq!(signature, expected);
+    }
+
+    #[test]
+    fn rejects_non_der_signature() {
+        // Raw 64-byte concatenated (r, s) instead of the required DER encoding.
+        let raw = low_s_signature().to_bytes().to_vec();
+        let result = signer_returning(raw).sign_digest(DIGEST.to_vec());
+        assert!(matches!(result, Err(KeypairSignerError::InvalidSignature)));
     }
 }


### PR DESCRIPTION
Performs the low-s signature normalization for `KeypairSigner` foreign trait here, instead of delegating to native callers which would need to implement their own modular arithmetic (e.g. CryptoKit doesn't normalize).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Turnkey request stamping and the P-256 signing contract for all foreign signers; incorrect normalization or DER handling could break API authentication.
> 
> **Overview**
> **P-256 signing through the FFI `KeypairSigner` is normalized in Bedrock** so native platforms (e.g. CryptoKit) do not need to implement low-S themselves.
> 
> `P256Signer::sign_digest` now parses the foreign bytes as DER, returns a `p256::ecdsa::Signature`, and applies `normalize_s()` before callers use the result. Invalid DER yields a new `KeypairSignerError::InvalidSignature`. Turnkey API stamping was updated to hex-encode `signature.to_der()` from that path. Tests cover high-S normalization, preservation of already-low-S signatures, RFC 6979 vectors, and rejection of raw 64-byte (non-DER) signatures.
> 
> A trivial log-line formatting change appears in the Safe 4337 migration processor (unrelated to signing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61725108ac0a805905763e687c2d7399edea7e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->