### PR TITLE
fix: settle migrations as succeeded when no longer applicable

### DIFF
--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -404,12 +404,33 @@ impl MigrationController {
         };
 
         if !is_applicable {
-            // For TTL-expired succeeded migrations, renew recheck_at to avoid
-            // calling is_applicable on every app open.
-            if matches!(record.status, MigrationStatus::Succeeded) {
-                record.recheck_at =
-                    Some(Utc::now() + Duration::days(MIGRATION_SUCCESS_TTL_DAYS));
-                let _ = self.save_record(&migration_id, &record);
+            // The desired end state already holds, however it was reached.
+            // Settle the record as `Succeeded` so future runs skip it until
+            // the TTL recheck instead of re-running `is_applicable` on every
+            // app open. This also converges migrations whose effect landed
+            // after a failed attempt (e.g. a transaction submitted by
+            // `execute` that only mined after that run gave up on it).
+            if !matches!(record.status, MigrationStatus::Succeeded) {
+                crate::info!(
+                    "migration.settled_not_applicable id={} previous_status={:?} timestamp={}",
+                    migration_id,
+                    record.status,
+                    Utc::now().to_rfc3339()
+                );
+                record.status = MigrationStatus::Succeeded;
+                record.completed_at = Some(Utc::now());
+                record.last_error_code = None;
+                record.last_error_message = None;
+            }
+            record.recheck_at =
+                Some(Utc::now() + Duration::days(MIGRATION_SUCCESS_TTL_DAYS));
+            if let Err(e) = self.save_record(&migration_id, &record) {
+                crate::error!(
+                    "migration.storage_error id={} error={:?} timestamp={}",
+                    migration_id,
+                    e,
+                    Utc::now().to_rfc3339()
+                );
             }
             return MigrationRunSummary {
                 skipped: 1,
@@ -662,6 +683,7 @@ mod tests {
     /// Test processor where `is_applicable` returns false
     struct NotApplicableProcessor {
         id: String,
+        applicability_check_count: Arc<AtomicU32>,
         execution_count: Arc<AtomicU32>,
     }
 
@@ -669,8 +691,13 @@ mod tests {
         fn new(id: &str) -> Self {
             Self {
                 id: id.to_string(),
+                applicability_check_count: Arc::new(AtomicU32::new(0)),
                 execution_count: Arc::new(AtomicU32::new(0)),
             }
+        }
+
+        fn applicability_check_count(&self) -> u32 {
+            self.applicability_check_count.load(Ordering::SeqCst)
         }
 
         fn execution_count(&self) -> u32 {
@@ -685,6 +712,8 @@ mod tests {
         }
 
         async fn is_applicable(&self) -> Result<bool, MigrationError> {
+            self.applicability_check_count
+                .fetch_add(1, Ordering::SeqCst);
             Ok(false)
         }
 
@@ -1582,18 +1611,114 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_not_applicable_processor_is_skipped() {
+    async fn test_not_applicable_processor_is_skipped_and_settled() {
         let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
         let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
 
-        let controller =
-            MigrationController::with_processors(kv_store, vec![processor.clone()]);
+        let controller = MigrationController::with_processors(
+            kv_store.clone(),
+            vec![processor.clone()],
+        );
 
         let result = controller.run_migrations().await;
         assert!(result.is_ok());
         let summary = result.unwrap();
         assert_eq!(summary.skipped, 1);
         assert_eq!(summary.succeeded, 0);
+        assert_eq!(processor.execution_count(), 0);
+
+        // A NotStarted migration whose end state already holds settles as
+        // Succeeded so it isn't re-checked on every app open.
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        let record_json = kv_store.get(key).expect("Record should exist");
+        let record: MigrationRecord =
+            serde_json::from_str(&record_json).expect("Should deserialize");
+        assert!(matches!(record.status, MigrationStatus::Succeeded));
+        assert!(record.completed_at.is_some());
+        assert!(record.recheck_at.is_some());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_failed_retryable_not_applicable_settles_as_succeeded() {
+        // Regression test: a migration stuck in FailedRetryable whose effect
+        // later landed (e.g. the relayed transaction mined after `execute`
+        // gave up polling) must converge to Succeeded once `is_applicable`
+        // reports the end state holds — not stay FailedRetryable forever.
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
+
+        let record = MigrationRecord {
+            status: MigrationStatus::FailedRetryable,
+            attempts: 1,
+            started_at: Some(Utc::now() - chrono::Duration::days(1)),
+            last_attempted_at: Some(Utc::now() - chrono::Duration::days(1)),
+            last_error_code: Some("PENDING_TIMEOUT".to_string()),
+            last_error_message: Some("still pending after polling".to_string()),
+            ..MigrationRecord::default()
+        };
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        kv_store
+            .set(key.clone(), serde_json::to_string(&record).unwrap())
+            .unwrap();
+
+        let controller = MigrationController::with_processors(
+            kv_store.clone(),
+            vec![processor.clone()],
+        );
+
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        let summary = result.unwrap();
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(processor.execution_count(), 0);
+
+        let record_json = kv_store.get(key).expect("Record should exist");
+        let updated_record: MigrationRecord =
+            serde_json::from_str(&record_json).expect("Should deserialize");
+        assert!(matches!(updated_record.status, MigrationStatus::Succeeded));
+        assert!(updated_record.completed_at.is_some());
+        assert!(updated_record.recheck_at.is_some());
+        assert!(updated_record.last_error_code.is_none());
+        assert!(updated_record.last_error_message.is_none());
+        // Settling is not an execution attempt.
+        assert_eq!(updated_record.attempts, 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_settled_migration_skips_applicability_check_on_next_run() {
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
+
+        // Start from FailedRetryable (the stuck state from the regression).
+        let record = MigrationRecord {
+            status: MigrationStatus::FailedRetryable,
+            attempts: 1,
+            last_error_code: Some("PENDING_TIMEOUT".to_string()),
+            ..MigrationRecord::default()
+        };
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        kv_store
+            .set(key, serde_json::to_string(&record).unwrap())
+            .unwrap();
+
+        let controller =
+            MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        // First run settles the record as Succeeded.
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        assert_eq!(processor.applicability_check_count(), 1);
+
+        // Subsequent runs skip without re-running the (potentially expensive)
+        // applicability check until the TTL recheck is due.
+        for _ in 0..3 {
+            let result = controller.run_migrations().await;
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().skipped, 1);
+        }
+        assert_eq!(processor.applicability_check_count(), 1);
         assert_eq!(processor.execution_count(), 0);
     }
 

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -399,38 +399,71 @@ impl MigrationController {
                     e,
                     Utc::now().to_rfc3339()
                 );
-                false
+                // Unable to determine applicability: skip this run without
+                // modifying the stored record so the next run re-checks.
+                return MigrationRunSummary {
+                    skipped: 1,
+                    ..MigrationRunSummary::default()
+                };
             }
         };
 
         if !is_applicable {
-            // The desired end state already holds, however it was reached.
-            // Settle the record as `Succeeded` so future runs skip it until
-            // the TTL recheck instead of re-running `is_applicable` on every
-            // app open. This also converges migrations whose effect landed
-            // after a failed attempt (e.g. a transaction submitted by
-            // `execute` that only mined after that run gave up on it).
-            if !matches!(record.status, MigrationStatus::Succeeded) {
-                crate::info!(
-                    "migration.settled_not_applicable id={} previous_status={:?} timestamp={}",
-                    migration_id,
-                    record.status,
-                    Utc::now().to_rfc3339()
-                );
-                record.status = MigrationStatus::Succeeded;
-                record.completed_at = Some(Utc::now());
-                record.last_error_code = None;
-                record.last_error_message = None;
-            }
-            record.recheck_at =
-                Some(Utc::now() + Duration::days(MIGRATION_SUCCESS_TTL_DAYS));
-            if let Err(e) = self.save_record(&migration_id, &record) {
-                crate::error!(
-                    "migration.storage_error id={} error={:?} timestamp={}",
-                    migration_id,
-                    e,
-                    Utc::now().to_rfc3339()
-                );
+            match record.status {
+                // TTL recheck of an already-succeeded migration: renew
+                // recheck_at so is_applicable isn't re-run on every app open.
+                MigrationStatus::Succeeded => {
+                    record.recheck_at =
+                        Some(Utc::now() + Duration::days(MIGRATION_SUCCESS_TTL_DAYS));
+                    if let Err(e) = self.save_record(&migration_id, &record) {
+                        crate::error!(
+                            "migration.storage_error id={} error={:?} timestamp={}",
+                            migration_id,
+                            e,
+                            Utc::now().to_rfc3339()
+                        );
+                    }
+                }
+
+                // The migration was attempted before and the desired end state
+                // now holds, however it was reached. Settle the record as
+                // `Succeeded` so future runs skip it until the TTL recheck.
+                // This converges migrations whose effect landed after a failed
+                // attempt (e.g. a transaction submitted by `execute` that only
+                // mined after that run gave up on it).
+                MigrationStatus::InProgress | MigrationStatus::FailedRetryable => {
+                    crate::info!(
+                        "migration.settled_not_applicable id={} previous_status={:?} timestamp={}",
+                        migration_id,
+                        record.status,
+                        Utc::now().to_rfc3339()
+                    );
+                    record.status = MigrationStatus::Succeeded;
+                    record.completed_at = Some(Utc::now());
+                    record.last_error_code = None;
+                    record.last_error_message = None;
+                    record.recheck_at =
+                        Some(Utc::now() + Duration::days(MIGRATION_SUCCESS_TTL_DAYS));
+                    if let Err(e) = self.save_record(&migration_id, &record) {
+                        crate::error!(
+                            "migration.storage_error id={} error={:?} timestamp={}",
+                            migration_id,
+                            e,
+                            Utc::now().to_rfc3339()
+                        );
+                        return MigrationRunSummary {
+                            failed_retryable: 1,
+                            ..MigrationRunSummary::default()
+                        };
+                    }
+                }
+
+                // Never attempted: `false` may mean "not applicable yet"
+                // (e.g. feature flag off, migration source data absent), so
+                // leave the record untouched and re-check on the next run.
+                // (`FailedTerminal` never reaches here; it is filtered out by
+                // `should_attempt` above.)
+                MigrationStatus::NotStarted | MigrationStatus::FailedTerminal => {}
             }
             return MigrationRunSummary {
                 skipped: 1,
@@ -715,6 +748,43 @@ mod tests {
             self.applicability_check_count
                 .fetch_add(1, Ordering::SeqCst);
             Ok(false)
+        }
+
+        async fn execute(&self) -> Result<ProcessorResult, MigrationError> {
+            self.execution_count.fetch_add(1, Ordering::SeqCst);
+            Ok(ProcessorResult::Success)
+        }
+    }
+
+    /// Test processor where `is_applicable` returns an error
+    struct ApplicabilityErrorProcessor {
+        id: String,
+        execution_count: Arc<AtomicU32>,
+    }
+
+    impl ApplicabilityErrorProcessor {
+        fn new(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                execution_count: Arc::new(AtomicU32::new(0)),
+            }
+        }
+
+        fn execution_count(&self) -> u32 {
+            self.execution_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl MigrationProcessor for ApplicabilityErrorProcessor {
+        fn migration_id(&self) -> String {
+            self.id.clone()
+        }
+
+        async fn is_applicable(&self) -> Result<bool, MigrationError> {
+            Err(MigrationError::InvalidOperation(
+                "RPC unavailable".to_string(),
+            ))
         }
 
         async fn execute(&self) -> Result<ProcessorResult, MigrationError> {
@@ -1611,7 +1681,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_not_applicable_processor_is_skipped_and_settled() {
+    async fn test_not_started_not_applicable_skips_without_settling() {
         let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
         let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
 
@@ -1627,15 +1697,14 @@ mod tests {
         assert_eq!(summary.succeeded, 0);
         assert_eq!(processor.execution_count(), 0);
 
-        // A NotStarted migration whose end state already holds settles as
-        // Succeeded so it isn't re-checked on every app open.
+        // A never-attempted migration is NOT settled: `false` may mean "not
+        // applicable yet" (feature flag off, source data absent), so nothing
+        // is persisted and the next run re-checks.
         let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
-        let record_json = kv_store.get(key).expect("Record should exist");
-        let record: MigrationRecord =
-            serde_json::from_str(&record_json).expect("Should deserialize");
-        assert!(matches!(record.status, MigrationStatus::Succeeded));
-        assert!(record.completed_at.is_some());
-        assert!(record.recheck_at.is_some());
+        assert!(matches!(
+            kv_store.get(key),
+            Err(KeyValueStoreError::KeyNotFound)
+        ));
     }
 
     #[tokio::test]
@@ -1683,6 +1752,87 @@ mod tests {
         assert!(updated_record.last_error_message.is_none());
         // Settling is not an execution attempt.
         assert_eq!(updated_record.attempts, 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_in_progress_not_applicable_settles_as_succeeded() {
+        // An InProgress record (e.g. app crashed mid-migration) whose desired
+        // end state now holds also converges to Succeeded.
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
+
+        let record = MigrationRecord {
+            status: MigrationStatus::InProgress,
+            attempts: 1,
+            last_attempted_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            ..MigrationRecord::default()
+        };
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        kv_store
+            .set(key.clone(), serde_json::to_string(&record).unwrap())
+            .unwrap();
+
+        let controller = MigrationController::with_processors(
+            kv_store.clone(),
+            vec![processor.clone()],
+        );
+
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().skipped, 1);
+        assert_eq!(processor.execution_count(), 0);
+
+        let record_json = kv_store.get(key).expect("Record should exist");
+        let updated_record: MigrationRecord =
+            serde_json::from_str(&record_json).expect("Should deserialize");
+        assert!(matches!(updated_record.status, MigrationStatus::Succeeded));
+        assert!(updated_record.recheck_at.is_some());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_applicability_error_skips_without_modifying_record() {
+        // An `is_applicable` error (e.g. transient RPC failure) must not
+        // settle the migration as Succeeded — the stored record stays
+        // untouched so the next run re-checks.
+        let kv_store = Arc::new(InMemoryDeviceKeyValueStore::new());
+        let processor = Arc::new(ApplicabilityErrorProcessor::new("test.migration.v1"));
+
+        let record = MigrationRecord {
+            status: MigrationStatus::FailedRetryable,
+            attempts: 2,
+            last_error_code: Some("PENDING_TIMEOUT".to_string()),
+            last_error_message: Some("still pending after polling".to_string()),
+            ..MigrationRecord::default()
+        };
+        let key = format!("{MIGRATION_KEY_PREFIX}test.migration.v1");
+        kv_store
+            .set(key.clone(), serde_json::to_string(&record).unwrap())
+            .unwrap();
+
+        let controller = MigrationController::with_processors(
+            kv_store.clone(),
+            vec![processor.clone()],
+        );
+
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().skipped, 1);
+        assert_eq!(processor.execution_count(), 0);
+
+        let record_json = kv_store.get(key).expect("Record should exist");
+        let updated_record: MigrationRecord =
+            serde_json::from_str(&record_json).expect("Should deserialize");
+        assert!(matches!(
+            updated_record.status,
+            MigrationStatus::FailedRetryable
+        ));
+        assert_eq!(updated_record.attempts, 2);
+        assert_eq!(
+            updated_record.last_error_code.as_deref(),
+            Some("PENDING_TIMEOUT")
+        );
     }
 
     #[tokio::test]

--- a/bedrock/src/migration/controller.rs
+++ b/bedrock/src/migration/controller.rs
@@ -793,6 +793,26 @@ mod tests {
         }
     }
 
+    /// Test key-value store that serves reads from an inner store but fails
+    /// all writes
+    struct ReadOnlyKvStore {
+        inner: InMemoryDeviceKeyValueStore,
+    }
+
+    impl DeviceKeyValueStore for ReadOnlyKvStore {
+        fn get(&self, key: String) -> Result<String, KeyValueStoreError> {
+            self.inner.get(key)
+        }
+
+        fn set(&self, _key: String, _value: String) -> Result<(), KeyValueStoreError> {
+            Err(KeyValueStoreError::UpdateFailure)
+        }
+
+        fn delete(&self, _key: String) -> Result<(), KeyValueStoreError> {
+            Err(KeyValueStoreError::UpdateFailure)
+        }
+    }
+
     /// Test key-value store that fails on all operations
     struct FailingKvStore;
 
@@ -1788,6 +1808,38 @@ mod tests {
             serde_json::from_str(&record_json).expect("Should deserialize");
         assert!(matches!(updated_record.status, MigrationStatus::Succeeded));
         assert!(updated_record.recheck_at.is_some());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_settle_save_failure_counts_as_failed_retryable() {
+        // If persisting the settled record fails, the run must report a
+        // retryable failure (consistent with the other save_record sites),
+        // not a successful skip.
+        let inner = InMemoryDeviceKeyValueStore::new();
+        let record = MigrationRecord {
+            status: MigrationStatus::FailedRetryable,
+            attempts: 1,
+            ..MigrationRecord::default()
+        };
+        inner
+            .set(
+                format!("{MIGRATION_KEY_PREFIX}test.migration.v1"),
+                serde_json::to_string(&record).unwrap(),
+            )
+            .unwrap();
+        let kv_store = Arc::new(ReadOnlyKvStore { inner });
+
+        let processor = Arc::new(NotApplicableProcessor::new("test.migration.v1"));
+        let controller =
+            MigrationController::with_processors(kv_store, vec![processor.clone()]);
+
+        let result = controller.run_migrations().await;
+        assert!(result.is_ok());
+        let summary = result.unwrap();
+        assert_eq!(summary.failed_retryable, 1);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(processor.execution_count(), 0);
     }
 
     #[tokio::test]

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -67,6 +67,14 @@ pub trait MigrationProcessor: Send + Sync {
     /// is off, or the migration's source data is absent), so the controller
     /// leaves the record untouched and re-checks on the next run.
     ///
+    /// Prefer reserving `Ok(false)` for "the desired end state holds". If a
+    /// transient condition (a feature flag, source data that may appear later)
+    /// is checked here, be aware that once the migration has been attempted,
+    /// `Ok(false)` settles it as `Succeeded` and it is not re-checked until
+    /// the TTL recheck. If the migration must resume promptly when the
+    /// condition clears, gate inside [`execute`](Self::execute) and return
+    /// `Retryable` instead.
+    ///
     /// # Returns
     /// - `Ok(true)` if the migration should run
     /// - `Ok(false)` if the migration should not run now (settled as

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -54,17 +54,23 @@ pub trait MigrationProcessor: Send + Sync {
     /// the desired end state does **not** yet hold. This ensures the system is
     /// truly idempotent and handles edge cases gracefully.
     ///
-    /// Returning `Ok(false)` means the desired end state already holds,
-    /// regardless of how it was reached: the controller settles the migration
-    /// as `Succeeded` and skips it until the TTL recheck. In particular, a
-    /// migration whose effect landed *after* a failed attempt (e.g. a
-    /// transaction submitted by [`execute`](Self::execute) that mined after
-    /// that run gave up on it) converges to `Succeeded` this way.
+    /// For a migration that has already been attempted (`InProgress` or
+    /// `FailedRetryable`), returning `Ok(false)` means the desired end state
+    /// now holds, regardless of how it was reached: the controller settles the
+    /// migration as `Succeeded` and skips it until the TTL recheck. In
+    /// particular, a migration whose effect landed *after* a failed attempt
+    /// (e.g. a transaction submitted by [`execute`](Self::execute) that mined
+    /// after that run gave up on it) converges to `Succeeded` this way.
+    ///
+    /// For a migration that has never been attempted (`NotStarted`),
+    /// `Ok(false)` may also mean "not applicable *yet*" (e.g. a feature flag
+    /// is off, or the migration's source data is absent), so the controller
+    /// leaves the record untouched and re-checks on the next run.
     ///
     /// # Returns
     /// - `Ok(true)` if the migration should run
-    /// - `Ok(false)` if the desired end state already holds (recorded as
-    ///   `Succeeded` and skipped until the TTL recheck)
+    /// - `Ok(false)` if the migration should not run now (settled as
+    ///   `Succeeded` if previously attempted; otherwise re-checked next run)
     /// - `Err(_)` if unable to determine (migration is skipped for this run
     ///   with the error logged; its stored record is not modified)
     async fn is_applicable(&self) -> Result<bool, MigrationError>;

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -47,16 +47,26 @@ pub trait MigrationProcessor: Send + Sync {
     /// The version should be included in the ID itself (e.g., ".v1", ".v2")
     fn migration_id(&self) -> String;
 
-    /// Check if this migration is applicable
+    /// Check whether this migration still needs to run
     ///
-    /// This method should check **actual state** (e.g., does v4 credential exist?)
-    /// to determine if the migration needs to run. This ensures the system is
+    /// This method should check **actual state** (e.g., does the v4 credential
+    /// exist? Is the on-chain allowance in place?) and return `true` only if
+    /// the desired end state does **not** yet hold. This ensures the system is
     /// truly idempotent and handles edge cases gracefully.
+    ///
+    /// Returning `Ok(false)` means the desired end state already holds,
+    /// regardless of how it was reached: the controller settles the migration
+    /// as `Succeeded` and skips it until the TTL recheck. In particular, a
+    /// migration whose effect landed *after* a failed attempt (e.g. a
+    /// transaction submitted by [`execute`](Self::execute) that mined after
+    /// that run gave up on it) converges to `Succeeded` this way.
     ///
     /// # Returns
     /// - `Ok(true)` if the migration should run
-    /// - `Ok(false)` if the migration should be skipped
-    /// - `Err(_)` if unable to determine (migration will be skipped with error logged)
+    /// - `Ok(false)` if the desired end state already holds (recorded as
+    ///   `Succeeded` and skipped until the TTL recheck)
+    /// - `Err(_)` if unable to determine (migration is skipped for this run
+    ///   with the error logged; its stored record is not modified)
     async fn is_applicable(&self) -> Result<bool, MigrationError>;
 
     /// Execute the migration

--- a/bedrock/src/migration/processor.rs
+++ b/bedrock/src/migration/processor.rs
@@ -63,17 +63,14 @@ pub trait MigrationProcessor: Send + Sync {
     /// after that run gave up on it) converges to `Succeeded` this way.
     ///
     /// For a migration that has never been attempted (`NotStarted`),
-    /// `Ok(false)` may also mean "not applicable *yet*" (e.g. a feature flag
-    /// is off, or the migration's source data is absent), so the controller
-    /// leaves the record untouched and re-checks on the next run.
+    /// `Ok(false)` may also mean "not applicable *yet*" (e.g. the migration's
+    /// source data has not appeared yet), so the controller leaves the record
+    /// untouched and re-checks on the next run.
     ///
-    /// Prefer reserving `Ok(false)` for "the desired end state holds". If a
-    /// transient condition (a feature flag, source data that may appear later)
-    /// is checked here, be aware that once the migration has been attempted,
-    /// `Ok(false)` settles it as `Succeeded` and it is not re-checked until
-    /// the TTL recheck. If the migration must resume promptly when the
-    /// condition clears, gate inside [`execute`](Self::execute) and return
-    /// `Retryable` instead.
+    /// Do **not** use `Ok(false)` for transient eligibility conditions such
+    /// as feature flags — gate rollout at registration time instead, by only
+    /// registering the processor with the `MigrationController` when the
+    /// migration should run.
     ///
     /// # Returns
     /// - `Ok(true)` if the migration should run

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -67,19 +67,15 @@ impl MigrationProcessor for ExampleProcessor {
         //     return Ok(false);
         // }
 
-        // 3. Check feature flags if applicable
-        // NOTE: once a migration has been attempted, returning `Ok(false)`
-        // settles it as `Succeeded` and it is not re-checked until the TTL
-        // recheck (~30 days). Only gate on transient conditions (feature
-        // flags, data that may appear later) here if that delay is
-        // acceptable; otherwise check the condition in `execute` and return
-        // `ProcessorResult::Retryable` while it blocks the migration.
-        // if !self.config.is_migration_enabled() {
-        //     return Ok(false);
-        // }
-
-        // 4. All checks passed - migration is needed
+        // 3. All checks passed - migration is needed
         // Ok(true)
+
+        // NOTE: do NOT gate on feature flags or other transient conditions
+        // here — `Ok(false)` means "the desired end state holds" and, once
+        // the migration has been attempted, settles it as `Succeeded` until
+        // the TTL recheck. Gate rollout at registration time instead: only
+        // register the processor with the `MigrationController`
+        // (`additional_processors`) when the flag is enabled.
 
         // Placeholder: skip this example processor
         Ok(false)

--- a/bedrock/src/migration/processors/example_processor.rs
+++ b/bedrock/src/migration/processors/example_processor.rs
@@ -68,6 +68,12 @@ impl MigrationProcessor for ExampleProcessor {
         // }
 
         // 3. Check feature flags if applicable
+        // NOTE: once a migration has been attempted, returning `Ok(false)`
+        // settles it as `Succeeded` and it is not re-checked until the TTL
+        // recheck (~30 days). Only gate on transient conditions (feature
+        // flags, data that may appear later) here if that delay is
+        // acceptable; otherwise check the condition in `execute` and return
+        // `ProcessorResult::Retryable` while it blocks the migration.
         // if !self.config.is_migration_enabled() {
         //     return Ok(false);
         // }


### PR DESCRIPTION
## Problem

Follow-up to the discussion in https://github.com/worldcoin/bedrock/pull/375#discussion_r3724967310.

When `is_applicable` returns `false`, the controller previously did nothing unless the record was already `Succeeded` (where it renewed `recheck_at`). This left a hole in the state machine:

1. `execute` submits a transaction, gives up waiting, returns `Retryable` → record is `FailedRetryable`
2. The transaction mines later; the desired on-chain state now holds
3. Every subsequent run: `FailedRetryable` → `is_applicable` returns `false` → skipped, **record never settles** → the on-chain applicability check (an RPC call) re-runs on every app open, forever

## Fix

When `is_applicable` returns `false` for a migration that was **already attempted** (`InProgress` / `FailedRetryable`), settle the record as `Succeeded`: set `completed_at` and `recheck_at`, clear the error fields, and persist. For attempted migrations, `false` means the desired end state now holds — regardless of how it was reached — so the migration has converged. `Succeeded` records still just renew `recheck_at` as before, and `attempts` is not incremented (settling is not an execution attempt).

Deliberately narrow semantics:

- **`NotStarted` records are not settled** — for a never-attempted migration, `false` may mean "not applicable *yet*" (e.g. the migration's source data has not appeared yet), so the record stays untouched and is re-checked on the next run, as before.
- **`is_applicable` errors never reach the settle path** — an error skips the run without modifying the stored record, so a transient RPC failure can't mark a migration `Succeeded`. Side effect: an error on a TTL-due `Succeeded` record no longer renews `recheck_at` (previously it silently deferred the recheck 30 days), so the recheck stays due and re-runs on the next app open until a check succeeds.
- **A `save_record` failure while settling counts as `failed_retryable`**, consistent with the other save sites.

**Contract clarification — no transient gating in `is_applicable`.** Within a `bool`, `is_applicable` cannot distinguish "the end state holds" from "temporarily ineligible", so `Ok(false)` is reserved for the former. Feature-flag / rollout gating belongs at **registration time**: only pass the processor to `MigrationController` (`additional_processors`) when the migration should run. The trait docs and `example_processor.rs` now say this explicitly (the template previously showed a flag check inside `is_applicable`; that example is removed). Both in-repo processors already comply — they check on-chain state only. If a future processor genuinely needs "temporarily ineligible" as a distinct outcome, that's a richer (FFI-breaking) `is_applicable` return type, deliberately out of scope here.

No trait signature changes, no processor changes — those come in a follow-up PR that makes `permit2_approval_processor` fire-and-forget (dropping the polling loop) and moves `safe_4337_module_processor`'s on-chain check into `is_applicable`, both of which depend on this controller behavior.

## Tests

- `test_failed_retryable_not_applicable_settles_as_succeeded` — the regression from the thread: stuck `FailedRetryable` + end state holds → record converges to `Succeeded` with errors cleared
- `test_in_progress_not_applicable_settles_as_succeeded` — same convergence for a crashed-mid-migration `InProgress` record
- `test_settled_migration_skips_applicability_check_on_next_run` — after settling, subsequent runs skip without re-running `is_applicable` (until the TTL recheck)
- `test_applicability_error_skips_without_modifying_record` — an `is_applicable` error leaves the stored record untouched
- `test_not_started_not_applicable_skips_without_settling` — never-attempted migrations persist nothing and are re-checked next run
- `test_settle_save_failure_counts_as_failed_retryable` — a storage failure while settling is reported as `failed_retryable`, not a successful skip
- All existing controller tests pass unchanged (notably the TTL recheck tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)