### PR TITLE
fix: prevent Android ARM32 UniFFI checksum crashes

### DIFF
--- a/.github/workflows/release-swift-kotlin.yml
+++ b/.github/workflows/release-swift-kotlin.yml
@@ -203,7 +203,14 @@ jobs:
 
       - name: Generate bindings
         working-directory: kotlin
-        run: cargo run -p uniffi-bindgen generate ./bedrock-android/src/main/jniLibs/arm64-v8a/libbedrock.so --library --language kotlin --no-format --out-dir bedrock-android/src/main/java
+        run: |
+          cargo run -p uniffi-bindgen generate \
+            ./bedrock-android/src/main/jniLibs/arm64-v8a/libbedrock.so \
+            --config ../uniffi.toml \
+            --library \
+            --language kotlin \
+            --no-format \
+            --out-dir bedrock-android/src/main/java
 
       - name: Set up Gradle
         working-directory: kotlin

--- a/uniffi.toml
+++ b/uniffi.toml
@@ -1,1 +1,6 @@
+[bindings.kotlin]
+# Work around UniFFI's u16 return-value signedness bug on Android ARM32.
+# Remove after upgrading to a UniFFI release containing mozilla/uniffi-rs#2897 and #2935.
+omit_checksums = true
+
 [bindings.swift]

--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -118,6 +118,8 @@ fn generate_bindings(root: &Path, library: &Path, out_dir: &Path) -> Result<()> 
         .current_dir(root)
         .args(["run", "-p", "uniffi-bindgen", "generate"])
         .arg(library)
+        .arg("--config")
+        .arg(root.join("uniffi.toml"))
         .args([
             "--library",
             "--language",


### PR DESCRIPTION
## Summary

- disable generated Kotlin API checksum validation through the shared UniFFI config
- make both the xtask and release Kotlin generators explicitly consume that config
- retain UniFFI contract-version validation

## Root cause

UniFFI 0.31 exposes API checksums as `u16`. On Android ARM32, the Kotlin/JNA direct return carrier can interpret values above `Short.MAX_VALUE` as signed while Rust returns the original unsigned value. The generated startup parity check then reports a checksum mismatch even though the Rust and Kotlin APIs match, crashing binding initialization.

This is the same production-blocking failure mode previously mitigated in [Oxide #975](https://github.com/worldcoin/oxide/pull/975). The upstream fixes are [mozilla/uniffi-rs#2897](https://github.com/mozilla/uniffi-rs/pull/2897) and [mozilla/uniffi-rs#2935](https://github.com/mozilla/uniffi-rs/pull/2935); the workaround can be removed after Bedrock upgrades to a UniFFI release containing both.

This changes only generated Kotlin API checksum checks. It does not change Bedrock APIs, cryptographic behavior, or UniFFI contract-version validation.

## Validation

Bedrock:

- `cargo fmt -- --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo build`
- `taplo fmt --check`
- `cargo deny check bans licenses sources`
- `cargo deny check advisories`
- `cargo test -p xtask` — 9/9 passed
- `cargo xtask kotlin test` — 42/42 passed
- release-style binding generation — API checksum calls absent; both contract-version checks retained
- workflow YAML parse and `git diff --check`

World App:

- `shasum -a 256 -c scripts/properties.sha256`
- `./gradlew formatkotlin lintkotlin detekt`
- `./gradlew ":domain:test" "testDebugUnitTest" "testDevDebugUnitTest"`
- built the dev app and test APK against the locally published patched AAR
- physical Pixel 3 forced to `armeabi-v7a`: Bedrock user-agent and personal-sign interop tests passed 2/2; normal World App cold start remained alive with Bedrock initialized
- Android 11 ARM64 emulator: the same interop tests passed 2/2
- packaged all four Android ABIs and verified the native libraries retain 16 KiB ELF load alignment

Note: the available physical ARM32 device runs Android 12 and did not reproduce the original crash with the unpatched artifact. The red-case closure is therefore established structurally (the faulty generated checksum path is absent), corroborated by the existing Oxide fix, and covered by patched ARM32 end-to-end execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes one generated-binding safety check (API checksums) on the Android Kotlin path; contract-version validation remains, and Bedrock/crypto behavior is unchanged.
> 
> **Overview**
> **Disables generated Kotlin API checksum validation** via shared `uniffi.toml` (`omit_checksums = true`) to avoid false startup failures on Android ARM32, where UniFFI `u16` checksums can be misread as signed through JNA while Rust returns unsigned values.
> 
> Both Kotlin binding generators now pass **`--config` pointing at `uniffi.toml`**: the release workflow’s `uniffi-bindgen` step and `xtask`’s `generate_bindings` in `kotlin.rs`. **UniFFI contract-version checks are unchanged**; only the API checksum parity path is omitted until a UniFFI release includes the upstream fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2898e63a45d5c7eb1c6a728acbff3513ad39f458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->