### PR TITLE
fix: enforces response max size for custom RPC/bundlers

### DIFF
--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -75,12 +75,19 @@ fn validate_rpc_url(url: &str) -> Result<(), RpcError> {
 
 // ── Low-level HTTP ────────────────────────────────────────────────────────────
 
+/// Ceiling on a bundler response body. A JSON-RPC reply is a few hundred bytes, and
+/// the endpoint is caller-supplied, so reading one unbounded lets it exhaust memory.
+const MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+/// Longest excerpt of endpoint-controlled text echoed back in an error.
+const MAX_ERROR_EXCERPT_CHARS: usize = 512;
+
 /// Makes a JSON-RPC POST request to an arbitrary URL using `reqwest`.
 ///
 /// The client is configured with a 15 s timeout to prevent indefinitely hanging requests.
 async fn post_json_rpc_to_url(url: &str, body: Vec<u8>) -> Result<Vec<u8>, RpcError> {
     let client = REQWEST_CLIENT.get_or_try_init(build_bundler_client)?;
-    let response = client
+    let mut response = client
         .post(url)
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .body(body)
@@ -90,19 +97,63 @@ async fn post_json_rpc_to_url(url: &str, body: Vec<u8>) -> Result<Vec<u8>, RpcEr
         .map_err(|e| RpcError::HttpError(e.without_url().to_string()))?;
 
     let status = response.status();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| RpcError::HttpError(e.without_url().to_string()))?;
+    let bytes = read_capped(&mut response).await?;
 
     if !status.is_success() {
         return Err(RpcError::HttpError(format!(
             "HTTP {status}: {}",
-            String::from_utf8_lossy(&bytes)
+            error_excerpt(&String::from_utf8_lossy(&bytes))
         )));
     }
 
-    Ok(bytes.to_vec())
+    Ok(bytes)
+}
+
+/// Reads a response body a frame at a time, giving up past [`MAX_RESPONSE_BYTES`].
+/// Frames arrive already decompressed, so the cap bounds the inflated size too.
+async fn read_capped(response: &mut reqwest::Response) -> Result<Vec<u8>, RpcError> {
+    let status = response.status();
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| {
+        RpcError::HttpError(format!("HTTP {status}: {}", e.without_url()))
+    })? {
+        if body.len() + chunk.len() > MAX_RESPONSE_BYTES {
+            crate::warn!(
+                bundler_host = response.url().host_str().unwrap_or("<unknown>"),
+                body_bytes = body.len() + chunk.len(),
+                http_status = status.as_u16(),
+                "bundler.response_exceeds_cap"
+            );
+            let error_message = format!(
+                "HTTP {status}: response exceeds {MAX_RESPONSE_BYTES} bytes: {}",
+                error_excerpt(&String::from_utf8_lossy(&body))
+            );
+            // Size must not reclassify a non-2xx away from `HttpError`.
+            return Err(if status.is_success() {
+                RpcError::InvalidResponse { error_message }
+            } else {
+                RpcError::HttpError(error_message)
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Trims endpoint-controlled text to a length worth putting in an error message,
+/// dropping the characters that would let it forge or reverse a rendered line.
+fn error_excerpt(text: &str) -> String {
+    // `is_control` misses the separators, bidi overrides and invisible joiners.
+    let mut kept = text.chars().filter(|c| {
+        !c.is_control()
+            && !matches!(*c, '\u{200e}'..='\u{200f}'
+                | '\u{2028}'..='\u{202e}' | '\u{2060}'..='\u{2069}')
+    });
+    let mut excerpt: String = kept.by_ref().take(MAX_ERROR_EXCERPT_CHARS).collect();
+    if kept.next().is_some() {
+        excerpt.push_str(" (truncated)");
+    }
+    excerpt
 }
 
 // ── Parsing helper ────────────────────────────────────────────────────────────
@@ -117,7 +168,7 @@ fn parse_json_rpc_response(response_bytes: &[u8]) -> Result<Value, RpcError> {
             serde_json::from_value(error.clone()).map_err(|_| RpcError::JsonError)?;
         return Err(RpcError::RpcResponseError {
             code: ep.code,
-            error_message: ep.message,
+            error_message: error_excerpt(&ep.message),
         });
     }
 
@@ -213,7 +264,8 @@ pub async fn verify_bundler_rpc_entrypoint(rpc_url: String) -> Result<(), RpcErr
     } else {
         Err(RpcError::InvalidResponse {
             error_message: format!(
-                "Bundler does not support the expected EntryPoint ({expected:?}); supported: {entrypoints:?}"
+                "Bundler does not support the expected EntryPoint ({expected:?}); supported: {}",
+                error_excerpt(&format!("{entrypoints:?}"))
             ),
         })
     }
@@ -296,6 +348,17 @@ mod tests {
     #[tokio::test]
     async fn build_bundler_client_succeeds() {
         build_bundler_client().expect("bundler client should build");
+    }
+
+    #[test]
+    fn test_error_excerpt_truncates_and_strips_line_breaking_characters() {
+        assert_eq!(error_excerpt("gas — ‘low’"), "gas — ‘low’");
+        assert_eq!(error_excerpt("a\nb\tc\r\0d\u{2028}e\u{202e}f"), "abcdef");
+
+        // Must count characters: a byte slice would panic mid-character.
+        let cut = "🚀".repeat(MAX_ERROR_EXCERPT_CHARS);
+        let excerpt = error_excerpt(&"🚀".repeat(MAX_ERROR_EXCERPT_CHARS + 1));
+        assert_eq!(excerpt, format!("{cut} (truncated)"));
     }
 
     #[test]

--- a/bedrock/tests/test_smart_account_bundler_sponsored.rs
+++ b/bedrock/tests/test_smart_account_bundler_sponsored.rs
@@ -1,3 +1,4 @@
+use std::io::{Read, Write};
 use std::sync::Arc;
 
 mod common;
@@ -7,6 +8,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use common::{deploy_safe, set_erc20_balance_for_safe, setup_anvil, IERC20};
+use flate2::{write::GzEncoder, Compression};
 
 use bedrock::{
     primitives::http_client::set_http_client,
@@ -24,33 +26,58 @@ use bedrock::smart_account::{
 
 // ── Helpers for error-handling integration tests ──────────────────────────────
 
-/// Starts a loopback HTTP server that responds to every request with the given
-/// status code and body. Returns `http://127.0.0.1:<port>`.
-fn start_mock_http_server(status: u16, body: String) -> String {
-    use std::io::{Read, Write};
-
+/// Starts a loopback HTTP server that answers one request per connection with
+/// `respond`. Returns `http://127.0.0.1:<port>`.
+fn start_loopback_server<F>(respond: F) -> String
+where
+    F: Fn(&mut std::net::TcpStream) + Send + 'static,
+{
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let url = format!("http://{}", listener.local_addr().unwrap());
 
     std::thread::spawn(move || {
         for stream in listener.incoming() {
-            let body = body.clone();
             let Ok(mut stream) = stream else { break };
-            std::thread::spawn(move || {
-                let mut buf = [0u8; 8192];
-                let _ = stream.read(&mut buf);
-                let response = format!(
-                    "HTTP/1.1 {status} -\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len()
-                );
-                if let Err(e) = stream.write_all(response.as_bytes()) {
-                    eprintln!("mock HTTP server: failed to write response: {e}");
-                }
-            });
+            let mut buf = [0u8; 8192];
+            let _ = stream.read(&mut buf);
+            respond(&mut stream);
         }
     });
 
     url
+}
+
+/// Starts a loopback HTTP server that responds to every request with the given
+/// status code and body.
+fn start_mock_http_server(status: u16, body: String) -> String {
+    start_loopback_server(move |stream| {
+        let response = format!(
+            "HTTP/1.1 {status} -\r\nContent-Length: {}\r\n\
+             Connection: close\r\n\r\n{body}",
+            body.len()
+        );
+        if let Err(e) = stream.write_all(response.as_bytes()) {
+            eprintln!("mock HTTP server: failed to write response: {e}");
+        }
+    })
+}
+
+/// Starts a loopback HTTP server whose kilobyte-sized gzip body inflates to a
+/// megabyte, so the cap has to count decompressed bytes to catch it.
+fn start_gzip_bomb_http_server() -> String {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(&vec![b'a'; 1024 * 1024]).unwrap();
+    let body = encoder.finish().unwrap();
+
+    start_loopback_server(move |stream| {
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\n\
+             Connection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream.write_all(header.as_bytes());
+        let _ = stream.write_all(&body);
+    })
 }
 
 /// A minimal `UnparsedUserOperation` whose fields are valid hex strings.
@@ -370,7 +397,9 @@ async fn test_verify_bundler_rpc_entrypoint_success() {
         serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "result": [entrypoint]
+            "result": [entrypoint],
+            // Pushes the body past a single read frame, covering reassembly.
+            "padding": "0".repeat(16 * 1024),
         })
         .to_string(),
     );
@@ -400,6 +429,37 @@ async fn test_verify_bundler_rpc_entrypoint_missing() {
         matches!(err, RpcError::InvalidResponse { .. }),
         "expected InvalidResponse; got {err:?}"
     );
+}
+
+#[tokio::test]
+async fn test_verify_bundler_rpc_entrypoint_rejects_over_cap_bodies() {
+    let err = verify_bundler_rpc_entrypoint(start_gzip_bomb_http_server())
+        .await
+        .expect_err("a body inflating past the cap must be rejected, not buffered");
+    let RpcError::InvalidResponse { error_message } = &err else {
+        panic!("expected InvalidResponse from the body cap; got {err:?}")
+    };
+    assert!(error_message.contains("exceeds"), "got {error_message}");
+
+    // Size must not reclassify a non-2xx, and the status has to reach the message.
+    let url = start_mock_http_server(502, "x".repeat(512 * 1024));
+    let err = verify_bundler_rpc_entrypoint(url)
+        .await
+        .expect_err("a 502 with an over-cap body must fail");
+    let RpcError::HttpError(message) = &err else {
+        panic!("expected HttpError for a non-2xx status; got {err:?}")
+    };
+    assert!(
+        message.contains("502") && message.contains("exceeds"),
+        "expected the status and the body cap; got {message}"
+    );
+
+    // A body that stops early must name the upstream status too.
+    let url = start_loopback_server(|s| {
+        let _ = s.write_all(b"HTTP/1.1 502 -\r\nContent-Length: 1000\r\n\r\npartial");
+    });
+    let err = verify_bundler_rpc_entrypoint(url).await.unwrap_err();
+    assert!(err.to_string().contains("502"), "status lost: {err}");
 }
 
 /// Live integration test that verifies a real bundler RPC supports the v0.7 EntryPoint.


### PR DESCRIPTION
Small defense-in-depth. Prevents a malicious RPC from causing OOM from sending a huge body / gzip bomb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP handling for caller-supplied bundler URLs (DoS and error-surface paths). Behavior is defensive and well-tested, but mis-capping or error-type changes could affect real bundler failures.
> 
> **Overview**
> Hardens client-supplied bundler RPC calls against oversized bodies (including gzip bombs) and log/error injection.
> 
> `post_json_rpc_to_url` now streams the response and stops at **256 KiB of decompressed bytes**. Over-cap 2xx replies become `InvalidResponse`; non-2xx stay `HttpError` so status is not lost. Endpoint-controlled strings in errors are truncated to 512 characters and stripped of control/bidi characters.
> 
> Tests cover gzip bombs, oversized 502s, truncated bodies, multi-chunk reads, and excerpt sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8eabe807c986a71b21666a4d4af800fe77d5f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->