### PR TITLE
fix: treat empty retrieve_metadata manifest_hash as no remote backup

### DIFF
--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -338,13 +338,20 @@ impl ManifestManager {
 
     /// Gated manifest read that ensures local is not stale vs remote.
     ///
+    /// When the account has no remote backup, the local manifest is authoritative:
+    /// the next successful sync creates the backup from it.
+    ///
     /// # Errors
     /// Returns an error if the remote hash does not match local or if network/IO errors occur.
     pub async fn load_manifest_gated(
         &self,
     ) -> Result<(V0BackupManifest, [u8; 32]), BackupError> {
-        let remote_hash = BackupServiceClient::get_remote_manifest_hash().await?;
         let (manifest, local_hash) = self.read_manifest()?;
+        let Some(remote_hash) = BackupServiceClient::get_remote_manifest_hash().await?
+        else {
+            let BackupManifest::V0(manifest) = manifest;
+            return Ok((manifest, local_hash));
+        };
         if remote_hash != local_hash {
             return Err(BackupError::RemoteAheadStaleError);
         }

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -338,8 +338,9 @@ impl ManifestManager {
 
     /// Gated manifest read that ensures local is not stale vs remote.
     ///
-    /// When the account has no remote backup, the local manifest is authoritative:
-    /// the next successful sync creates the backup from it.
+    /// When the account has no remote backup, the local manifest is authoritative for
+    /// contents, but the returned hash is the default (empty) manifest hash: with no
+    /// remote head, that is the parent the next sync must declare.
     ///
     /// # Errors
     /// Returns an error if the remote hash does not match local or if network/IO errors occur.
@@ -350,7 +351,7 @@ impl ManifestManager {
         let Some(remote_hash) = BackupServiceClient::get_remote_manifest_hash().await?
         else {
             let BackupManifest::V0(manifest) = manifest;
-            return Ok((manifest, local_hash));
+            return Ok((manifest, BackupManifest::default().to_hash()?));
         };
         if remote_hash != local_hash {
             return Err(BackupError::RemoteAheadStaleError);

--- a/bedrock/src/backup/service_client.rs
+++ b/bedrock/src/backup/service_client.rs
@@ -37,7 +37,8 @@ pub trait BackupServiceApi: Send + Sync {
 /// Only the required attributes are returned to Bedrock (avoids additional memory allocations)
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct RetrieveMetadataResponsePayload {
-    /// The hex-encoded manifest hash.
+    /// The hex-encoded manifest hash, or an empty string when the account has
+    /// no backup yet (the server's `backup_not_found` case).
     pub manifest_hash: String,
     /// Encryption keys present
     pub encryption_keys: Option<Vec<BackupReportEncryptionKeyKind>>,
@@ -103,7 +104,11 @@ impl BackupServiceClient {
     }
 
     /// See `BackupServiceApi::retrieve_metadata`.
-    pub async fn get_remote_manifest_hash() -> Result<[u8; 32], BackupError> {
+    ///
+    /// Returns `Ok(None)` when the account has no remote backup (the server
+    /// responds with an empty `manifest_hash`), versus a present backup whose
+    /// hash must be validated against local state.
+    pub async fn get_remote_manifest_hash() -> Result<Option<[u8; 32]>, BackupError> {
         let api = get_api()?;
         let response = api.retrieve_metadata().await?;
 
@@ -133,6 +138,9 @@ impl BackupServiceClient {
             }
         }
         let hash = response.manifest_hash.trim_start_matches("0x");
+        if hash.is_empty() {
+            return Ok(None);
+        }
         let hash = hex::decode(hash)
             .map_err(|_| BackupError::Generic {
                 error_message:
@@ -148,6 +156,6 @@ impl BackupServiceClient {
                 error_message:
                     format!("[BackupServiceClient] invalid response from retrieve_metadata, manifest_hash is not the correct length: {hash_len}"),
             })?;
-        Ok(hash)
+        Ok(Some(hash))
     }
 }

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -75,6 +75,10 @@ impl FakeBackupServiceApi {
     fn set_remote_hash(&self, hex_hash: String) {
         self.state.lock().unwrap().remote_manifest_hash_hex = Some(hex_hash);
     }
+    /// Simulates the server reporting no backup for the account (empty `manifest_hash`).
+    fn set_no_remote_backup(&self) {
+        self.state.lock().unwrap().remote_manifest_hash_hex = Some(String::new());
+    }
     fn set_sync_error_bad_status(&self, code: u64, response_body: Vec<u8>) {
         self.state.lock().unwrap().sync_error = Some(NextSyncErrorConfig {
             code,
@@ -217,6 +221,63 @@ async fn test_list_files_stale_remote() {
         .await
         .expect_err("expected stale error");
     assert_eq!(err.to_string(), "Remote manifest is ahead of local; fetch and apply latest backup before updating");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_list_files_no_remote_backup() {
+    let api = init_test_globals();
+    api.reset();
+
+    let m = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
+        files: vec![V0BackupManifestEntry {
+            designator: BackupFileDesignator::OrbPkg,
+            file_path: "orb_pkg/personal_custody/pcp.bin".to_string(),
+            checksum_hex: hex::encode(blake3::hash(b"abc").as_bytes()),
+        }],
+    });
+    write_manifest_with_prefix(&m, "backup_test_list_no_remote");
+    api.set_no_remote_backup();
+
+    let mgr = ManifestManager::new_with_prefix("backup_test_list_no_remote");
+    let list = mgr.list_files(BackupFileDesignator::OrbPkg).await.unwrap();
+    assert_eq!(list, vec!["orb_pkg/personal_custody/pcp.bin".to_string()]);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_store_file_no_remote_backup_creates_backup() {
+    let api = init_test_globals();
+    api.reset();
+
+    // Local manifest exists but the account has no remote backup yet.
+    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
+        files: vec![],
+    });
+    write_manifest_with_prefix(&m0, "backup_test_store_no_remote");
+    api.set_no_remote_backup();
+
+    write_global_file("pcp/source.bin", b"hello-bytes");
+    let backup_sk = SecretKey::generate(&mut rand::thread_rng());
+    let backup_pk_hex = hex::encode(backup_sk.public_key().as_bytes());
+
+    let mgr = ManifestManager::new_with_prefix("backup_test_store_no_remote");
+    mgr.store_file(
+        BackupFileDesignator::OrbPkg,
+        "pcp/source.bin".to_string(),
+        &RootKey::new_random().danger_to_json().unwrap(),
+        backup_pk_hex,
+    )
+    .await
+    .unwrap();
+
+    // The first sync uses the default (empty) manifest hash as the current state.
+    let last = api.state.lock().unwrap().last_sync.clone().unwrap();
+    assert_eq!(
+        last.current_manifest_hash,
+        BackupManifest::default_hash_hex()
+    );
+    assert_ne!(last.new_manifest_hash, last.current_manifest_hash);
 }
 
 #[tokio::test]

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -282,6 +282,51 @@ async fn test_store_file_no_remote_backup_creates_backup() {
 
 #[tokio::test]
 #[serial]
+async fn test_store_file_no_remote_backup_with_nonempty_local_manifest() {
+    let api = init_test_globals();
+    api.reset();
+
+    // Local manifest already has an entry, but the account has no remote backup
+    // (e.g. local writes raced ahead of the first successful sync).
+    write_global_file("docs/existing.bin", b"EXISTING");
+    let m0 = BackupManifest::V0(crate::backup::backup_format::v0::V0BackupManifest {
+        files: vec![V0BackupManifestEntry {
+            designator: BackupFileDesignator::DocumentPkg,
+            file_path: "docs/existing.bin".to_string(),
+            checksum_hex: hex::encode(blake3::hash(b"EXISTING").as_bytes()),
+        }],
+    });
+    write_manifest_with_prefix(&m0, "backup_test_store_no_remote_nonempty");
+    api.set_no_remote_backup();
+
+    write_global_file("pcp/source.bin", b"hello-bytes");
+    let backup_sk = SecretKey::generate(&mut rand::thread_rng());
+    let backup_pk_hex = hex::encode(backup_sk.public_key().as_bytes());
+
+    let mgr = ManifestManager::new_with_prefix("backup_test_store_no_remote_nonempty");
+    mgr.store_file(
+        BackupFileDesignator::OrbPkg,
+        "pcp/source.bin".to_string(),
+        &RootKey::new_random().danger_to_json().unwrap(),
+        backup_pk_hex,
+    )
+    .await
+    .unwrap();
+
+    // With no remote head, the sync parent is the default manifest hash even
+    // though the local manifest is non-empty; the upload carries both files.
+    let last = api.state.lock().unwrap().last_sync.clone().unwrap();
+    assert_eq!(
+        last.current_manifest_hash,
+        BackupManifest::default_hash_hex()
+    );
+
+    let committed = get_manifest_from_disk("backup_test_store_no_remote_nonempty");
+    assert_eq!(committed.entries_length(), 2);
+}
+
+#[tokio::test]
+#[serial]
 async fn test_list_files_missing_manifest() {
     let api = init_test_globals();
     api.reset();


### PR DESCRIPTION
## Problem

World App Android emits ~90k warn logs/day (~65k devices, all app versions) of:

```
[BackupServiceClient] invalid response from retrieve_metadata, manifest_hash is not the correct length: 0
```

The Android backup bridge returns an empty `manifest_hash` when the account has no backup (no local sync factor, or the server's `backup_not_found` response). `get_remote_manifest_hash` treated that as a malformed 32-byte hash and errored.

Two consequences beyond log noise:

- `listFiles`/`storeFile`/`replaceAllFilesForDesignator` all go through `load_manifest_gated`, so every backup sync tick failed for non-enrolled devices.
- Devices whose local state was wiped after `backup_does_not_exist` could never sync again — `load_manifest_gated` threw before any mutation ran.

iOS is unaffected; its bridge throws on metadata failures instead of returning an empty hash.

## Change

- `BackupServiceClient::get_remote_manifest_hash` now returns `Result<Option<[u8; 32]>>`. An empty `manifest_hash` maps to `Ok(None)`; genuinely malformed hashes (non-hex, wrong length) still error.
- `ManifestManager::load_manifest_gated` treats `None` as "no remote backup": the local manifest is authoritative and the next sync creates the backup. This matches `create_sealed_backup_for_new_user`, which initializes the manifest to the empty default and uses its hash as the backup's starting `manifest_hash`.
- `RetrieveMetadataResponsePayload::manifest_hash` doc comment now records the empty-means-no-backup contract. No generated-binding signature changes; iOS needs no adaptation.

Companion (not required to merge first): worldcoin/wld-android branch `fix/backup-metadata-empty-sentinel` stops the bridge from also collapsing genuine failures (network/auth) into the empty-hash sentinel, so real errors surface as errors. Old clients keep working unchanged against this bedrock — they error exactly as they do today until the bridge fix ships.

## Testing

- Two new serial tests: `test_list_files_no_remote_backup` (local entries returned) and `test_store_file_no_remote_backup_creates_backup` (sync fires with `default_hash_hex()` as `current_manifest_hash`).
- `cargo test -p bedrock --lib backup::` — 58/58 pass.
- `cargo clippy -p bedrock --all-targets` and `cargo fmt --check` clean. (Six `erc4626` tests fail on this machine because they spawn a local anvil node; they fail identically on an unmodified checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup staleness gating and the parent hash used on first remote create. Wrong handling could skip a real remote head or upload against the empty parent incorrectly, though malformed hashes still fail.
> 
> **Overview**
> Stops treating an empty `retrieve_metadata` `manifest_hash` as a malformed hash. Android uses that empty string for accounts with no backup (`backup_not_found`), which previously failed every gated list/store/replace and blocked first-time sync.
> 
> `get_remote_manifest_hash` now returns `Ok(None)` for an empty hash (still errors on non-hex or wrong length). `load_manifest_gated` then trusts the local manifest for contents but uses the **default empty-manifest hash** as the next sync parent, matching new-user backup creation.
> 
> Tests cover listing with no remote, first store using `default_hash_hex()` as `current_manifest_hash`, and a non-empty local racing ahead of the first remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162a093cba4abcee22d49df0409480f3ab53e29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->