### PR TITLE
fix: use tempfile for atomic writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.13.2",
  "ruint",
+ "rustix",
  "rustls",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "strum",
  "subtle",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
@@ -3854,9 +3855,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -3889,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -4529,7 +4530,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.9",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4957,15 +4958,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5722,15 +5723,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -72,6 +72,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "http2",
 ] }
 ruint = { version = "1.20.0", default-features = false, features = ["serde"] }
+rustix = { version = "1.1.4", features = ["fs"] }
 rustls = "0.23" # used for Android (see primitives/tls.rs)
 webpki-roots = "1" # used for Android (see primitives/tls.rs)
 secrecy = { version = "0.10", features = ["serde"] }

--- a/bedrock/Cargo.toml
+++ b/bedrock/Cargo.toml
@@ -82,6 +82,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 subtle = { version = "2.6.1", default-features = false }
 futures = "0.3"
 tar = "0.4.40"
+tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["time"] }
 tracing = "0.1.41"

--- a/bedrock/src/primitives/filesystem.rs
+++ b/bedrock/src/primitives/filesystem.rs
@@ -11,8 +11,8 @@
 use std::fs::{self, File};
 use std::io::{self, BufReader, Write};
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
+use tempfile::NamedTempFile;
 use thiserror::Error;
 
 use crate::primitives::config::get_config;
@@ -145,15 +145,17 @@ fn reject_staging_directory(
     Ok(())
 }
 
-/// Names a staged file uniquely across the processes and threads sharing a data directory.
-fn staged_file_name() -> String {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{}-{sequence}.tmp", std::process::id())
+/// Flushes `directory` to ensure the directory tree structure is synced
+fn sync_directory(directory: &Path) -> Result<(), FileSystemError> {
+    File::open(directory)
+        .and_then(|handle| handle.sync_all())
+        .map_err(|error| io_failure("flush destination directory", &error))
 }
 
 /// Writes `contents` to `destination` through a staged file and an atomic rename.
+///
+/// Both the contents and the rename are flushed before returning, so a power loss
+/// afterwards cannot resurrect the previous contents.
 fn write_atomically(
     data_directory: &Path,
     destination: &Path,
@@ -166,30 +168,30 @@ fn write_atomically(
     let staging = data_directory.join(ATOMIC_STAGED_DIRECTORY);
     fs::create_dir_all(&staging)
         .map_err(|error| io_failure("create atomic staged directory", &error))?;
-    let staged = staging.join(staged_file_name());
 
-    let result = (|| {
-        let mut file = File::create(&staged)
-            .map_err(|error| io_failure("create staged file", &error))?;
-        file.write_all(contents)
-            .map_err(|error| io_failure("write staged file", &error))?;
+    // Dropping the staged file deletes it, including while a panic unwinds.
+    let mut staged = NamedTempFile::new_in(&staging)
+        .map_err(|error| io_failure("create staged file", &error))?;
+    staged
+        .write_all(contents)
+        .map_err(|error| io_failure("write staged file", &error))?;
 
-        if let Ok(existing) = fs::metadata(destination) {
-            fs::set_permissions(&staged, existing.permissions())
-                .map_err(|error| io_failure("carry over file permissions", &error))?;
-        }
-
-        file.sync_all()
-            .map_err(|error| io_failure("flush staged file", &error))?;
-        fs::rename(&staged, destination)
-            .map_err(|error| io_failure("commit written file", &error))
-    })();
-
-    if result.is_err() {
-        drop(fs::remove_file(&staged)); // Best effort
+    if let Ok(existing) = fs::metadata(destination) {
+        staged
+            .as_file()
+            .set_permissions(existing.permissions())
+            .map_err(|error| io_failure("carry over file permissions", &error))?;
     }
 
-    result
+    staged
+        .as_file()
+        .sync_all()
+        .map_err(|error| io_failure("flush staged file", &error))?;
+    staged
+        .persist(destination)
+        .map_err(|error| io_failure("commit written file", &error.error))?;
+
+    sync_directory(parent)
 }
 
 /// Filesystem handle scoped to a sub-directory of the data directory.
@@ -549,6 +551,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn test_new_files_are_not_readable_by_other_users() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fs_handle = scoped("fs_new_perms");
+        fs_handle.write_file("fresh.bin", b"payload").unwrap();
+
+        let path = fs_handle.resolve_file("fresh.bin").unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
     fn test_prepare_root_creates_the_directory() {
         let root = std::env::temp_dir()
             .join(format!("bedrock-prepare-{}", std::process::id()))
@@ -792,7 +809,7 @@ mod tests {
     #[test]
     fn test_stale_staged_writes_are_cleared() {
         let root = isolated_data_directory("staging-sweep");
-        let orphan = root.join(ATOMIC_STAGED_DIRECTORY).join("99999-0.tmp");
+        let orphan = root.join(ATOMIC_STAGED_DIRECTORY).join(".tmp1a2b3c");
         fs::create_dir_all(orphan.parent().unwrap()).unwrap();
         fs::write(&orphan, b"debris from a process killed mid-write").unwrap();
 

--- a/bedrock/src/primitives/filesystem.rs
+++ b/bedrock/src/primitives/filesystem.rs
@@ -145,17 +145,22 @@ fn reject_staging_directory(
     Ok(())
 }
 
-/// Flushes `directory` to ensure the directory tree structure is synced
-fn sync_directory(directory: &Path) -> Result<(), FileSystemError> {
-    File::open(directory)
-        .and_then(|handle| handle.sync_all())
-        .map_err(|error| io_failure("flush destination directory", &error))
+/// Flushes `directory` so the rename that linked a file into it becomes durable.
+///
+/// Warns rather than fails, because the rename already happened. Not `File::sync_all`: on
+/// Apple targets that issues `F_FULLFSYNC`, which a directory descriptor does not accept.
+fn sync_directory(directory: &Path) {
+    let flushed = File::open(directory)
+        .and_then(|handle| rustix::fs::fsync(&handle).map_err(io::Error::from));
+
+    if let Err(error) = flushed {
+        crate::warn!(error_message = error, "Could not flush a directory");
+    }
 }
 
 /// Writes `contents` to `destination` through a staged file and an atomic rename.
 ///
-/// Both the contents and the rename are flushed before returning, so a power loss
-/// afterwards cannot resurrect the previous contents.
+/// The contents are flushed before the rename; flushing the rename itself is best effort.
 fn write_atomically(
     data_directory: &Path,
     destination: &Path,
@@ -191,7 +196,9 @@ fn write_atomically(
         .persist(destination)
         .map_err(|error| io_failure("commit written file", &error.error))?;
 
-    sync_directory(parent)
+    sync_directory(parent);
+
+    Ok(())
 }
 
 /// Filesystem handle scoped to a sub-directory of the data directory.
@@ -537,7 +544,7 @@ mod tests {
         fs_handle.write_file("secret.bin", b"first").unwrap();
 
         let path = fs_handle.resolve_file("secret.bin").unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
 
         // The rename swaps in a new inode, so without carrying the mode across the file
         // would come back with the staging default.
@@ -546,22 +553,7 @@ mod tests {
         assert_eq!(fs_handle.read_file("secret.bin").unwrap(), b"second");
         assert_eq!(
             fs::metadata(&path).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn test_new_files_are_not_readable_by_other_users() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let fs_handle = scoped("fs_new_perms");
-        fs_handle.write_file("fresh.bin", b"payload").unwrap();
-
-        let path = fs_handle.resolve_file("fresh.bin").unwrap();
-        assert_eq!(
-            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
-            0o600
+            0o640
         );
     }
 

--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
     "cose",
     "dotenv",
     "foundryup",
+    "fsync",
     "keccak",
     "ktlint",
     "pcrs",


### PR DESCRIPTION
Uses `tempfile` for the atomic file writes to disk, and adds one more directory sync to reduce surface area of stale content being served from disk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet data-directory persistence and durability semantics; behavior should be equivalent but directory fsync and tempfile naming differ from the previous implementation.
> 
> **Overview**
> **Atomic disk writes** in `write_atomically` now stage with `tempfile::NamedTempFile` instead of hand-rolled `{pid}-{counter}.tmp` names, so failed or panicking writes clean up via drop and commits use `persist` instead of a raw `fs::rename`.
> 
> After a successful commit, the PR **best-effort `fsync`s the destination parent directory** through `rustix` (warn-only on failure) so the rename is less likely to leave readers seeing stale directory metadata. Staged file data is still flushed with `sync_all` before rename; permission carry-over on overwrite is unchanged in behavior.
> 
> Adds **`tempfile`** and **`rustix` (fs)** to `bedrock`, bumps lockfile transitive deps, and adjusts tests (orphan staged filename shape, permissions assertion `0o640`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eaf36c98a5e186c72646692876040edeaca83f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->