### PR TITLE
[BackupManager] export `post_delete_backup`

### DIFF
--- a/bedrock/src/backup/mod.rs
+++ b/bedrock/src/backup/mod.rs
@@ -592,6 +592,29 @@ impl BackupManager {
     ) -> Result<BackupMetadata, BackupOperationError> {
         self.service()?.retrieve_metadata(sync_factor).await
     }
+
+    /// Clears the local state after a backup deletion: the manifest file
+    /// and the backup base report
+    ///
+    /// # Errors
+    /// - Returns an error if the post-processing fails.
+    fn post_delete_backup() -> Result<(), BackupError> {
+        crate::info!("Cleaning up backup system... Deleting manifest file after backup is disabled/deleted.");
+
+        let manifest = match ManifestManager::new().danger_delete_manifest() {
+            Ok(())
+            | Err(BackupError::FileSystem(FileSystemError::FileDoesNotExist)) => Ok(()),
+            Err(error) => Err(error),
+        };
+
+        let report = ClientEventsReporter::new().delete_base_report();
+        if let Err(error) = &report {
+            crate::warn!("[ClientEvents] failed to delete base report: {error:?}");
+        }
+
+        manifest?;
+        report.map_err(Into::into)
+    }
 }
 
 /// A **Sync Factor** signer, has only read permissions and specific delete permissions.
@@ -617,29 +640,6 @@ pub struct ManifestDebug {
 
 /// Internal helpers (not exported)
 impl BackupManager {
-    /// Clears the local state after a backup deletion: the manifest file
-    /// and the backup base report
-    ///
-    /// # Errors
-    /// - Returns an error if the post-processing fails.
-    fn post_delete_backup() -> Result<(), BackupError> {
-        crate::info!("Cleaning up backup system... Deleting manifest file after backup is disabled/deleted.");
-
-        let manifest = match ManifestManager::new().danger_delete_manifest() {
-            Ok(())
-            | Err(BackupError::FileSystem(FileSystemError::FileDoesNotExist)) => Ok(()),
-            Err(error) => Err(error),
-        };
-
-        let report = ClientEventsReporter::new().delete_base_report();
-        if let Err(error) = &report {
-            crate::warn!("[ClientEvents] failed to delete base report: {error:?}");
-        }
-
-        manifest?;
-        report.map_err(Into::into)
-    }
-
     fn service(&self) -> Result<&BackupServiceClient, BackupOperationError> {
         self.backup_service.get_or_try_init(|| {
             let config = get_config().ok_or_else(|| {


### PR DESCRIPTION
Android is using post_delete_backup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocation with no change to cleanup logic; limited to local manifest and client-events state after backup deletion.
> 
> **Overview**
> Moves **`post_delete_backup`** from the internal `BackupManager` impl into the **`#[bedrock_export]`** impl so native clients (notably **Android**) can invoke the same local cleanup path when a backup is disabled or deleted outside Bedrock’s `remove_factor` flow.
> 
> Behavior is unchanged: it deletes the on-disk manifest (treating a missing file as success) and removes the backup **base report**, logging a warning if report deletion fails before returning any error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3882d45f8a4347266886496504af9638179e1d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->