### PR TITLE
fix(test): await ERC-4337 transaction receipt

### DIFF
--- a/bedrock/tests/test_smart_account_erc4337_transaction_execution.rs
+++ b/bedrock/tests/test_smart_account_erc4337_transaction_execution.rs
@@ -115,11 +115,12 @@ async fn test_integration_erc4337_transaction_execution() -> anyhow::Result<()> 
     user_op.signature = sig_with_timestamps.into();
 
     // Submit through the 4337 EntryPoint
-    let _ = entry_point
+    let pending_tx = entry_point
         .handleOps(vec![PackedUserOperation::try_from(&user_op)?], owner)
         .from(owner)
         .send()
         .await?;
+    pending_tx.get_receipt().await?;
 
     // Assert the transfer has succeeded
     let after_balance = provider.get_balance(safe_address2).await?;


### PR DESCRIPTION
This test kept failing in my unrelated PR, while succeeding locally. Fixed flakiness by awaiting the receipt before checking the balance. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or security impact.
> 
> **Overview**
> Fixes a **race in the ERC-4337 smart-account integration test** by waiting for `handleOps` to be mined before checking balances.
> 
> The test now keeps the pending transaction from `send()` and calls **`get_receipt().await?`** so the native ETH transfer assertion runs after execution, not right after broadcast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ee371aed6b6becaee392a79be382ae95cdd457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->