### PR TITLE
fix: treat a missing local manifest as an empty list in list_files

### DIFF
--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -180,7 +180,10 @@ impl ManifestManager {
     ) -> Result<Vec<String>, BackupError> {
         let (manifest, _local_hash) = match self.load_manifest_gated().await {
             Err(BackupError::ManifestNotFound) => {
-                return if BackupServiceClient::get_remote_manifest_hash().await?.is_some() {
+                return if BackupServiceClient::get_remote_manifest_hash()
+                    .await?
+                    .is_some()
+                {
                     Err(BackupError::RemoteAheadStaleError)
                 } else {
                     Ok(Vec::new())

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -164,13 +164,8 @@ impl ManifestManager {
     ///
     /// The caller must supply an HTTP client and signer to perform the gate. This method does not mutate state.
     ///
-    /// A device that never wrote a manifest has no files recorded: the local `ManifestNotFound`
-    /// is reported as an empty list rather than an error — once the remote head confirms the
-    /// account has no backup — so read-only callers (such as the personal-custody backup syncs
-    /// on accounts that never created a backup) are not failed by the mere absence of a backup.
-    /// A remote backup with no local manifest (fresh install before restore, local storage loss)
-    /// keeps failing, with `RemoteAheadStaleError` so the native layer restores before trusting
-    /// the local view. Mutating methods keep surfacing `ManifestNotFound`.
+    /// A missing local manifest returns an empty list when the account has no remote backup,
+    /// and `RemoteAheadStaleError` when it has one (the device must restore first).
     ///
     /// # Errors
     /// Returns an error if the remote hash does not match local or if network/IO errors occur.

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -165,9 +165,12 @@ impl ManifestManager {
     /// The caller must supply an HTTP client and signer to perform the gate. This method does not mutate state.
     ///
     /// A device that never wrote a manifest has no files recorded: the local `ManifestNotFound`
-    /// is reported as an empty list rather than an error, so read-only callers (such as the
-    /// personal-custody backup syncs on accounts that never created a backup) are not failed by
-    /// the mere absence of a backup. Mutating methods keep surfacing `ManifestNotFound`.
+    /// is reported as an empty list rather than an error — once the remote head confirms the
+    /// account has no backup — so read-only callers (such as the personal-custody backup syncs
+    /// on accounts that never created a backup) are not failed by the mere absence of a backup.
+    /// A remote backup with no local manifest (fresh install before restore, local storage loss)
+    /// keeps failing, with `RemoteAheadStaleError` so the native layer restores before trusting
+    /// the local view. Mutating methods keep surfacing `ManifestNotFound`.
     ///
     /// # Errors
     /// Returns an error if the remote hash does not match local or if network/IO errors occur.
@@ -176,7 +179,13 @@ impl ManifestManager {
         designator: BackupFileDesignator,
     ) -> Result<Vec<String>, BackupError> {
         let (manifest, _local_hash) = match self.load_manifest_gated().await {
-            Err(BackupError::ManifestNotFound) => return Ok(Vec::new()),
+            Err(BackupError::ManifestNotFound) => {
+                return if BackupServiceClient::get_remote_manifest_hash().await?.is_some() {
+                    Err(BackupError::RemoteAheadStaleError)
+                } else {
+                    Ok(Vec::new())
+                };
+            }
             result => result?,
         };
 

--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -164,13 +164,21 @@ impl ManifestManager {
     ///
     /// The caller must supply an HTTP client and signer to perform the gate. This method does not mutate state.
     ///
+    /// A device that never wrote a manifest has no files recorded: the local `ManifestNotFound`
+    /// is reported as an empty list rather than an error, so read-only callers (such as the
+    /// personal-custody backup syncs on accounts that never created a backup) are not failed by
+    /// the mere absence of a backup. Mutating methods keep surfacing `ManifestNotFound`.
+    ///
     /// # Errors
     /// Returns an error if the remote hash does not match local or if network/IO errors occur.
     pub async fn list_files(
         &self,
         designator: BackupFileDesignator,
     ) -> Result<Vec<String>, BackupError> {
-        let (manifest, _local_hash) = self.load_manifest_gated().await?;
+        let (manifest, _local_hash) = match self.load_manifest_gated().await {
+            Err(BackupError::ManifestNotFound) => return Ok(Vec::new()),
+            result => result?,
+        };
 
         let files = manifest
             .files

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -331,17 +331,41 @@ async fn test_store_file_no_remote_backup_with_nonempty_local_manifest() {
 
 #[tokio::test]
 #[serial]
-async fn test_list_files_missing_manifest_is_empty() {
+async fn test_list_files_missing_manifest_no_remote_is_empty() {
     let api = init_test_globals();
     api.reset();
 
-    // A device that never created a backup has no local manifest at all. Listing must
-    // report "no files recorded" rather than ManifestNotFound: read-only backup syncs
-    // (e.g. the face PCP delete cleanup) run on such accounts, and the absence of a
-    // backup is not an error for them. Mutating methods keep surfacing ManifestNotFound.
+    // A device that never created a backup has no local manifest at all. Once the remote
+    // head confirms no backup exists, listing must report "no files recorded" rather than
+    // ManifestNotFound: read-only backup syncs (e.g. the face PCP delete cleanup) run on
+    // such accounts, and the absence of a backup is not an error for them. Mutating
+    // methods keep surfacing ManifestNotFound.
+    api.set_no_remote_backup();
+
     let mgr = ManifestManager::new_with_prefix("backup_test_list_missing");
     let list = mgr.list_files(BackupFileDesignator::OrbPkg).await.unwrap();
     assert!(list.is_empty());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_list_files_missing_manifest_with_remote_is_stale() {
+    let api = init_test_globals();
+    api.reset();
+
+    // A remote backup with no local manifest (fresh install before restore, local storage
+    // loss) must not read as "no files recorded" — the native layer has to restore first.
+    api.set_remote_hash(hex::encode(blake3::hash(b"remote-backup").as_bytes()));
+
+    let mgr = ManifestManager::new_with_prefix("backup_test_list_missing_remote");
+    let err = mgr
+        .list_files(BackupFileDesignator::OrbPkg)
+        .await
+        .expect_err("expected stale error");
+    assert_eq!(
+        err.to_string(),
+        "Remote manifest is ahead of local; fetch and apply latest backup before updating"
+    );
 }
 
 #[tokio::test]

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -335,11 +335,7 @@ async fn test_list_files_missing_manifest_no_remote_is_empty() {
     let api = init_test_globals();
     api.reset();
 
-    // A device that never created a backup has no local manifest at all. Once the remote
-    // head confirms no backup exists, listing must report "no files recorded" rather than
-    // ManifestNotFound: read-only backup syncs (e.g. the face PCP delete cleanup) run on
-    // such accounts, and the absence of a backup is not an error for them. Mutating
-    // methods keep surfacing ManifestNotFound.
+    // No local manifest was ever written (account never created a backup).
     api.set_no_remote_backup();
 
     let mgr = ManifestManager::new_with_prefix("backup_test_list_missing");
@@ -353,8 +349,7 @@ async fn test_list_files_missing_manifest_with_remote_is_stale() {
     let api = init_test_globals();
     api.reset();
 
-    // A remote backup with no local manifest (fresh install before restore, local storage
-    // loss) must not read as "no files recorded" — the native layer has to restore first.
+    // Remote backup exists but the local manifest is missing (e.g. fresh install before restore).
     api.set_remote_hash(hex::encode(blake3::hash(b"remote-backup").as_bytes()));
 
     let mgr = ManifestManager::new_with_prefix("backup_test_list_missing_remote");

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -331,17 +331,17 @@ async fn test_store_file_no_remote_backup_with_nonempty_local_manifest() {
 
 #[tokio::test]
 #[serial]
-async fn test_list_files_missing_manifest() {
+async fn test_list_files_missing_manifest_is_empty() {
     let api = init_test_globals();
     api.reset();
 
-    // Do not create a manifest for this prefix
+    // A device that never created a backup has no local manifest at all. Listing must
+    // report "no files recorded" rather than ManifestNotFound: read-only backup syncs
+    // (e.g. the face PCP delete cleanup) run on such accounts, and the absence of a
+    // backup is not an error for them. Mutating methods keep surfacing ManifestNotFound.
     let mgr = ManifestManager::new_with_prefix("backup_test_list_missing");
-    let err = mgr
-        .list_files(BackupFileDesignator::OrbPkg)
-        .await
-        .expect_err("expected missing manifest error");
-    assert_eq!(err.to_string(), "Manifest not found");
+    let list = mgr.list_files(BackupFileDesignator::OrbPkg).await.unwrap();
+    assert!(list.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

`ManifestManager::list_files` fails with `ManifestNotFound` on any device that never created a backup, because `load_manifest_gated` reads the local manifest before the remote gate and no manifest file was ever written.

Oxide's personal-custody backup syncs call `list_files` after local PCP mutations — the face PCP delete (`delete_face_pcp_and_sync_backup_if_configured`) and the stale-PCP cleanup inside `get_face_enrollment_attempt_status`. On accounts without a backup, the whole operation therefore reports failure even though the local mutation already succeeded. Concretely, in World App Android (wld-android [MCORE-1893](https://linear.app/worldcoin/issue/MCORE-1893)): a no-backup user whose SelfieCheck v4 enrollment fails gets a spurious "PCP deletion failed" from the cleanup, with the PCP actually gone from disk.

This is the remaining half of #418: #418 fixed the empty **remote** `manifest_hash` (0.5.x devices error with `manifest_hash is not the correct length: 0`), but on ≥0.6.1 the same devices now fail one step earlier on the **local** read with `BackupException$ManifestNotFound` — device-verified on wld-android's bedrock 0.6.1 bump (worldcoin/wld-android#8567).

## Fix

No manifest means no files recorded: `list_files` returns an empty list when the local read yields `ManifestNotFound`, short-circuiting before the remote gate (no network call for never-backed-up devices). Mutating methods (`store_file`, `remove_file`, `replace_all_files_for_designator`) are untouched and keep surfacing `ManifestNotFound`, so backup-creation flows keep their signal.

`test_list_files_missing_manifest` asserted the old contract (from #160's general hardening, before this call pattern existed) and is updated to the new one.

## Testing

- `cargo test -p bedrock --lib backup`: 151 passed.
- Device E2E (Pixel 3, `org.world.id.dev` devDebug on worldcoin/wld-android#8567, fresh account with the backup step skipped, face PCP present on disk):
  - bedrock 0.6.1: Developer Settings → Delete Face Dedupe fails with `backup list error: … BackupException$ManifestNotFound` although the local file is deleted.
  - bedrock 0.6.1 + this fix (local snapshot integrated into the app): same action succeeds cleanly — `Successfully deleted local face PCP`, no backup error, file removed. Re-verified after 6307897 with the remote-head gate: device confirmed to have no local manifest (`files/oxide/backup_manager/` absent), so the run exercised the new `ManifestNotFound` → remote-confirmed-empty branch.

Adjacent, not addressed here: `isLocalBackupStale` also errors (`InvalidManifestHashError`) at app start on the same never-backed-up accounts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read-path backup semantics used by post-mutation sync (e.g. PCP cleanup); wrong remote/local branching could hide staleness or skip needed restore, though scope is limited to `list_files`.
> 
> **Overview**
> **`ManifestManager::list_files`** no longer surfaces **`ManifestNotFound`** when there is no local `manifest.json`. On that path it checks the remote manifest head: accounts with **no remote backup** get an **empty file list**; accounts with a **remote backup** but no local manifest get **`RemoteAheadStaleError`** (restore before listing).
> 
> Manifest **mutations** (`store_file`, `remove_file`, etc.) are unchanged and still error if the local manifest is missing. Docs and tests split the old “missing manifest” case into no-remote (empty) vs remote-present (stale).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848830e4045e22706eb9919decd30c504704dded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

