### PR TITLE
feat(migration): top up the TFH paymaster's ERC-20 allowance (staging only)

### DIFF
--- a/bedrock/src/migration/wallet/mod.rs
+++ b/bedrock/src/migration/wallet/mod.rs
@@ -8,3 +8,6 @@ pub mod permit2_approval;
 
 /// Installs the ERC-4337 module on legacy Safes that lack it.
 pub mod safe_4337_module;
+
+/// Tops up the paymaster's ERC-20 allowance. Staging and sandbox only.
+pub mod tfh_paymaster_approval;

--- a/bedrock/src/migration/wallet/permit2_approval.rs
+++ b/bedrock/src/migration/wallet/permit2_approval.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use crate::migration::error::MigrationError;
 use crate::migration::{WalletMigration, WalletMigrationResult};
 use crate::primitives::Network;
-use crate::smart_account::{Is4337Encodable, SafeSmartAccount};
-use crate::transactions::contracts::erc20::Erc20;
-use crate::transactions::contracts::permit2::{BatchPermit2Approval, PERMIT2_ADDRESS};
+use crate::smart_account::{Is4337Encodable, SafeSmartAccount, TransactionTypeId};
+use crate::transactions::contracts::erc20::{BatchErc20Approval, Erc20};
+use crate::transactions::contracts::permit2::PERMIT2_ADDRESS;
 use crate::transactions::contracts::worldchain::{
     USDC_ADDRESS, WBTC_ADDRESS, WETH_ADDRESS, WLD_ADDRESS,
 };
@@ -107,18 +107,23 @@ impl WalletMigration for Permit2ApprovalMigration {
 
         // Fire-and-forget: the hash is kept for log correlation only. The next
         // observation of the allowances is what proves they landed.
-        let addresses: Vec<Address> = tokens.iter().map(|(addr, _)| *addr).collect();
+        let approvals: Vec<(Address, U256)> =
+            tokens.iter().map(|(addr, _)| (*addr, U256::MAX)).collect();
         let names: Vec<&str> = tokens.iter().map(|(_, name)| *name).collect();
 
-        match BatchPermit2Approval::new(&addresses)
-            .sign_and_execute(
-                &self.safe_account,
-                Network::WorldChain,
-                None,
-                None,
-                RpcProviderName::Any,
-            )
-            .await
+        match BatchErc20Approval::new(
+            PERMIT2_ADDRESS,
+            &approvals,
+            TransactionTypeId::Permit2Approve,
+        )
+        .sign_and_execute(
+            &self.safe_account,
+            Network::WorldChain,
+            None,
+            None,
+            RpcProviderName::Any,
+        )
+        .await
         {
             Ok(hash) => {
                 info!(

--- a/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
+++ b/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
@@ -1,17 +1,15 @@
 //! Tops up the Safe's ERC-20 allowance to the TFH multi-token paymaster.
 //!
-//! **Staging and sandbox only.** [`TfhPaymasterApprovalMigration::new`] returns
-//! `None` on production, so the migration cannot be constructed — let alone
-//! registered or submitted — there.
+//! **Staging and sandbox only.** `WalletMigrationController` is the only thing
+//! that registers it, and does not on production, so there it never runs and
+//! never gets a record.
 
 use std::sync::Arc;
 
-use alloy::primitives::{Address, Bytes, U256};
+use alloy::primitives::{uint, Address, Bytes, U256};
 
 use crate::migration::wallet_migration::{WalletMigration, WalletMigrationResult};
 use crate::migration::MigrationError;
-use crate::primitives::config::{current_environment_or_default, BedrockEnvironment};
-use crate::primitives::contracts::IMulticall3;
 use crate::primitives::Network;
 use crate::smart_account::{Is4337Encodable, SafeSmartAccount};
 use crate::transactions::contracts::erc20::{BatchErc20Approval, Erc20};
@@ -22,56 +20,32 @@ use crate::transactions::rpc::{get_rpc_client, RpcProviderName};
 use crate::{info, smart_account::TransactionTypeId};
 use async_trait::async_trait;
 
-/// One token the paymaster takes payment in, and the allowance it is granted.
-struct PaymasterToken {
-    address: Address,
-    name: &'static str,
-    /// The allowance granted when topping up.
-    target: U256,
-}
+/// 100 WLD, at 18 decimals.
+const WLD_TARGET: U256 = uint!(100_000000000000000000_U256);
 
-/// 100 WLD, 18 decimals.
-const WLD_TARGET: U256 = U256::from_limbs([7_766_279_631_452_241_920, 5, 0, 0]);
+/// 30 USDC, at 6 decimals.
+const USDC_TARGET: U256 = uint!(30_000000_U256);
 
-/// 30 USDC, 6 decimals.
-const USDC_TARGET: U256 = U256::from_limbs([30_000_000, 0, 0, 0]);
-
-/// The tokens the paymaster accepts, with the allowance each is granted.
-const PAYMASTER_TOKENS: [PaymasterToken; 2] = [
-    PaymasterToken {
-        address: WLD_ADDRESS,
-        name: "WLD",
-        target: WLD_TARGET,
-    },
-    PaymasterToken {
-        address: USDC_ADDRESS,
-        name: "USDC",
-        target: USDC_TARGET,
-    },
+/// The tokens the paymaster charges in, and the allowance each is granted.
+const PAYMASTER_TOKENS: [(Address, &str, U256); 2] = [
+    (WLD_ADDRESS, "WLD", WLD_TARGET),
+    (USDC_ADDRESS, "USDC", USDC_TARGET),
 ];
 
 /// Grants the TFH paymaster an ERC-20 allowance so it can charge for gas.
 ///
-/// **Staging and sandbox only.** A token is topped up when the Safe holds some
-/// of it *and* its allowance has fallen below half the target — the paymaster
-/// spends the allowance down, so this runs again as it drains.
+/// A token is topped up when the Safe holds some of it *and* its allowance has
+/// fallen below half the target — the paymaster spends the allowance down, so
+/// this runs again as it drains. Registered on staging and sandbox only.
 pub struct TfhPaymasterApprovalMigration {
     safe_account: Arc<SafeSmartAccount>,
 }
 
 impl TfhPaymasterApprovalMigration {
-    /// Creates the migration, or `None` on production.
-    ///
-    /// The environment defaults to production when the config is uninitialized,
-    /// so an unknown environment also declines.
+    /// Creates the migration for the given Safe smart account.
     #[must_use]
-    pub fn new(safe_account: Arc<SafeSmartAccount>) -> Option<Self> {
-        match current_environment_or_default() {
-            BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
-                Some(Self { safe_account })
-            }
-            BedrockEnvironment::Production => None,
-        }
+    pub const fn new(safe_account: Arc<SafeSmartAccount>) -> Self {
+        Self { safe_account }
     }
 
     /// **Observe.** One batched read of every token's balance and allowance,
@@ -83,55 +57,60 @@ impl TfhPaymasterApprovalMigration {
             .map_err(|e| MigrationError::InvalidOperation(e.to_string()))?;
         let safe = self.safe_account.wallet_address;
 
-        let mut calls: Vec<(Address, Bytes)> =
-            Vec::with_capacity(PAYMASTER_TOKENS.len() * 2);
-        for token in &PAYMASTER_TOKENS {
-            calls.push((token.address, Erc20::encode_balance_of(safe).into()));
-            calls.push((
-                token.address,
-                Erc20::encode_allowance(safe, TFH_PAYMASTER_ADDRESS).into(),
-            ));
-        }
+        let calls: Vec<(Address, Bytes)> = PAYMASTER_TOKENS
+            .iter()
+            .flat_map(|(token, _, _)| {
+                [
+                    (*token, Erc20::encode_balance_of(safe).into()),
+                    (
+                        *token,
+                        Erc20::encode_allowance(safe, TFH_PAYMASTER_ADDRESS).into(),
+                    ),
+                ]
+            })
+            .collect();
 
         let results = rpc_client
             .eth_call_batched(Network::WorldChain, &calls)
             .await
             .map_err(|e| MigrationError::InvalidOperation(e.to_string()))?;
 
+        // A short array would drop a token and read as "no gap", so refuse it.
+        if results.len() != calls.len() {
+            return Err(MigrationError::InvalidOperation(format!(
+                "Multicall3 returned {} results for {} calls",
+                results.len(),
+                calls.len()
+            )));
+        }
+
         // Two calls per token, in order, so the results pair up.
         let mut gap = Vec::new();
-        for (token, pair) in PAYMASTER_TOKENS.iter().zip(results.chunks_exact(2)) {
-            let balance = Self::word(&pair[0], token.name, "balanceOf")?;
-            let allowance = Self::word(&pair[1], token.name, "allowance")?;
+        for ((token, name, target), pair) in
+            PAYMASTER_TOKENS.iter().zip(results.chunks_exact(2))
+        {
+            if pair.iter().any(|r| !r.success || r.returnData.len() < 32) {
+                return Err(MigrationError::InvalidOperation(format!(
+                    "Multicall3 balance/allowance query failed for {name}"
+                )));
+            }
+            let balance = U256::from_be_slice(&pair[0].returnData[..32]);
+            let allowance = U256::from_be_slice(&pair[1].returnData[..32]);
 
             // Both conditions, per token: a WLD-only holder gets WLD alone.
-            if balance.is_zero() || allowance >= token.target / U256::from(2) {
+            if balance.is_zero() || allowance >= *target / uint!(2_U256) {
                 continue;
             }
             info!(
-                token = token.name,
+                token = *name,
                 allowance = allowance.to_string(),
-                target = token.target.to_string(),
+                target = target.to_string(),
                 "wallet_migration.paymaster_allowance_low"
             );
-            gap.push((token.address, token.target, token.name));
+            gap.push((*token, *target, *name));
         }
 
         Ok(gap)
-    }
-
-    /// Reads one 32-byte word out of a batched result.
-    fn word(
-        result: &IMulticall3::Result,
-        token: &str,
-        call: &str,
-    ) -> Result<U256, MigrationError> {
-        if !result.success || result.returnData.len() < 32 {
-            return Err(MigrationError::InvalidOperation(format!(
-                "Multicall3 {call} query failed for {token}"
-            )));
-        }
-        Ok(U256::from_be_slice(&result.returnData[..32]))
     }
 }
 
@@ -196,11 +175,6 @@ mod tests {
         "4142710b9b4caaeb000b8e5de271bbebac7f509aab2f5e61d1ed1958bfe6d583";
     const TEST_WALLET: &str = "0x4564420674EA68fcc61b463C0494807C759d47e6";
 
-    /// Marks the child run of [`test_production_never_constructs`].
-    const PRODUCTION_CHILD_ENV: &str = "BEDROCK_TFH_PAYMASTER_PROD_CHILD";
-    const PRODUCTION_TEST_NAME: &str =
-        "migration::wallet::tfh_paymaster_approval::tests::test_production_never_constructs";
-
     fn account() -> Arc<SafeSmartAccount> {
         Arc::new(
             SafeSmartAccount::from_private_key_hex(TEST_KEY.to_string(), TEST_WALLET)
@@ -210,11 +184,11 @@ mod tests {
 
     #[test]
     fn test_migration_id_is_versioned() {
-        crate::primitives::filesystem::init_test_filesystem();
-        let migration = TfhPaymasterApprovalMigration::new(account()).unwrap();
+        let migration = TfhPaymasterApprovalMigration::new(account());
         assert_eq!(migration.migration_id(), "wallet.tfh_paymaster.approval.v1");
     }
 
+    /// Pins the targets to the documented human amounts and their decimals.
     #[test]
     fn test_targets_are_the_documented_amounts() {
         assert_eq!(
@@ -231,65 +205,9 @@ mod tests {
     #[test]
     fn test_half_target_is_the_trigger() {
         assert_eq!(
-            WLD_TARGET / U256::from(2),
+            WLD_TARGET / uint!(2_U256),
             U256::from(50u64) * U256::from(10u64).pow(U256::from(18))
         );
-        assert_eq!(USDC_TARGET / U256::from(2), U256::from(15_000_000u64));
-    }
-
-    /// The test process is configured as staging, so it constructs.
-    #[test]
-    fn test_staging_constructs() {
-        crate::primitives::filesystem::init_test_filesystem();
-        assert!(TfhPaymasterApprovalMigration::new(account()).is_some());
-    }
-
-    /// Production, and an uninitialized config that defaults to it, both refuse.
-    ///
-    /// Runs in a fresh process: the config is a process-wide `OnceLock`, so the
-    /// staging value the other tests rely on cannot be replaced in place.
-    #[test]
-    fn test_production_never_constructs() {
-        use crate::primitives::config::{set_config, Os};
-
-        if std::env::var_os(PRODUCTION_CHILD_ENV).is_none() {
-            let output = std::process::Command::new(std::env::current_exe().unwrap())
-                .args(["--exact", "--nocapture", PRODUCTION_TEST_NAME])
-                .env(PRODUCTION_CHILD_ENV, "1")
-                .output()
-                .expect("re-run this test in a child process");
-            let report = String::from_utf8_lossy(&output.stdout);
-            assert!(
-                output.status.success(),
-                "child run failed:\n{report}{}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            assert!(
-                report.contains("1 passed"),
-                "child did not run the test, only: {report}"
-            );
-            return;
-        }
-
-        // Uninitialized: the environment defaults to production, so it declines.
-        assert!(
-            TfhPaymasterApprovalMigration::new(account()).is_none(),
-            "an uninitialized config must not construct the migration"
-        );
-
-        let root = std::env::temp_dir()
-            .join(format!("bedrock-tfh-paymaster-prod-{}", std::process::id()));
-        set_config(
-            BedrockEnvironment::Production,
-            Os::Ios,
-            root.to_string_lossy().into_owned(),
-        )
-        .expect("configure a production test environment");
-
-        assert!(
-            TfhPaymasterApprovalMigration::new(account()).is_none(),
-            "production must never construct the migration"
-        );
-        drop(std::fs::remove_dir_all(&root));
+        assert_eq!(USDC_TARGET / uint!(2_U256), U256::from(15_000_000u64));
     }
 }

--- a/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
+++ b/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
@@ -1,0 +1,295 @@
+//! Tops up the Safe's ERC-20 allowance to the TFH multi-token paymaster.
+//!
+//! **Staging and sandbox only.** [`TfhPaymasterApprovalMigration::new`] returns
+//! `None` on production, so the migration cannot be constructed — let alone
+//! registered or submitted — there.
+
+use std::sync::Arc;
+
+use alloy::primitives::{Address, Bytes, U256};
+
+use crate::migration::wallet_migration::{WalletMigration, WalletMigrationResult};
+use crate::migration::MigrationError;
+use crate::primitives::config::{current_environment_or_default, BedrockEnvironment};
+use crate::primitives::contracts::IMulticall3;
+use crate::primitives::Network;
+use crate::smart_account::{Is4337Encodable, SafeSmartAccount};
+use crate::transactions::contracts::erc20::{BatchErc20Approval, Erc20};
+use crate::transactions::contracts::worldchain::{
+    TFH_PAYMASTER_ADDRESS, USDC_ADDRESS, WLD_ADDRESS,
+};
+use crate::transactions::rpc::{get_rpc_client, RpcProviderName};
+use crate::{info, smart_account::TransactionTypeId};
+use async_trait::async_trait;
+
+/// One token the paymaster takes payment in, and the allowance it is granted.
+struct PaymasterToken {
+    address: Address,
+    name: &'static str,
+    /// The allowance granted when topping up.
+    target: U256,
+}
+
+/// 100 WLD, 18 decimals.
+const WLD_TARGET: U256 = U256::from_limbs([7_766_279_631_452_241_920, 5, 0, 0]);
+
+/// 30 USDC, 6 decimals.
+const USDC_TARGET: U256 = U256::from_limbs([30_000_000, 0, 0, 0]);
+
+/// The tokens the paymaster accepts, with the allowance each is granted.
+const PAYMASTER_TOKENS: [PaymasterToken; 2] = [
+    PaymasterToken {
+        address: WLD_ADDRESS,
+        name: "WLD",
+        target: WLD_TARGET,
+    },
+    PaymasterToken {
+        address: USDC_ADDRESS,
+        name: "USDC",
+        target: USDC_TARGET,
+    },
+];
+
+/// Grants the TFH paymaster an ERC-20 allowance so it can charge for gas.
+///
+/// **Staging and sandbox only.** A token is topped up when the Safe holds some
+/// of it *and* its allowance has fallen below half the target — the paymaster
+/// spends the allowance down, so this runs again as it drains.
+pub struct TfhPaymasterApprovalMigration {
+    safe_account: Arc<SafeSmartAccount>,
+}
+
+impl TfhPaymasterApprovalMigration {
+    /// Creates the migration, or `None` on production.
+    ///
+    /// The environment defaults to production when the config is uninitialized,
+    /// so an unknown environment also declines.
+    #[must_use]
+    pub fn new(safe_account: Arc<SafeSmartAccount>) -> Option<Self> {
+        match current_environment_or_default() {
+            BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => {
+                Some(Self { safe_account })
+            }
+            BedrockEnvironment::Production => None,
+        }
+    }
+
+    /// **Observe.** One batched read of every token's balance and allowance,
+    /// returning those that are held and under half their target — the gap.
+    async fn observe(
+        &self,
+    ) -> Result<Vec<(Address, U256, &'static str)>, MigrationError> {
+        let rpc_client = get_rpc_client()
+            .map_err(|e| MigrationError::InvalidOperation(e.to_string()))?;
+        let safe = self.safe_account.wallet_address;
+
+        let mut calls: Vec<(Address, Bytes)> =
+            Vec::with_capacity(PAYMASTER_TOKENS.len() * 2);
+        for token in &PAYMASTER_TOKENS {
+            calls.push((token.address, Erc20::encode_balance_of(safe).into()));
+            calls.push((
+                token.address,
+                Erc20::encode_allowance(safe, TFH_PAYMASTER_ADDRESS).into(),
+            ));
+        }
+
+        let results = rpc_client
+            .eth_call_batched(Network::WorldChain, &calls)
+            .await
+            .map_err(|e| MigrationError::InvalidOperation(e.to_string()))?;
+
+        // Two calls per token, in order, so the results pair up.
+        let mut gap = Vec::new();
+        for (token, pair) in PAYMASTER_TOKENS.iter().zip(results.chunks_exact(2)) {
+            let balance = Self::word(&pair[0], token.name, "balanceOf")?;
+            let allowance = Self::word(&pair[1], token.name, "allowance")?;
+
+            // Both conditions, per token: a WLD-only holder gets WLD alone.
+            if balance.is_zero() || allowance >= token.target / U256::from(2) {
+                continue;
+            }
+            info!(
+                token = token.name,
+                allowance = allowance.to_string(),
+                target = token.target.to_string(),
+                "wallet_migration.paymaster_allowance_low"
+            );
+            gap.push((token.address, token.target, token.name));
+        }
+
+        Ok(gap)
+    }
+
+    /// Reads one 32-byte word out of a batched result.
+    fn word(
+        result: &IMulticall3::Result,
+        token: &str,
+        call: &str,
+    ) -> Result<U256, MigrationError> {
+        if !result.success || result.returnData.len() < 32 {
+            return Err(MigrationError::InvalidOperation(format!(
+                "Multicall3 {call} query failed for {token}"
+            )));
+        }
+        Ok(U256::from_be_slice(&result.returnData[..32]))
+    }
+}
+
+#[async_trait]
+impl WalletMigration for TfhPaymasterApprovalMigration {
+    fn migration_id(&self) -> String {
+        "wallet.tfh_paymaster.approval.v1".to_string()
+    }
+
+    async fn end_state_holds(&self) -> Result<bool, MigrationError> {
+        Ok(self.observe().await?.is_empty())
+    }
+
+    async fn reconcile(&self) -> Result<WalletMigrationResult, MigrationError> {
+        // The only chain read of this pass; the gap is a local, never a field.
+        let gap = self.observe().await?;
+        if gap.is_empty() {
+            return Ok(WalletMigrationResult::Converged);
+        }
+
+        let approvals: Vec<(Address, U256)> = gap
+            .iter()
+            .map(|(token, target, _)| (*token, *target))
+            .collect();
+        let names: Vec<&str> = gap.iter().map(|(_, _, name)| *name).collect();
+
+        match BatchErc20Approval::new(
+            TFH_PAYMASTER_ADDRESS,
+            &approvals,
+            TransactionTypeId::TfhPaymasterApprove,
+        )
+        .sign_and_execute(
+            &self.safe_account,
+            Network::WorldChain,
+            None,
+            None,
+            RpcProviderName::Any,
+        )
+        .await
+        {
+            Ok(hash) => {
+                info!(
+                    tokens = format!("{names:?}"),
+                    user_op_hash = format!("{hash:#x}"),
+                    "wallet_migration.paymaster_approvals_submitted"
+                );
+                Ok(WalletMigrationResult::submitted(format!("{hash:#x}")))
+            }
+            Err(e) => Ok(WalletMigrationResult::retry(
+                "RPC_ERROR",
+                format!("Failed to submit paymaster approvals for {names:?}: {e}"),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_KEY: &str =
+        "4142710b9b4caaeb000b8e5de271bbebac7f509aab2f5e61d1ed1958bfe6d583";
+    const TEST_WALLET: &str = "0x4564420674EA68fcc61b463C0494807C759d47e6";
+
+    /// Marks the child run of [`test_production_never_constructs`].
+    const PRODUCTION_CHILD_ENV: &str = "BEDROCK_TFH_PAYMASTER_PROD_CHILD";
+    const PRODUCTION_TEST_NAME: &str =
+        "migration::wallet::tfh_paymaster_approval::tests::test_production_never_constructs";
+
+    fn account() -> Arc<SafeSmartAccount> {
+        Arc::new(
+            SafeSmartAccount::from_private_key_hex(TEST_KEY.to_string(), TEST_WALLET)
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_migration_id_is_versioned() {
+        crate::primitives::filesystem::init_test_filesystem();
+        let migration = TfhPaymasterApprovalMigration::new(account()).unwrap();
+        assert_eq!(migration.migration_id(), "wallet.tfh_paymaster.approval.v1");
+    }
+
+    #[test]
+    fn test_targets_are_the_documented_amounts() {
+        assert_eq!(
+            WLD_TARGET,
+            U256::from(100u64) * U256::from(10u64).pow(U256::from(18))
+        );
+        assert_eq!(
+            USDC_TARGET,
+            U256::from(30u64) * U256::from(10u64).pow(U256::from(6))
+        );
+    }
+
+    /// The top-up trigger is half the target, so document both halves.
+    #[test]
+    fn test_half_target_is_the_trigger() {
+        assert_eq!(
+            WLD_TARGET / U256::from(2),
+            U256::from(50u64) * U256::from(10u64).pow(U256::from(18))
+        );
+        assert_eq!(USDC_TARGET / U256::from(2), U256::from(15_000_000u64));
+    }
+
+    /// The test process is configured as staging, so it constructs.
+    #[test]
+    fn test_staging_constructs() {
+        crate::primitives::filesystem::init_test_filesystem();
+        assert!(TfhPaymasterApprovalMigration::new(account()).is_some());
+    }
+
+    /// Production, and an uninitialized config that defaults to it, both refuse.
+    ///
+    /// Runs in a fresh process: the config is a process-wide `OnceLock`, so the
+    /// staging value the other tests rely on cannot be replaced in place.
+    #[test]
+    fn test_production_never_constructs() {
+        use crate::primitives::config::{set_config, Os};
+
+        if std::env::var_os(PRODUCTION_CHILD_ENV).is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "--nocapture", PRODUCTION_TEST_NAME])
+                .env(PRODUCTION_CHILD_ENV, "1")
+                .output()
+                .expect("re-run this test in a child process");
+            let report = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                output.status.success(),
+                "child run failed:\n{report}{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                report.contains("1 passed"),
+                "child did not run the test, only: {report}"
+            );
+            return;
+        }
+
+        // Uninitialized: the environment defaults to production, so it declines.
+        assert!(
+            TfhPaymasterApprovalMigration::new(account()).is_none(),
+            "an uninitialized config must not construct the migration"
+        );
+
+        let root = std::env::temp_dir()
+            .join(format!("bedrock-tfh-paymaster-prod-{}", std::process::id()));
+        set_config(
+            BedrockEnvironment::Production,
+            Os::Ios,
+            root.to_string_lossy().into_owned(),
+        )
+        .expect("configure a production test environment");
+
+        assert!(
+            TfhPaymasterApprovalMigration::new(account()).is_none(),
+            "production must never construct the migration"
+        );
+        drop(std::fs::remove_dir_all(&root));
+    }
+}

--- a/bedrock/src/migration/wallet_controller.rs
+++ b/bedrock/src/migration/wallet_controller.rs
@@ -1,5 +1,6 @@
 use super::wallet::permit2_approval::Permit2ApprovalMigration;
 use super::wallet::safe_4337_module::Safe4337ModuleMigration;
+use super::wallet::tfh_paymaster_approval::TfhPaymasterApprovalMigration;
 use super::wallet_migration::{WalletMigration, WalletMigrationResult};
 use crate::migration::controller::MigrationRunSummary;
 use crate::migration::error::MigrationError;
@@ -50,13 +51,23 @@ impl WalletMigrationController {
         let Some(account) = safe_account else {
             return Self::with_migrations(kv_store, vec![]);
         };
+
+        let mut migrations: Vec<Arc<dyn WalletMigration>> =
+            vec![Arc::new(Permit2ApprovalMigration::new(account.clone()))];
+
+        // `None` on production, so the paymaster approval is never registered
+        // there and no record for it is ever written.
+        if let Some(paymaster) = TfhPaymasterApprovalMigration::new(account.clone()) {
+            migrations.push(Arc::new(paymaster));
+        }
+
         Self {
             records: RecordStore::new(kv_store, WALLET_KEY_PREFIX),
             // The 4337 repair relays a plain owner-signed `execTransaction`, so
             // it is the one migration that works on an unrepaired Safe — which
             // makes it everything else's prerequisite.
-            prerequisite: Some(Arc::new(Safe4337ModuleMigration::new(account.clone()))),
-            migrations: vec![Arc::new(Permit2ApprovalMigration::new(account))],
+            prerequisite: Some(Arc::new(Safe4337ModuleMigration::new(account))),
+            migrations,
         }
     }
 

--- a/bedrock/src/migration/wallet_controller.rs
+++ b/bedrock/src/migration/wallet_controller.rs
@@ -7,6 +7,7 @@ use crate::migration::error::MigrationError;
 use crate::migration::record_store::{
     MigrationRecord, MigrationRecordEntry, MigrationStatus, RecordStore, Submission,
 };
+use crate::primitives::config::{current_environment_or_default, BedrockEnvironment};
 use crate::primitives::key_value_store::DeviceKeyValueStore;
 use crate::smart_account::SafeSmartAccount;
 use chrono::{Duration, Utc};
@@ -55,10 +56,16 @@ impl WalletMigrationController {
         let mut migrations: Vec<Arc<dyn WalletMigration>> =
             vec![Arc::new(Permit2ApprovalMigration::new(account.clone()))];
 
-        // `None` on production, so the paymaster approval is never registered
-        // there and no record for it is ever written.
-        if let Some(paymaster) = TfhPaymasterApprovalMigration::new(account.clone()) {
-            migrations.push(Arc::new(paymaster));
+        // Staging and sandbox only, so production never runs the paymaster
+        // approval and never writes a record for it. An uninitialized config
+        // reads as production, so an unknown environment is excluded too.
+        if matches!(
+            current_environment_or_default(),
+            BedrockEnvironment::Staging | BedrockEnvironment::Sandbox
+        ) {
+            migrations.push(Arc::new(TfhPaymasterApprovalMigration::new(
+                account.clone(),
+            )));
         }
 
         Self {
@@ -527,6 +534,91 @@ mod tests {
             Arc::new(InMemoryDeviceKeyValueStore::new()),
             migrations,
         )
+    }
+
+    /// Marks the child run of [`test_production_omits_the_paymaster_approval`].
+    const PRODUCTION_CHILD_ENV: &str = "BEDROCK_WALLET_PROD_CHILD";
+    const PRODUCTION_TEST_NAME: &str =
+        "migration::wallet_controller::tests::test_production_omits_the_paymaster_approval";
+
+    /// The default set for a Safe-backed controller.
+    fn default_set() -> WalletMigrationController {
+        let account = Arc::new(
+            crate::smart_account::SafeSmartAccount::from_private_key_hex(
+                "4142710b9b4caaeb000b8e5de271bbebac7f509aab2f5e61d1ed1958bfe6d583"
+                    .to_string(),
+                "0x4564420674EA68fcc61b463C0494807C759d47e6",
+            )
+            .unwrap(),
+        );
+        WalletMigrationController::new(
+            Arc::new(InMemoryDeviceKeyValueStore::new()),
+            Some(account),
+        )
+    }
+
+    /// Staging registers the repair, Permit2, and the paymaster approval.
+    #[tokio::test]
+    async fn test_staging_registers_the_paymaster_approval() {
+        crate::primitives::filesystem::init_test_filesystem();
+        assert_eq!(default_set().len(), 3);
+        assert!(default_set()
+            .all()
+            .any(|m| m.migration_id() == "wallet.tfh_paymaster.approval.v1"));
+    }
+
+    /// Production registers everything *but* the paymaster approval, so no
+    /// record for it is ever written there.
+    ///
+    /// Runs in a fresh process: the config is a process-wide `OnceLock`, so the
+    /// staging value the other tests rely on cannot be replaced in place. The
+    /// uninitialized case is covered first, since it defaults to production.
+    #[test]
+    fn test_production_omits_the_paymaster_approval() {
+        use crate::primitives::config::{set_config, Os};
+
+        if std::env::var_os(PRODUCTION_CHILD_ENV).is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "--nocapture", PRODUCTION_TEST_NAME])
+                .env(PRODUCTION_CHILD_ENV, "1")
+                .output()
+                .expect("re-run this test in a child process");
+            let report = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                output.status.success(),
+                "child run failed:\n{report}{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                report.contains("1 passed"),
+                "child did not run the test, only: {report}"
+            );
+            return;
+        }
+
+        let assert_omitted = |c: WalletMigrationController| {
+            assert_eq!(c.len(), 2, "the paymaster approval must not be registered");
+            assert!(
+                !c.all()
+                    .any(|m| m.migration_id() == "wallet.tfh_paymaster.approval.v1"),
+                "the paymaster approval must not be registered"
+            );
+        };
+
+        // Uninitialized reads as production.
+        assert_omitted(default_set());
+
+        let root = std::env::temp_dir()
+            .join(format!("bedrock-wallet-prod-{}", std::process::id()));
+        set_config(
+            BedrockEnvironment::Production,
+            Os::Ios,
+            root.to_string_lossy().into_owned(),
+        )
+        .expect("configure a production test environment");
+
+        assert_omitted(default_set());
+        drop(std::fs::remove_dir_all(&root));
     }
 
     /// A migration that was never needed converges on the first pass, and is

--- a/bedrock/src/smart_account/nonce.rs
+++ b/bedrock/src/smart_account/nonce.rs
@@ -46,6 +46,8 @@ pub enum TransactionTypeId {
     WLDVaultMigration = 139,
     /// USD Vault migration to ERC-4626 vault
     USDVaultMigration = 140,
+    /// ERC-20 approve for the TFH multi-token paymaster
+    TfhPaymasterApprove = 141,
 }
 
 impl TransactionTypeId {

--- a/bedrock/src/transactions/contracts/erc20.rs
+++ b/bedrock/src/transactions/contracts/erc20.rs
@@ -15,6 +15,8 @@ use crate::{
     transactions::{RpcClient, RpcError},
 };
 
+use super::multisend::{MultiSend, MultiSendTx};
+
 sol! {
     /// The ERC20 contract interface.
     ///
@@ -135,6 +137,94 @@ impl Erc20 {
     #[must_use]
     pub fn encode_allowance(owner: Address, spender: Address) -> Vec<u8> {
         IErc20::allowanceCall { owner, spender }.abi_encode()
+    }
+
+    /// Encodes an ERC-20 `balanceOf` call.
+    #[must_use]
+    pub fn encode_balance_of(account: Address) -> Vec<u8> {
+        IErc20::balanceOfCall { account }.abi_encode()
+    }
+}
+
+/// Batched ERC-20 `approve(spender, amount)` calls via `MultiSend`.
+///
+/// One 4337 `UserOperation` granting `spender` a specific allowance on each
+/// token. Unlike [`BatchPermit2Approval`](super::permit2::BatchPermit2Approval)
+/// the spender and the per-token amounts are both callers' choice.
+pub struct BatchErc20Approval {
+    call_data: Bytes,
+    to: Address,
+    operation: SafeOperation,
+    transaction_type: TransactionTypeId,
+}
+
+impl BatchErc20Approval {
+    /// Batches `approve(spender, amount)` for each `(token, amount)` pair.
+    ///
+    /// `transaction_type` tags the nonce key, so each caller's approvals get
+    /// their own transaction class.
+    #[must_use]
+    pub fn new(
+        spender: Address,
+        approvals: &[(Address, U256)],
+        transaction_type: TransactionTypeId,
+    ) -> Self {
+        let entries: Vec<MultiSendTx> = approvals
+            .iter()
+            .map(|(token, amount)| {
+                let data = Self::encode_approve(spender, *amount);
+                MultiSendTx {
+                    operation: SafeOperation::Call as u8,
+                    to: *token,
+                    value: U256::ZERO,
+                    data_length: U256::from(data.len()),
+                    data: data.into(),
+                }
+            })
+            .collect();
+
+        let bundle = MultiSend::build_bundle(&entries);
+
+        Self {
+            call_data: bundle.data.into(),
+            to: bundle.to,
+            operation: bundle.operation,
+            transaction_type,
+        }
+    }
+
+    fn encode_approve(spender: Address, value: U256) -> Vec<u8> {
+        IErc20::approveCall { spender, value }.abi_encode()
+    }
+}
+
+impl Is4337Encodable for BatchErc20Approval {
+    type MetadataArg = ();
+
+    fn build_execute_user_op_call_data(&self) -> Bytes {
+        ISafe4337Module::executeUserOpCall {
+            to: self.to,
+            value: U256::ZERO,
+            data: self.call_data.clone(),
+            operation: self.operation as u8,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn build_preflight_user_operation(
+        &self,
+        wallet_address: Address,
+        _metadata: Option<Self::MetadataArg>,
+    ) -> Result<UserOperation, PrimitiveError> {
+        let key =
+            NonceKeyV1::new(self.transaction_type, InstructionFlag::Default, [0u8; 10]);
+
+        Ok(UserOperation::new_with_defaults(
+            wallet_address,
+            key.encode(),
+            self.build_execute_user_op_call_data(),
+        ))
     }
 }
 

--- a/bedrock/src/transactions/contracts/permit2.rs
+++ b/bedrock/src/transactions/contracts/permit2.rs
@@ -1,8 +1,8 @@
 //! Permit2 contract types, helpers, and batched ERC20 approvals.
 //!
 //! Contains the Permit2 `IAllowanceTransfer` interface, `PermitTransferFrom` / `TokenPermissions`
-//! EIP-712 types, `Permit2Approve` for on-chain allowance approvals, and `BatchPermit2Approval`
-//! for batching ERC20 `approve(spender, type(uint256).max)` calls via `MultiSend`.
+//! EIP-712 types and `Permit2Approve` for on-chain allowance approvals.
+//! Batching several is [`BatchErc20Approval`](super::erc20::BatchErc20Approval).
 
 use alloy::{
     dyn_abi::{Eip712Domain, TypedData},
@@ -21,8 +21,6 @@ use crate::smart_account::{
     TransactionTypeId, UserOperation,
 };
 
-use super::erc20::Erc20;
-use super::multisend::{MultiSend, MultiSendTx};
 pub use super::worldchain::PERMIT2_ADDRESS;
 
 // ---------------------------------------------------------------------------
@@ -174,86 +172,6 @@ impl Is4337Encodable for Permit2Approve {
 }
 
 // ---------------------------------------------------------------------------
-// BatchPermit2Approval (multiple ERC20 approvals via MultiSend)
-// ---------------------------------------------------------------------------
-
-/// Batched ERC20 `approve(spender, type(uint256).max)` calls via `MultiSend`.
-///
-/// Builds a single 4337 `UserOperation` that grants a spender contract max allowance
-/// on each of the given token contracts.
-pub struct BatchPermit2Approval {
-    call_data: Bytes,
-    to: Address,
-    operation: SafeOperation,
-}
-
-impl BatchPermit2Approval {
-    /// Creates a new batch of ERC20 max approvals to the Permit2 contract.
-    ///
-    /// # Arguments
-    /// * `tokens` - The ERC20 token addresses to approve.
-    #[must_use]
-    pub fn new(tokens: &[Address]) -> Self {
-        let approve_data = Erc20::encode_approve(PERMIT2_ADDRESS, U256::MAX);
-
-        let entries: Vec<MultiSendTx> = tokens
-            .iter()
-            .map(|token| MultiSendTx {
-                operation: SafeOperation::Call as u8,
-                to: *token,
-                value: U256::ZERO,
-                data_length: U256::from(approve_data.len()),
-                data: approve_data.clone().into(),
-            })
-            .collect();
-
-        let bundle = MultiSend::build_bundle(&entries);
-
-        Self {
-            call_data: bundle.data.into(),
-            to: bundle.to,
-            operation: bundle.operation,
-        }
-    }
-}
-
-impl Is4337Encodable for BatchPermit2Approval {
-    type MetadataArg = ();
-
-    fn build_execute_user_op_call_data(&self) -> Bytes {
-        ISafe4337Module::executeUserOpCall {
-            to: self.to,
-            value: U256::ZERO,
-            data: self.call_data.clone(),
-            operation: self.operation as u8,
-        }
-        .abi_encode()
-        .into()
-    }
-
-    fn build_preflight_user_operation(
-        &self,
-        wallet_address: Address,
-        _metadata: Option<Self::MetadataArg>,
-    ) -> Result<UserOperation, PrimitiveError> {
-        let call_data = self.build_execute_user_op_call_data();
-
-        let key = NonceKeyV1::new(
-            TransactionTypeId::Permit2Approve,
-            InstructionFlag::Default,
-            [0u8; 10],
-        );
-        let nonce = key.encode();
-
-        Ok(UserOperation::new_with_defaults(
-            wallet_address,
-            nonce,
-            call_data,
-        ))
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -261,7 +179,7 @@ impl Is4337Encodable for BatchPermit2Approval {
 mod tests {
     use super::*;
     use crate::primitives::{Network, BEDROCK_NONCE_PREFIX_CONST};
-    use crate::transactions::contracts::erc20::IErc20;
+    use crate::transactions::contracts::erc20::{BatchErc20Approval, Erc20, IErc20};
     use crate::transactions::contracts::multisend::MULTISEND_ADDRESS;
     use alloy::primitives::{address, fixed_bytes, uint};
     use std::str::FromStr;
@@ -363,8 +281,12 @@ mod tests {
     fn test_batch_execute_user_op_calldata() {
         let usdc = address!("0x79A02482A880bCE3F13e09Da970dC34db4CD24d1");
         let weth = address!("0x4200000000000000000000000000000000000006");
-        let tokens = vec![usdc, weth];
-        let batch = BatchPermit2Approval::new(&tokens);
+        let tokens = [usdc, weth];
+        let batch = BatchErc20Approval::new(
+            PERMIT2_ADDRESS,
+            &tokens.iter().map(|t| (*t, U256::MAX)).collect::<Vec<_>>(),
+            TransactionTypeId::Permit2Approve,
+        );
 
         let call_data = batch.build_execute_user_op_call_data();
         let call_data_bytes: &[u8] = &call_data;

--- a/bedrock/src/transactions/contracts/worldchain.rs
+++ b/bedrock/src/transactions/contracts/worldchain.rs
@@ -26,7 +26,7 @@ pub static WLD_ADDRESS: Address =
 
 /// The Tools for Humanity multi-token ERC-20 paymaster (WLD and USDC).
 ///
-/// Sponsors user operations and takes payment in tokens, so it needs an ERC-20
-/// allowance from the Safe. Superseded `0x161F475B…`, which is drained.
+/// **Staging deployment.** Sponsors user operations and takes payment in
+/// tokens, so it needs an ERC-20 allowance from the Safe.
 pub static TFH_PAYMASTER_ADDRESS: Address =
     address!("0xBF09Bc530dc29623c3cE171A4D9bf03edafE763c");

--- a/bedrock/src/transactions/contracts/worldchain.rs
+++ b/bedrock/src/transactions/contracts/worldchain.rs
@@ -23,3 +23,10 @@ pub static WBTC_ADDRESS: Address =
 /// WLD token address on `WorldChain`.
 pub static WLD_ADDRESS: Address =
     address!("0x2cFc85d8E48F8EAB294be644d9E25C3030863003");
+
+/// The Tools for Humanity multi-token ERC-20 paymaster (WLD and USDC).
+///
+/// Sponsors user operations and takes payment in tokens, so it needs an ERC-20
+/// allowance from the Safe. Superseded `0x161F475B…`, which is drained.
+pub static TFH_PAYMASTER_ADDRESS: Address =
+    address!("0xBF09Bc530dc29623c3cE171A4D9bf03edafE763c");

--- a/bedrock/tests/common.rs
+++ b/bedrock/tests/common.rs
@@ -71,6 +71,7 @@ sol! {
     #[sol(rpc)]
     interface IERC20 {
         function transfer(address to, uint256 amount) external returns (bool);
+        function transferFrom(address from, address to, uint256 amount) external returns (bool);
         function balanceOf(address account) external view returns (uint256);
         function approve(address spender, uint256 amount) external returns (bool);
         function allowance(address owner, address spender) external view returns (uint256);

--- a/bedrock/tests/test_tfh_paymaster_approval_migration.rs
+++ b/bedrock/tests/test_tfh_paymaster_approval_migration.rs
@@ -279,6 +279,47 @@ async fn test_tfh_paymaster_approval_migration_full_flow() -> anyhow::Result<()>
     );
     assert!(migration.end_state_holds().await?);
 
+    // 8) The same for USDC, which consumes allowance differently: Circle's
+    //    FiatToken decrements even from `type(uint256).max`, where a standard
+    //    ERC-20 skips the decrement there. Finite approvals sidestep that split
+    //    — both decrement below MAX — so USDC needs no special case here, and
+    //    this proves it rather than assuming it.
+    let twenty_usdc = U256::from(20_000_000u64);
+    paymaster_spends(
+        &anvil.endpoint_url(),
+        USDC_ADDRESS,
+        safe_address,
+        twenty_usdc,
+    )
+    .await?;
+    assert_eq!(
+        usdc.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        usdc_target() - twenty_usdc,
+        "USDC should decrement by exactly what was pulled"
+    );
+
+    assert!(!migration.end_state_holds().await?);
+    assert!(matches!(
+        migration.reconcile().await?,
+        WalletMigrationResult::Submitted { .. }
+    ));
+    assert_eq!(
+        usdc.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        usdc_target(),
+        "the USDC top-up should restore the full target"
+    );
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        wld_target(),
+        "WLD was at target, so the USDC top-up must leave it alone"
+    );
+
     drop(std::fs::remove_dir_all(&root));
     Ok(())
 }

--- a/bedrock/tests/test_tfh_paymaster_approval_migration.rs
+++ b/bedrock/tests/test_tfh_paymaster_approval_migration.rs
@@ -1,0 +1,284 @@
+//! End-to-end coverage for [`TfhPaymasterApprovalMigration`] against a real chain.
+//!
+//! Proves the two conditions that gate a top-up — the Safe holds the token, and
+//! its allowance has fallen below half the target — and that the paymaster
+//! draining the allowance is what brings the migration back.
+
+use std::sync::Arc;
+
+mod common;
+use alloy::{
+    primitives::{Address, U256},
+    providers::{ext::AnvilApi, Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use common::{deploy_safe, set_erc20_balance_with_slot, setup_anvil, IERC20};
+
+use bedrock::{
+    migration::wallet::tfh_paymaster_approval::TfhPaymasterApprovalMigration,
+    migration::{WalletMigration, WalletMigrationResult},
+    primitives::{
+        config::{set_config, BedrockEnvironment, Os},
+        http_client::set_http_client,
+    },
+    smart_account::{SafeSmartAccount, ENTRYPOINT_4337},
+    test_utils::{AnvilBackedHttpClient, IEntryPoint},
+    transactions::contracts::worldchain::{
+        TFH_PAYMASTER_ADDRESS, USDC_ADDRESS, WLD_ADDRESS,
+    },
+};
+
+/// 100 WLD, the target allowance.
+fn wld_target() -> U256 {
+    U256::from(100u64) * U256::from(10u64).pow(U256::from(18))
+}
+
+/// 30 USDC, the target allowance.
+fn usdc_target() -> U256 {
+    U256::from(30_000_000u64)
+}
+
+/// Storage slot of WLD's balances mapping.
+const WLD_BALANCES_SLOT: u64 = 0;
+
+/// Storage slot of USDC's balances mapping. USDC on World Chain is Circle's
+/// `FiatToken`, which keeps them at slot 9 rather than 0.
+const USDC_BALANCES_SLOT: u64 = 9;
+
+/// Funds `token` for the Safe and proves the write landed.
+///
+/// Asserting the readback turns a wrong storage layout into a clear failure
+/// rather than a confusing one downstream.
+async fn fund<P>(
+    provider: &P,
+    token: Address,
+    safe: Address,
+    amount: U256,
+    balances_slot: u64,
+) -> anyhow::Result<()>
+where
+    P: Provider<alloy::network::Ethereum> + AnvilApi<alloy::network::Ethereum>,
+{
+    set_erc20_balance_with_slot(
+        provider,
+        token,
+        safe,
+        amount,
+        U256::from(balances_slot),
+    )
+    .await?;
+    let observed = IERC20::new(token, provider).balanceOf(safe).call().await?;
+    assert_eq!(
+        observed, amount,
+        "balance write did not land for {token}; its balances mapping is not at \
+         slot {balances_slot}"
+    );
+    Ok(())
+}
+
+/// Has the paymaster pull `amount` out of the Safe, draining its allowance the
+/// way it does in production.
+async fn paymaster_spends(
+    endpoint: &reqwest::Url,
+    token: Address,
+    safe: Address,
+    amount: U256,
+) -> anyhow::Result<()> {
+    // No wallet filler: an impersonated sender must go out unsigned, or the
+    // provider tries to find a signing credential for the paymaster.
+    let provider = ProviderBuilder::new().connect_http(endpoint.clone());
+
+    provider
+        .anvil_set_balance(TFH_PAYMASTER_ADDRESS, U256::from(1e18 as u64))
+        .await?;
+    provider
+        .anvil_impersonate_account(TFH_PAYMASTER_ADDRESS)
+        .await?;
+
+    let receipt = IERC20::new(token, &provider)
+        .transferFrom(safe, TFH_PAYMASTER_ADDRESS, amount)
+        .from(TFH_PAYMASTER_ADDRESS)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(
+        receipt.status(),
+        "the paymaster's transferFrom should succeed"
+    );
+
+    provider
+        .anvil_stop_impersonating_account(TFH_PAYMASTER_ADDRESS)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_tfh_paymaster_approval_migration_full_flow() -> anyhow::Result<()> {
+    // 1) The migration only exists off production, so configure staging first.
+    let root = std::env::temp_dir()
+        .join(format!("bedrock-tfh-paymaster-it-{}", std::process::id()));
+    set_config(
+        BedrockEnvironment::Staging,
+        Os::Ios,
+        root.to_string_lossy().into_owned(),
+    )?;
+
+    let anvil = setup_anvil();
+    let owner_signer = PrivateKeySigner::random();
+    let owner_key_hex = hex::encode(owner_signer.to_bytes());
+    let owner = owner_signer.address();
+
+    let provider = ProviderBuilder::new()
+        .wallet(owner_signer.clone())
+        .connect_http(anvil.endpoint_url());
+    provider
+        .anvil_set_balance(owner, U256::from(1e18 as u64))
+        .await?;
+
+    // 2) A Safe with the 4337 module, funded at the EntryPoint so its userOps
+    //    can be executed.
+    let safe_address = deploy_safe(&provider, owner, U256::ZERO).await?;
+    let entry_point = IEntryPoint::new(*ENTRYPOINT_4337, &provider);
+    entry_point
+        .depositTo(safe_address)
+        .value(U256::from(1e18 as u64))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    set_http_client(Arc::new(AnvilBackedHttpClient::new(provider.clone())));
+
+    let safe_account = Arc::new(SafeSmartAccount::from_private_key_hex(
+        owner_key_hex,
+        &safe_address.to_string(),
+    )?);
+    let migration = TfhPaymasterApprovalMigration::new(safe_account)
+        .expect("staging must construct the migration");
+    assert_eq!(migration.migration_id(), "wallet.tfh_paymaster.approval.v1");
+
+    let wld = IERC20::new(WLD_ADDRESS, &provider);
+    let usdc = IERC20::new(USDC_ADDRESS, &provider);
+
+    // 3) No balances: nothing to approve, even though both allowances are zero.
+    //    A wallet with no tokens never needs the paymaster.
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        U256::ZERO
+    );
+    assert!(
+        migration.end_state_holds().await?,
+        "a Safe holding neither token has nothing to approve"
+    );
+    assert!(matches!(
+        migration.reconcile().await?,
+        WalletMigrationResult::Converged
+    ));
+
+    // 4) WLD only. The gap is per-token, so USDC must stay untouched.
+    fund(
+        &provider,
+        WLD_ADDRESS,
+        safe_address,
+        wld_target(),
+        WLD_BALANCES_SLOT,
+    )
+    .await?;
+    assert!(!migration.end_state_holds().await?);
+    assert!(matches!(
+        migration.reconcile().await?,
+        WalletMigrationResult::Submitted { .. }
+    ));
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        wld_target(),
+        "WLD should be approved for exactly the target, not uint256::max"
+    );
+    assert_eq!(
+        usdc.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        U256::ZERO,
+        "USDC is not held, so it must not have been approved"
+    );
+    assert!(migration.end_state_holds().await?);
+
+    // 5) Now USDC too. WLD is already at target, so only USDC is submitted.
+    fund(
+        &provider,
+        USDC_ADDRESS,
+        safe_address,
+        usdc_target(),
+        USDC_BALANCES_SLOT,
+    )
+    .await?;
+    assert!(!migration.end_state_holds().await?);
+    assert!(matches!(
+        migration.reconcile().await?,
+        WalletMigrationResult::Submitted { .. }
+    ));
+    assert_eq!(
+        usdc.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        usdc_target(),
+        "USDC should be approved for exactly 30 USDC"
+    );
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        wld_target(),
+        "the WLD allowance was already at target and must be left alone"
+    );
+
+    // 6) The paymaster spends a little WLD. Still at or above half, so no work.
+    let ten_wld = U256::from(10u64) * U256::from(10u64).pow(U256::from(18));
+    paymaster_spends(&anvil.endpoint_url(), WLD_ADDRESS, safe_address, ten_wld).await?;
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        wld_target() - ten_wld
+    );
+    assert!(
+        migration.end_state_holds().await?,
+        "90 WLD is still above half the target, so nothing is topped up"
+    );
+
+    // 7) It spends past half. That reopens the gap and the top-up restores the
+    //    full target.
+    let fifty_wld = U256::from(50u64) * U256::from(10u64).pow(U256::from(18));
+    paymaster_spends(&anvil.endpoint_url(), WLD_ADDRESS, safe_address, fifty_wld)
+        .await?;
+    let drained = wld
+        .allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+        .call()
+        .await?;
+    assert!(
+        drained < wld_target() / U256::from(2),
+        "the allowance should now be below half the target, got {drained}"
+    );
+
+    assert!(!migration.end_state_holds().await?);
+    assert!(matches!(
+        migration.reconcile().await?,
+        WalletMigrationResult::Submitted { .. }
+    ));
+    assert_eq!(
+        wld.allowance(safe_address, TFH_PAYMASTER_ADDRESS)
+            .call()
+            .await?,
+        wld_target(),
+        "the top-up should restore the full target allowance"
+    );
+    assert!(migration.end_state_holds().await?);
+
+    drop(std::fs::remove_dir_all(&root));
+    Ok(())
+}

--- a/bedrock/tests/test_tfh_paymaster_approval_migration.rs
+++ b/bedrock/tests/test_tfh_paymaster_approval_migration.rs
@@ -115,7 +115,8 @@ async fn paymaster_spends(
 
 #[tokio::test]
 async fn test_tfh_paymaster_approval_migration_full_flow() -> anyhow::Result<()> {
-    // 1) The migration only exists off production, so configure staging first.
+    // 1) Staging: `WalletMigrationController` only registers this off
+    //    production, and `set_erc20_balance_with_slot` needs a config anyway.
     let root = std::env::temp_dir()
         .join(format!("bedrock-tfh-paymaster-it-{}", std::process::id()));
     set_config(
@@ -154,8 +155,7 @@ async fn test_tfh_paymaster_approval_migration_full_flow() -> anyhow::Result<()>
         owner_key_hex,
         &safe_address.to_string(),
     )?);
-    let migration = TfhPaymasterApprovalMigration::new(safe_account)
-        .expect("staging must construct the migration");
+    let migration = TfhPaymasterApprovalMigration::new(safe_account);
     assert_eq!(migration.migration_id(), "wallet.tfh_paymaster.approval.v1");
 
     let wld = IERC20::new(WLD_ADDRESS, &provider);


### PR DESCRIPTION
## What

A wallet migration that keeps the TFH multi-token paymaster's ERC-20 allowance topped up, so it can charge for gas in WLD or USDC.

> [!IMPORTANT]
> **Staging and sandbox only.** `TfhPaymasterApprovalMigration::new` returns `None` on production, so the migration cannot be constructed there — let alone registered, observed, or submitted. No record for it is ever written on production.

## The rule

A token is topped up when **both** hold:

1. the Safe has a non-zero balance of it, and
2. its allowance to the paymaster has fallen below **half** the target.

| Token | Target allowance | Tops up below |
| --- | --- | --- |
| WLD | 100 × 10¹⁸ | 50 WLD |
| USDC | 30 × 10⁶ | 15 USDC |

Both conditions are **per token**: a Safe holding only WLD gets WLD approved and USDC left untouched.

Approvals are for the **exact target, never `uint256::max`**. The paymaster spends the allowance down, and because the framework re-observes on every launch, the migration comes back and tops it up once it crosses below half. Convergence is not a terminal state here — it is the steady state between top-ups.

## Paymaster address

`0xBF09Bc530dc29623c3cE171A4D9bf03edafE763c` — the multi-token (WLD + USDC) deployment, from temporal-apps `e37f93a`, corroborated across `world-app-helper-contracts` and `crypto-apps`. The previous `0x161F475B…` is drained with its stake unlocked and can no longer sponsor.

## How production is excluded

The gate is in the constructor rather than a runtime check, so there is no path that reaches a submission:

```rust
pub fn new(safe_account: Arc<SafeSmartAccount>) -> Option<Self> {
    match current_environment_or_default() {
        BedrockEnvironment::Staging | BedrockEnvironment::Sandbox => Some(Self { safe_account }),
        BedrockEnvironment::Production => None,
    }
}
```

`current_environment_or_default()` returns `Production` when the config is uninitialized, so an **unknown** environment also declines. `WalletMigrationController::new` only pushes the migration when the constructor yields one.

`test_production_never_constructs` covers both refusals — uninitialized, then explicitly `Production`. It runs in a **fresh child process**, because the config is a process-wide `OnceLock` and the test binary is configured as staging for every other test.

## New shared pieces

- **`BatchErc20Approval`** (`contracts/erc20.rs`) — batched `approve(spender, amount)` via `MultiSend`, with the spender, the per-token amounts, and the nonce's transaction class all chosen by the caller. `BatchPermit2Approval` could not serve: it hardcodes the Permit2 spender and `U256::MAX`. It is left untouched rather than refactored onto this, to keep a shipped path out of the diff.
- **`TransactionTypeId::TfhPaymasterApprove = 141`** — appended, so no existing value moves. The enum's docs call out that downstream systems depend on the exact numbers.
- **`TFH_PAYMASTER_ADDRESS`**, and `Erc20::encode_balance_of`.

## Observation

One `eth_call_batched` per pass — `balanceOf` and `allowance` for each token, four calls in one Multicall3 round trip. `reconcile` reuses the value, so a healthy launch reads the chain once, and the gap is a local rather than a field.

## Tests

**Unit (5):** the id, both targets against `100e18` / `30e6`, both halves as the trigger, staging constructs, and the production refusal in a fresh process.

**Anvil, against a WorldChain fork** (`test_tfh_paymaster_approval_migration_full_flow`), walking the rule end to end:

1. No balances → nothing to approve, even with a zero allowance.
2. WLD only → WLD approved to exactly 100, **USDC allowance still zero**.
3. USDC funded → USDC approved to exactly 30, WLD left alone.
4. The paymaster impersonates itself and `transferFrom`s 10 WLD → 90 is still above half, so nothing happens.
5. It spends past half → the gap reopens and the top-up restores the full 100.

Step 4/5 drains the allowance the way production does, rather than writing the slot directly.

Also verified: `cargo clippy --all-targets --all-features` clean, 408 lib tests, the three pre-existing migration integration tests, and a `--no-default-features` build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Submits on-chain ERC-20 approvals from user Safes on staging/sandbox; production is gated off, but mistaken environment config or allowance logic could approve the paymaster for real token balances in non-prod wallets.
> 
> **Overview**
> Adds **`TfhPaymasterApprovalMigration`**, which observes WLD/USDC balances and paymaster allowances on World Chain and submits batched ERC-20 approvals when the Safe holds a token and allowance drops below half the target (100 WLD / 30 USDC, finite amounts—not max). **`WalletMigrationController`** only registers this migration in **staging and sandbox**; production and uninitialized config keep the existing two migrations.
> 
> Introduces **`BatchErc20Approval`** (MultiSend batched `approve` with caller-chosen spender, amounts, and `TransactionTypeId`). The Permit2 wallet migration now uses it instead of removed **`BatchPermit2Approval`**; the paymaster migration uses **`TfhPaymasterApprove`** and **`TFH_PAYMASTER_ADDRESS`**. Adds **`Erc20::encode_balance_of`**, unit/controller tests (including a child-process check that production omits the migration), and an Anvil fork integration test for the full top-up/drain cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30b8f6023e262699c4a311b4b5978b8d8a3201d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->