### PR TITLE
refactor(rpc): preserve structured error responses

### DIFF
--- a/bedrock/src/transactions/custom_bundler.rs
+++ b/bedrock/src/transactions/custom_bundler.rs
@@ -20,7 +20,7 @@ use crate::{
     smart_account::{SafeSmartAccount, UserOperation, ENTRYPOINT_4337},
     transactions::{
         foreign::UnparsedUserOperation,
-        rpc::{ErrorPayload, Id, JsonRpcRequest, RpcError, RpcMethod},
+        rpc::{Id, JsonRpcError, JsonRpcRequest, RpcError, RpcMethod},
         TransactionError,
     },
 };
@@ -164,7 +164,7 @@ fn parse_json_rpc_response(response_bytes: &[u8]) -> Result<Value, RpcError> {
         serde_json::from_slice(response_bytes).map_err(|_| RpcError::JsonError)?;
 
     if let Some(error) = json.get("error") {
-        let ep: ErrorPayload =
+        let ep: JsonRpcError =
             serde_json::from_value(error.clone()).map_err(|_| RpcError::JsonError)?;
         return Err(RpcError::RpcResponseError {
             code: ep.code,

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -18,18 +18,18 @@ use alloy::{hex::FromHex, providers::MULTICALL3_ADDRESS};
 
 pub use crate::primitives::contracts::IMulticall3;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{Map, Value};
 use std::sync::{Arc, OnceLock};
 
 mod wire;
 
-pub(crate) use wire::{ErrorPayload, JsonRpcRequest};
 pub use wire::{
     Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
     RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
     WaGetUserOperationReceiptResponse,
 };
+pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
 
 #[cfg(test)]
 mod tests;
@@ -82,6 +82,38 @@ pub enum RpcError {
     /// Safe Smart Account operation error
     #[error("Safe Smart Account operation failed: {0}")]
     SafeSmartAccountError(String),
+}
+
+impl From<JsonRpcError> for RpcError {
+    fn from(error: JsonRpcError) -> Self {
+        Self::RpcResponseError {
+            code: error.code,
+            error_message: error.message,
+        }
+    }
+}
+
+/// Internal RPC failure that preserves structured JSON-RPC error responses.
+#[derive(Debug)]
+pub(crate) enum RpcCallError {
+    Rpc(RpcError),
+    Response(JsonRpcError),
+}
+
+impl From<RpcError> for RpcCallError {
+    fn from(error: RpcError) -> Self {
+        Self::Rpc(error)
+    }
+}
+
+impl From<RpcCallError> for RpcError {
+    fn from(error: RpcCallError) -> Self {
+        match error {
+            RpcCallError::Rpc(error) => error,
+            // Preserve the existing public error shape at API boundaries.
+            RpcCallError::Response(error) => error.into(),
+        }
+    }
 }
 
 impl From<HttpError> for RpcError {
@@ -143,10 +175,10 @@ impl RpcClient {
         method: RpcMethod,
         params: P,
         provider: RpcProviderName,
-    ) -> Result<R, RpcError>
+    ) -> Result<R, RpcCallError>
     where
         P: Serialize,
-        R: for<'de> Deserialize<'de>,
+        R: DeserializeOwned,
     {
         // unique request ID
         let id = Id::String(format!("tx_{}", hex::encode(rand::random::<[u8; 16]>())));
@@ -171,20 +203,18 @@ impl RpcClient {
             .http_client
             .as_ref()
             .fetch_from_app_backend(endpoint, HttpMethod::Post, headers, Some(request))
-            .await?;
+            .await
+            .map_err(RpcError::from)?;
 
         let json_response: Value =
             serde_json::from_slice(&response_bytes).map_err(|_| RpcError::JsonError)?;
 
         // Check if it's an error response
         if let Some(error) = json_response.get("error") {
-            let error_payload: ErrorPayload = serde_json::from_value(error.clone())
+            let error_payload: JsonRpcError = serde_json::from_value(error.clone())
                 .map_err(|_| RpcError::JsonError)?;
 
-            return Err(RpcError::RpcResponseError {
-                code: error_payload.code,
-                error_message: error_payload.message,
-            });
+            return Err(RpcCallError::Response(error_payload));
         }
 
         json_response.get("result").map_or_else(
@@ -192,10 +222,12 @@ impl RpcClient {
                 Err(RpcError::InvalidResponse {
                     error_message: "Response missing both 'result' and 'error' fields"
                         .to_string(),
-                })
+                }
+                .into())
             },
             |result| {
-                serde_json::from_value(result.clone()).map_err(|_| RpcError::JsonError)
+                serde_json::from_value(result.clone())
+                    .map_err(|_| RpcError::JsonError.into())
             },
         )
     }
@@ -230,6 +262,7 @@ impl RpcClient {
 
         self.rpc_call(network, RpcMethod::SponsorUserOperation, params, provider)
             .await
+            .map_err(RpcError::from)
     }
 
     /// Requests sponsorship for a `UserOperation` via `pm_sponsorUserOperation` (V2)
@@ -266,6 +299,7 @@ impl RpcClient {
             RpcProviderName::Any,
         )
         .await
+        .map_err(RpcError::from)
     }
 
     /// Submits a signed `UserOperation` via `eth_sendUserOperation`
@@ -363,6 +397,7 @@ impl RpcClient {
             RpcProviderName::Any,
         )
         .await
+        .map_err(RpcError::from)
     }
 
     /// Makes multiple read calls in a single `eth_call` via Multicall3 `aggregate3`.
@@ -508,6 +543,7 @@ impl RpcClient {
             RpcProviderName::Any,
         )
         .await
+        .map_err(RpcError::from)
     }
 }
 

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -2,6 +2,23 @@ use super::*;
 use alloy::primitives::{address, bytes, U128, U256};
 use serde_json::json;
 
+struct StaticHttpClient {
+    response: Vec<u8>,
+}
+
+#[async_trait::async_trait]
+impl AuthenticatedHttpClient for StaticHttpClient {
+    async fn fetch_from_app_backend(
+        &self,
+        _url: String,
+        _method: HttpMethod,
+        _headers: Vec<HttpHeader>,
+        _body: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, HttpError> {
+        Ok(self.response.clone())
+    }
+}
+
 #[test]
 fn test_sponsor_response_parsing() {
     let json_response = json!({
@@ -28,17 +45,54 @@ fn test_sponsor_response_parsing() {
 }
 
 #[test]
-fn test_error_payload_parsing() {
+fn test_json_rpc_error_without_data() {
     let error_json = json!({
         "code": -32000,
         "message": "execution reverted",
         "data": null
     });
 
-    let error_payload: ErrorPayload = serde_json::from_value(error_json).unwrap();
+    let error_payload: JsonRpcError = serde_json::from_value(error_json).unwrap();
 
     assert_eq!(error_payload.code, -32000);
     assert_eq!(error_payload.message, "execution reverted");
+    assert_eq!(error_payload.data, None);
+}
+
+#[tokio::test]
+async fn test_rpc_call_preserves_structured_error_data() {
+    let data = json!({
+        "retryable": true,
+        "reason": "policy_limit",
+    });
+    let response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "tx_test",
+        "error": {
+            "code": -32000,
+            "message": "request declined",
+            "data": data,
+        },
+    }))
+    .unwrap();
+    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
+
+    let error = client
+        .rpc_call::<_, Value>(
+            Network::WorldChain,
+            RpcMethod::PmSponsorUserOperation,
+            Vec::<Value>::new(),
+            RpcProviderName::Any,
+        )
+        .await
+        .unwrap_err();
+
+    let RpcCallError::Response(error) = error else {
+        panic!("expected a JSON-RPC response error");
+    };
+    assert_eq!(error.code, -32000);
+    assert_eq!(error.message, "request declined");
+    assert_eq!(error.data, Some(data));
 }
 
 #[test]

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -88,13 +88,12 @@ impl<T> JsonRpcRequest<T> {
     }
 }
 
-/// JSON-RPC error payload, shared with [`crate::transactions::custom_bundler`].
+/// JSON-RPC error response, shared with [`crate::transactions::custom_bundler`].
 #[derive(Debug, Deserialize)]
-pub struct ErrorPayload {
+pub struct JsonRpcError {
     pub code: i64,
     pub message: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub data: Option<Value>,
 }
 


### PR DESCRIPTION
Makes the internal `rpc_call` retain the complete JSON-RPC error response, including optional structured `data`. Existing public RPC methods continue converting errors to the current `RpcError` shape, so their behavior and API remain unchanged.

This provides a lossless internal boundary for callers that need to interpret structured errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of internal RPC error typing with public APIs unchanged; risk is limited to subtle error-handling regressions inside `rpc_call`.
> 
> **Overview**
> **Internal `rpc_call` now keeps full JSON-RPC errors** instead of collapsing them into `RpcError::RpcResponseError` immediately. JSON-RPC failures return `RpcCallError::Response` carrying `JsonRpcError` (renamed from `ErrorPayload`), including optional structured **`data`**.
> 
> Public RPC helpers still surface **`RpcError`** via `map_err(RpcError::from)`, so external behavior stays the same: `RpcResponseError` only exposes **code** and **message** (`data` is dropped at the API boundary). `From<JsonRpcError>` for `RpcError` encodes that mapping.
> 
> `custom_bundler` parsing follows the **`JsonRpcError`** rename. Tests add a stub HTTP client and assert **`rpc_call` preserves `error.data`** for structured declines (e.g. policy/retry hints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be8c4732d3f3a82d0084a01fc68f06af8224882d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->