### PR TITLE
chore(rpc): parse sponsorship decline responses

### DIFF
--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -27,8 +27,7 @@ mod wire;
 pub use wire::{
     Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
     RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
-    SponsorshipDeclineDetails, SponsorshipDeclineReason,
-    WaGetUserOperationReceiptResponse,
+    SponsorshipDecline, SponsorshipDeclineReason, WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
 
@@ -40,17 +39,6 @@ static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
 
 const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
 const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
-
-/// A protocol-sponsorship decline with its JSON-RPC envelope intact.
-#[derive(Debug, PartialEq, Eq)]
-pub struct SponsorshipDecline {
-    /// JSON-RPC error code.
-    pub code: i64,
-    /// JSON-RPC error message.
-    pub error_message: String,
-    /// Parsed sponsorship-decline data.
-    pub details: SponsorshipDeclineDetails,
-}
 
 impl TryFrom<JsonRpcError> for SponsorshipDecline {
     type Error = JsonRpcError;
@@ -65,15 +53,11 @@ impl TryFrom<JsonRpcError> for SponsorshipDecline {
         let Some(data) = error.data.as_ref() else {
             return Err(error);
         };
-        let Ok(details) = serde_json::from_value(data.clone()) else {
+        let Ok(decline) = serde_json::from_value(data.clone()) else {
             return Err(error);
         };
 
-        Ok(Self {
-            code: error.code,
-            error_message: error.message,
-            details,
-        })
+        Ok(decline)
     }
 }
 
@@ -157,15 +141,6 @@ impl From<RpcCallError> for RpcError {
     }
 }
 
-impl From<SponsorshipDecline> for RpcError {
-    fn from(decline: SponsorshipDecline) -> Self {
-        Self::RpcResponseError {
-            code: decline.code,
-            error_message: decline.error_message,
-        }
-    }
-}
-
 impl From<HttpError> for RpcError {
     fn from(e: HttpError) -> Self {
         Self::HttpError(e.to_string())
@@ -184,9 +159,12 @@ impl From<SafeSmartAccountError> for RpcError {
     }
 }
 
+/// Result of requesting paymaster sponsorship for a user operation.
 #[derive(Debug)]
-pub(crate) enum PmSponsorUserOperationOutcome {
+pub enum PmSponsorUserOperationOutcome {
+    /// Sponsorship was approved with the returned gas and paymaster fields.
     Sponsored(PmSponsorUserOperationResponse),
+    /// Protocol sponsorship was declined with a self-sponsorship advisory.
     Declined(SponsorshipDecline),
 }
 
@@ -335,31 +313,14 @@ impl RpcClient {
     /// - The HTTP request fails
     /// - The request serialization fails
     /// - The response parsing fails
-    /// - The RPC returns an error response
+    /// - The RPC returns an unexpected error response
     pub async fn pm_sponsor_user_operation(
         &self,
         network: Network,
         user_operation: &UserOperation,
         entry_point: Address,
         context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationResponse, RpcError> {
-        match self
-            .request_pm_sponsorship(network, user_operation, entry_point, context)
-            .await
-            .map_err(RpcError::from)?
-        {
-            PmSponsorUserOperationOutcome::Sponsored(response) => Ok(response),
-            PmSponsorUserOperationOutcome::Declined(decline) => Err(decline.into()),
-        }
-    }
-
-    pub(crate) async fn request_pm_sponsorship(
-        &self,
-        network: Network,
-        user_operation: &UserOperation,
-        entry_point: Address,
-        context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationOutcome, RpcCallError> {
+    ) -> Result<PmSponsorUserOperationOutcome, RpcError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
@@ -378,10 +339,10 @@ impl RpcClient {
             Err(RpcCallError::Response(error)) => {
                 match SponsorshipDecline::try_from(error) {
                     Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
-                    Err(error) => Err(RpcCallError::Response(error)),
+                    Err(error) => Err(error.into()),
                 }
             }
-            Err(error) => Err(error),
+            Err(RpcCallError::Rpc(error)) => Err(error),
         }
     }
 

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -25,9 +25,10 @@ use std::sync::{Arc, OnceLock};
 mod wire;
 
 pub use wire::{
-    Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
-    RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
-    SponsorshipDecline, SponsorshipDeclineReason, WaGetUserOperationReceiptResponse,
+    Id, PmSponsorshipApproval, PmSponsorshipDecline, PmSponsorshipDeclineReason,
+    RelaySafeTransactionRequest, RpcMethod, RpcProviderName,
+    SponsorUserOperationResponse, SponsorshipContext,
+    WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
 
@@ -40,7 +41,7 @@ static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
 const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
 const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
 
-impl TryFrom<JsonRpcError> for SponsorshipDecline {
+impl TryFrom<JsonRpcError> for PmSponsorshipDecline {
     type Error = JsonRpcError;
 
     fn try_from(error: JsonRpcError) -> Result<Self, Self::Error> {
@@ -159,13 +160,13 @@ impl From<SafeSmartAccountError> for RpcError {
     }
 }
 
-/// Result of requesting paymaster sponsorship for a user operation.
+/// Response from requesting paymaster sponsorship for a user operation.
 #[derive(Debug)]
-pub enum PmSponsorUserOperationOutcome {
+pub enum PmSponsorUserOperationResponse {
     /// Sponsorship was approved with the returned gas and paymaster fields.
-    Sponsored(PmSponsorUserOperationResponse),
+    Approved(PmSponsorshipApproval),
     /// Protocol sponsorship was declined with a self-sponsorship advisory.
-    Declined(SponsorshipDecline),
+    Declined(PmSponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests
@@ -320,7 +321,7 @@ impl RpcClient {
         user_operation: &UserOperation,
         entry_point: Address,
         context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationOutcome, RpcError> {
+    ) -> Result<PmSponsorUserOperationResponse, RpcError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
@@ -335,10 +336,12 @@ impl RpcClient {
             )
             .await
         {
-            Ok(response) => Ok(PmSponsorUserOperationOutcome::Sponsored(response)),
+            Ok(response) => Ok(PmSponsorUserOperationResponse::Approved(response)),
             Err(RpcCallError::Response(error)) => {
-                match SponsorshipDecline::try_from(error) {
-                    Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
+                match PmSponsorshipDecline::try_from(error) {
+                    Ok(decline) => {
+                        Ok(PmSponsorUserOperationResponse::Declined(decline))
+                    }
                     Err(error) => Err(error.into()),
                 }
             }

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -25,9 +25,9 @@ use std::sync::{Arc, OnceLock};
 mod wire;
 
 pub use wire::{
-    Id, PmSponsorshipApproval, PmSponsorshipDecline, PmSponsorshipDeclineReason,
-    RelaySafeTransactionRequest, RpcMethod, RpcProviderName,
-    SponsorUserOperationResponse, SponsorshipContext,
+    Id, PmSponsorUserOperationResponse, PmSponsorshipApproval, PmSponsorshipDecline,
+    PmSponsorshipDeclineReason, RelaySafeTransactionRequest, RpcMethod,
+    RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
     WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
@@ -158,15 +158,6 @@ impl From<SafeSmartAccountError> for RpcError {
     fn from(e: SafeSmartAccountError) -> Self {
         Self::SafeSmartAccountError(e.to_string())
     }
-}
-
-/// Response from requesting paymaster sponsorship for a user operation.
-#[derive(Debug)]
-pub enum PmSponsorUserOperationResponse {
-    /// Sponsorship was approved with the returned gas and paymaster fields.
-    Approved(PmSponsorshipApproval),
-    /// Protocol sponsorship was declined with a self-sponsorship advisory.
-    Declined(PmSponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -27,6 +27,7 @@ mod wire;
 pub use wire::{
     Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
     RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
+    SponsorshipDeclineDetails, SponsorshipDeclineReason,
     WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
@@ -36,6 +37,46 @@ mod tests;
 
 /// Global RPC client instance for Bedrock operations
 static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
+
+const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
+const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
+
+/// A protocol-sponsorship decline with its JSON-RPC envelope intact.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SponsorshipDecline {
+    /// JSON-RPC error code.
+    pub code: i64,
+    /// JSON-RPC error message.
+    pub error_message: String,
+    /// Parsed sponsorship-decline data.
+    pub details: SponsorshipDeclineDetails,
+}
+
+impl TryFrom<JsonRpcError> for SponsorshipDecline {
+    type Error = JsonRpcError;
+
+    fn try_from(error: JsonRpcError) -> Result<Self, Self::Error> {
+        if error.code != SPONSORSHIP_DECLINED_CODE
+            || error.message != SPONSORSHIP_DECLINED_MESSAGE
+        {
+            return Err(error);
+        }
+
+        let Some(data) = error.data.as_ref() else {
+            return Err(error);
+        };
+        let Ok(details) = serde_json::from_value(data.clone()) else {
+            return Err(error);
+        };
+
+        Ok(Self {
+            code: error.code,
+            error_message: error.message,
+            details,
+        })
+    }
+}
+
 /// Errors that can occur when interacting with RPC operations.
 #[crate::bedrock_error]
 
@@ -116,6 +157,15 @@ impl From<RpcCallError> for RpcError {
     }
 }
 
+impl From<SponsorshipDecline> for RpcError {
+    fn from(decline: SponsorshipDecline) -> Self {
+        Self::RpcResponseError {
+            code: decline.code,
+            error_message: decline.error_message,
+        }
+    }
+}
+
 impl From<HttpError> for RpcError {
     fn from(e: HttpError) -> Self {
         Self::HttpError(e.to_string())
@@ -132,6 +182,12 @@ impl From<SafeSmartAccountError> for RpcError {
     fn from(e: SafeSmartAccountError) -> Self {
         Self::SafeSmartAccountError(e.to_string())
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum PmSponsorUserOperationOutcome {
+    Sponsored(PmSponsorUserOperationResponse),
+    Declined(SponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests
@@ -287,19 +343,46 @@ impl RpcClient {
         entry_point: Address,
         context: &SponsorshipContext,
     ) -> Result<PmSponsorUserOperationResponse, RpcError> {
+        match self
+            .request_pm_sponsorship(network, user_operation, entry_point, context)
+            .await
+            .map_err(RpcError::from)?
+        {
+            PmSponsorUserOperationOutcome::Sponsored(response) => Ok(response),
+            PmSponsorUserOperationOutcome::Declined(decline) => Err(decline.into()),
+        }
+    }
+
+    pub(crate) async fn request_pm_sponsorship(
+        &self,
+        network: Network,
+        user_operation: &UserOperation,
+        entry_point: Address,
+        context: &SponsorshipContext,
+    ) -> Result<PmSponsorUserOperationOutcome, RpcCallError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
             context.to_json_value(),
         ];
-        self.rpc_call(
-            network,
-            RpcMethod::PmSponsorUserOperation,
-            params,
-            RpcProviderName::Any,
-        )
-        .await
-        .map_err(RpcError::from)
+        match self
+            .rpc_call(
+                network,
+                RpcMethod::PmSponsorUserOperation,
+                params,
+                RpcProviderName::Any,
+            )
+            .await
+        {
+            Ok(response) => Ok(PmSponsorUserOperationOutcome::Sponsored(response)),
+            Err(RpcCallError::Response(error)) => {
+                match SponsorshipDecline::try_from(error) {
+                    Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
+                    Err(error) => Err(RpcCallError::Response(error)),
+                }
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Submits a signed `UserOperation` via `eth_sendUserOperation`

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -95,6 +95,127 @@ async fn test_rpc_call_preserves_structured_error_data() {
     assert_eq!(error.data, Some(data));
 }
 
+#[tokio::test]
+async fn test_request_pm_sponsorship_returns_typed_decline() {
+    let response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "tx_test",
+        "error": {
+            "code": SPONSORSHIP_DECLINED_CODE,
+            "message": SPONSORSHIP_DECLINED_MESSAGE,
+            "data": {
+                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+                "reason": "gas_usage",
+            },
+        },
+    }))
+    .unwrap();
+    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
+
+    let outcome = client
+        .request_pm_sponsorship(
+            Network::WorldChain,
+            &UserOperation::default(),
+            Address::ZERO,
+            &SponsorshipContext::Protocol,
+        )
+        .await
+        .unwrap();
+
+    let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
+        panic!("expected sponsorship to be declined");
+    };
+    assert_eq!(decline.code, SPONSORSHIP_DECLINED_CODE);
+    assert_eq!(decline.error_message, SPONSORSHIP_DECLINED_MESSAGE);
+    assert_eq!(
+        decline.details.token,
+        address!("2cfc85d8e48f8eab294be644d9e25c3030863003")
+    );
+    assert_eq!(
+        decline.details.paymaster_address,
+        address!("0000000000000039cd5e8ae05257ce51c473ddd1")
+    );
+    assert_eq!(decline.details.reason, SponsorshipDeclineReason::GasUsage);
+}
+
+#[tokio::test]
+async fn test_pm_sponsor_user_operation_preserves_public_error() {
+    let response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "tx_test",
+        "error": {
+            "code": SPONSORSHIP_DECLINED_CODE,
+            "message": SPONSORSHIP_DECLINED_MESSAGE,
+            "data": {
+                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+                "reason": "gas_usage",
+            },
+        },
+    }))
+    .unwrap();
+    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
+
+    let error = client
+        .pm_sponsor_user_operation(
+            Network::WorldChain,
+            &UserOperation::default(),
+            Address::ZERO,
+            &SponsorshipContext::Protocol,
+        )
+        .await
+        .unwrap_err();
+
+    let RpcError::RpcResponseError {
+        code,
+        error_message,
+    } = error
+    else {
+        panic!("expected the legacy JSON-RPC error");
+    };
+    assert_eq!(code, SPONSORSHIP_DECLINED_CODE);
+    assert_eq!(error_message, SPONSORSHIP_DECLINED_MESSAGE);
+}
+
+#[test]
+fn test_malformed_sponsorship_decline_preserves_rpc_error() {
+    let data = json!({
+        "token": "not-an-address",
+        "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+        "reason": "gas_usage",
+    });
+    let error = JsonRpcError {
+        code: SPONSORSHIP_DECLINED_CODE,
+        message: SPONSORSHIP_DECLINED_MESSAGE.to_string(),
+        data: Some(data.clone()),
+    };
+
+    let error = SponsorshipDecline::try_from(error).unwrap_err();
+
+    assert_eq!(error.data, Some(data));
+}
+
+#[test]
+fn test_sponsorship_decline_preserves_unknown_reason() {
+    let error = JsonRpcError {
+        code: SPONSORSHIP_DECLINED_CODE,
+        message: SPONSORSHIP_DECLINED_MESSAGE.to_string(),
+        data: Some(json!({
+            "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+            "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+            "reason": "new_policy",
+        })),
+    };
+
+    let decline = SponsorshipDecline::try_from(error).unwrap();
+
+    assert_eq!(
+        decline.details.reason,
+        SponsorshipDeclineReason::Unknown("new_policy".to_string())
+    );
+}
+
 #[test]
 fn test_user_operation_serialization_with_null_fields() {
     let user_op = UserOperation {

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -123,7 +123,7 @@ async fn test_pm_sponsor_user_operation_returns_typed_decline() {
         .await
         .unwrap();
 
-    let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
+    let PmSponsorUserOperationResponse::Declined(decline) = outcome else {
         panic!("expected sponsorship to be declined");
     };
     assert_eq!(
@@ -134,7 +134,7 @@ async fn test_pm_sponsor_user_operation_returns_typed_decline() {
         decline.paymaster_address,
         address!("0000000000000039cd5e8ae05257ce51c473ddd1")
     );
-    assert_eq!(decline.reason, SponsorshipDeclineReason::GasUsage);
+    assert_eq!(decline.reason, PmSponsorshipDeclineReason::GasUsage);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn test_malformed_sponsorship_decline_preserves_rpc_error() {
         data: Some(data.clone()),
     };
 
-    let error = SponsorshipDecline::try_from(error).unwrap_err();
+    let error = PmSponsorshipDecline::try_from(error).unwrap_err();
 
     assert_eq!(error.data, Some(data));
 }
@@ -167,11 +167,11 @@ fn test_sponsorship_decline_preserves_unknown_reason() {
         })),
     };
 
-    let decline = SponsorshipDecline::try_from(error).unwrap();
+    let decline = PmSponsorshipDecline::try_from(error).unwrap();
 
     assert_eq!(
         decline.reason,
-        SponsorshipDeclineReason::Unknown("new_policy".to_string())
+        PmSponsorshipDeclineReason::Unknown("new_policy".to_string())
     );
 }
 
@@ -361,8 +361,7 @@ fn test_pm_sponsor_response_parsing() {
         "maxFeePerGas": "0x0",
         "maxPriorityFeePerGas": "0x0",
     });
-    let r: PmSponsorUserOperationResponse =
-        serde_json::from_value(no_paymaster).unwrap();
+    let r: PmSponsorshipApproval = serde_json::from_value(no_paymaster).unwrap();
     assert_eq!(r.call_gas_limit, U128::ZERO);
     assert_eq!(r.verification_gas_limit, U128::ZERO);
     assert_eq!(r.pre_verification_gas, U256::ZERO);
@@ -386,8 +385,7 @@ fn test_pm_sponsor_response_parsing() {
         "paymasterPostOpGasLimit": "0x706e",
         "paymasterData": "0x01000066d1a1a4",
     });
-    let r: PmSponsorUserOperationResponse =
-        serde_json::from_value(with_paymaster).unwrap();
+    let r: PmSponsorshipApproval = serde_json::from_value(with_paymaster).unwrap();
     assert_eq!(
         r.paymaster,
         Some(address!("0000000000000039cd5e8aE05257CE51C473ddd1"))

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -96,7 +96,7 @@ async fn test_rpc_call_preserves_structured_error_data() {
 }
 
 #[tokio::test]
-async fn test_request_pm_sponsorship_returns_typed_decline() {
+async fn test_pm_sponsor_user_operation_returns_typed_decline() {
     let response = serde_json::to_vec(&json!({
         "jsonrpc": "2.0",
         "id": "tx_test",
@@ -114,7 +114,7 @@ async fn test_request_pm_sponsorship_returns_typed_decline() {
     let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
 
     let outcome = client
-        .request_pm_sponsorship(
+        .pm_sponsor_user_operation(
             Network::WorldChain,
             &UserOperation::default(),
             Address::ZERO,
@@ -126,56 +126,15 @@ async fn test_request_pm_sponsorship_returns_typed_decline() {
     let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
         panic!("expected sponsorship to be declined");
     };
-    assert_eq!(decline.code, SPONSORSHIP_DECLINED_CODE);
-    assert_eq!(decline.error_message, SPONSORSHIP_DECLINED_MESSAGE);
     assert_eq!(
-        decline.details.token,
+        decline.token,
         address!("2cfc85d8e48f8eab294be644d9e25c3030863003")
     );
     assert_eq!(
-        decline.details.paymaster_address,
+        decline.paymaster_address,
         address!("0000000000000039cd5e8ae05257ce51c473ddd1")
     );
-    assert_eq!(decline.details.reason, SponsorshipDeclineReason::GasUsage);
-}
-
-#[tokio::test]
-async fn test_pm_sponsor_user_operation_preserves_public_error() {
-    let response = serde_json::to_vec(&json!({
-        "jsonrpc": "2.0",
-        "id": "tx_test",
-        "error": {
-            "code": SPONSORSHIP_DECLINED_CODE,
-            "message": SPONSORSHIP_DECLINED_MESSAGE,
-            "data": {
-                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
-                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
-                "reason": "gas_usage",
-            },
-        },
-    }))
-    .unwrap();
-    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
-
-    let error = client
-        .pm_sponsor_user_operation(
-            Network::WorldChain,
-            &UserOperation::default(),
-            Address::ZERO,
-            &SponsorshipContext::Protocol,
-        )
-        .await
-        .unwrap_err();
-
-    let RpcError::RpcResponseError {
-        code,
-        error_message,
-    } = error
-    else {
-        panic!("expected the legacy JSON-RPC error");
-    };
-    assert_eq!(code, SPONSORSHIP_DECLINED_CODE);
-    assert_eq!(error_message, SPONSORSHIP_DECLINED_MESSAGE);
+    assert_eq!(decline.reason, SponsorshipDeclineReason::GasUsage);
 }
 
 #[test]
@@ -211,7 +170,7 @@ fn test_sponsorship_decline_preserves_unknown_reason() {
     let decline = SponsorshipDecline::try_from(error).unwrap();
 
     assert_eq!(
-        decline.details.reason,
+        decline.reason,
         SponsorshipDeclineReason::Unknown("new_policy".to_string())
     );
 }

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -100,18 +100,18 @@ pub struct JsonRpcError {
 /// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct SponsorshipDecline {
+pub struct PmSponsorshipDecline {
     /// ERC-20 token the user can use to pay the transaction fee.
     pub token: Address,
     /// Paymaster contract that accepts the fee token.
     pub paymaster_address: Address,
     /// Policy reason for declining protocol sponsorship.
-    pub reason: SponsorshipDeclineReason,
+    pub reason: PmSponsorshipDeclineReason,
 }
 
-/// Reason protocol sponsorship was declined.
+/// Reason a `pm_sponsorUserOperation` request was declined.
 #[derive(Debug, PartialEq, Eq)]
-pub enum SponsorshipDeclineReason {
+pub enum PmSponsorshipDeclineReason {
     /// The L2 base fee exceeded the sponsorship threshold.
     L2BaseFee,
     /// The L1 data fee exceeded the sponsorship threshold.
@@ -124,7 +124,7 @@ pub enum SponsorshipDeclineReason {
     Unknown(String),
 }
 
-impl<'de> Deserialize<'de> for SponsorshipDeclineReason {
+impl<'de> Deserialize<'de> for PmSponsorshipDeclineReason {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -166,7 +166,7 @@ pub struct SponsorUserOperationResponse {
     pub provider_name: RpcProviderName,
 }
 
-/// Response from `pm_sponsorUserOperation` (V2)
+/// Approved sponsorship fields returned by `pm_sponsorUserOperation` (V2).
 ///
 /// Paymaster fields (`paymaster`, `paymaster_data`,
 /// `paymaster_verification_gas_limit`, `paymaster_post_op_gas_limit`) are
@@ -176,7 +176,7 @@ pub struct SponsorUserOperationResponse {
 /// `Option<T>` so both shapes deserialize.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PmSponsorUserOperationResponse {
+pub struct PmSponsorshipApproval {
     /// Call gas limit
     pub call_gas_limit: U128,
     /// Verification gas limit

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -97,6 +97,15 @@ pub struct JsonRpcError {
     pub data: Option<Value>,
 }
 
+/// Response from requesting paymaster sponsorship for a user operation.
+#[derive(Debug)]
+pub enum PmSponsorUserOperationResponse {
+    /// Sponsorship was approved with the returned gas and paymaster fields.
+    Approved(PmSponsorshipApproval),
+    /// Protocol sponsorship was declined with a self-sponsorship advisory.
+    Declined(PmSponsorshipDecline),
+}
+
 /// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::{Address, Bytes, U128, U256};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 /// JSON-RPC request ID
@@ -95,6 +95,49 @@ pub struct JsonRpcError {
     pub message: String,
     #[serde(default)]
     pub data: Option<Value>,
+}
+
+/// Structured details returned when protocol sponsorship is declined.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SponsorshipDeclineDetails {
+    /// ERC-20 token the user can use to pay the transaction fee.
+    pub token: Address,
+    /// Paymaster contract that accepts the fee token.
+    pub paymaster_address: Address,
+    /// Policy reason for declining protocol sponsorship.
+    pub reason: SponsorshipDeclineReason,
+}
+
+/// Reason protocol sponsorship was declined.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SponsorshipDeclineReason {
+    /// The L2 base fee exceeded the sponsorship threshold.
+    L2BaseFee,
+    /// The L1 data fee exceeded the sponsorship threshold.
+    L1DataFee,
+    /// The user's transaction count exceeded the sponsorship threshold.
+    TransactionCount,
+    /// The estimated gas usage exceeded the sponsorship threshold.
+    GasUsage,
+    /// A reason introduced by a newer sponsorship service.
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for SponsorshipDeclineReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "l2_base_fee" => Self::L2BaseFee,
+            "l1_data_fee" => Self::L1DataFee,
+            "tx_count" => Self::TransactionCount,
+            "gas_usage" => Self::GasUsage,
+            _ => Self::Unknown(value),
+        })
+    }
 }
 
 /// Response from `wa_sponsorUserOperation`

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -102,11 +102,11 @@ pub struct JsonRpcError {
 pub enum PmSponsorUserOperationResponse {
     /// Sponsorship was approved with the returned gas and paymaster fields.
     Approved(PmSponsorshipApproval),
-    /// Protocol sponsorship was declined with a self-sponsorship advisory.
+    /// Sponsorship was declined with a self-sponsorship advisory.
     Declined(PmSponsorshipDecline),
 }
 
-/// Self-sponsorship advisory returned when protocol sponsorship is declined.
+/// Self-sponsorship advisory returned when sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PmSponsorshipDecline {
@@ -114,7 +114,7 @@ pub struct PmSponsorshipDecline {
     pub token: Address,
     /// Paymaster contract that accepts the fee token.
     pub paymaster_address: Address,
-    /// Policy reason for declining protocol sponsorship.
+    /// Policy reason for declining sponsorship.
     pub reason: PmSponsorshipDeclineReason,
 }
 

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -97,10 +97,10 @@ pub struct JsonRpcError {
     pub data: Option<Value>,
 }
 
-/// Structured details returned when protocol sponsorship is declined.
+/// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct SponsorshipDeclineDetails {
+pub struct SponsorshipDecline {
     /// ERC-20 token the user can use to pay the transaction fee.
     pub token: Address,
     /// Paymaster contract that accepts the fee token.


### PR DESCRIPTION
Parse structured `pm_sponsorUserOperation` results into `PmSponsorUserOperationResponse`. Approved responses carry `PmSponsorshipApproval`; declines carry `PmSponsorshipDecline` with the fee token, paymaster address, and reason.

Unknown future reasons remain representable. Malformed or unrelated JSON-RPC errors continue through the existing `RpcError` path. This prepares Bedrock's transaction lifecycle to offer the self-sponsored retry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public result shape and error semantics for paymaster sponsorship RPC calls on the user-operation path; callers must handle `Declined` instead of relying on generic RPC errors.
> 
> **Overview**
> **`pm_sponsor_user_operation`** no longer treats every JSON-RPC error as failure. Success now returns **`PmSponsorUserOperationResponse`**: either **`Approved`** (gas/paymaster fields, renamed from the old flat struct to **`PmSponsorshipApproval`**) or **`Declined`** with a parsed **`PmSponsorshipDecline`** (fee token, paymaster address, policy reason).
> 
> Declines are recognized only when the RPC error is code **`-32602`** with message **`sponsorship declined`** and valid **`data`**; malformed decline payloads and other RPC errors still surface as **`RpcError`**. Decline reasons map known wire strings (`gas_usage`, `l2_base_fee`, etc.) to enums and preserve forward compatibility via **`Unknown`**.
> 
> Tests cover happy-path decline parsing, malformed data, and unknown reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13374448add1cd9a2f4e067f88b71e87eec399c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->