### PR TITLE
chore: align Rust toolchains on 1.98.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Check code formatting
         run: cargo fmt -- --check
@@ -75,7 +75,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
 
       - name: Build Swift bindings
@@ -123,7 +123,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Download Swift build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 https://github.com/actions/download-artifact/releases/tag/v8.0.1
@@ -155,7 +155,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
@@ -193,7 +193,7 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.1.1
         with:
           command: check ${{ matrix.checks }}
-          rust-version: stable
+          rust-version: 1.97.1
 
   kotlin-build-and-test:
     name: Build and Test Kotlin Bindings
@@ -209,7 +209,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Build and test Kotlin bindings
         run: cargo xtask kotlin test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Check code formatting
         run: cargo fmt -- --check
@@ -75,7 +75,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
 
       - name: Build Swift bindings
@@ -123,7 +123,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Download Swift build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 https://github.com/actions/download-artifact/releases/tag/v8.0.1
@@ -155,7 +155,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1 https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.9.1
@@ -193,7 +193,7 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.1.1
         with:
           command: check ${{ matrix.checks }}
-          rust-version: 1.97.1
+          rust-version: 1.98.1
 
   kotlin-build-and-test:
     name: Build and Test Kotlin Bindings
@@ -209,7 +209,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Build and test Kotlin bindings
         run: cargo xtask kotlin test

--- a/.github/workflows/release-swift-kotlin.yml
+++ b/.github/workflows/release-swift-kotlin.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
 
       - name: Build the Swift project
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
           targets: ${{ matrix.settings.target }}
 
       - name: Install Cross
@@ -179,7 +179,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Setup Java
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0 https://github.com/actions/setup-java/releases/tag/v5.7.0

--- a/.github/workflows/release-swift-kotlin.yml
+++ b/.github/workflows/release-swift-kotlin.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
 
       - name: Build the Swift project
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
           targets: ${{ matrix.settings.target }}
 
       - name: Install Cross
@@ -179,7 +179,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Setup Java
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0 https://github.com/actions/setup-java/releases/tag/v5.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: stable
+          toolchain: 1.97.1
 
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131 https://github.com/release-plz/action/releases/tag/v0.5.131

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # 2026-07-16
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.1
 
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131 https://github.com/release-plz/action/releases/tag/v0.5.131

--- a/bedrock/src/backup/turnkey/mod.rs
+++ b/bedrock/src/backup/turnkey/mod.rs
@@ -39,7 +39,7 @@ static TURNKEY_MIGRATION_LOCK: once_cell::sync::Lazy<tokio::sync::Mutex<()>> =
 /// Hard ceiling on a full migration run. A degraded Turnkey (repeated timeouts
 /// plus retry backoff) must not block the caller indefinitely, and iOS cannot
 /// cancel a uniffi async call, so the deadline lives here.
-const MIGRATION_RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+const MIGRATION_RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(3);
 
 /// High level manager to perform Turnkey account operations such as setup and
 /// migration reconciliation.

--- a/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
+++ b/bedrock/src/migration/wallet/tfh_paymaster_approval.rs
@@ -87,7 +87,7 @@ impl TfhPaymasterApprovalMigration {
         // Two calls per token, in order, so the results pair up.
         let mut gap = Vec::new();
         for ((token, name, target), pair) in
-            PAYMASTER_TOKENS.iter().zip(results.chunks_exact(2))
+            PAYMASTER_TOKENS.iter().zip(results.as_chunks::<2>().0)
         {
             if pair.iter().any(|r| !r.success || r.returnData.len() < 32) {
                 return Err(MigrationError::InvalidOperation(format!(

--- a/bedrock/src/smart_account/mod.rs
+++ b/bedrock/src/smart_account/mod.rs
@@ -573,7 +573,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
         result.unwrap_err().to_string(),
-        format!("failed to decode hex-encoded secret into k256 signer: encoded key was not the right length (64 hex)")
+        "failed to decode hex-encoded secret into k256 signer: encoded key was not the right length (64 hex)".to_string()
     );
     }
 
@@ -589,9 +589,8 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!(
-                "failed to decode hex-encoded secret into k256 signer: signature error"
-            )
+            "failed to decode hex-encoded secret into k256 signer: signature error"
+                .to_string()
         );
     }
 
@@ -777,7 +776,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("Primitive error: invalid input on token: odd number of digits")
+            "Primitive error: invalid input on token: odd number of digits".to_string()
         );
     }
 
@@ -809,7 +808,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            format!("the contract 0x000000000022D473030F116dDEE9F6B43aC78BA3 is restricted from TypedData signing.")
+            "the contract 0x000000000022D473030F116dDEE9F6B43aC78BA3 is restricted from TypedData signing.".to_string()
         );
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "default"
 targets = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "default"
 targets = [


### PR DESCRIPTION
Align Bedrock's repository toolchain, CI, cargo-deny, and release workflows on Rust 1.98.1 for the shared rollout instead of mixing Rust 1.94.1 with floating stable jobs.

Retain the original upgrade's behavior-preserving Clippy fix, use fixed-size result chunks for the paymaster migration, and replace test-only constant `format!` calls as required by Rust 1.98. Dependencies and runtime behavior are unchanged.

### Validation

- `cargo +1.98.1 fmt --all -- --check`
- `cargo +1.98.1 clippy --workspace --all-targets --all-features -- -D warnings`
- Paymaster migration unit tests: 3 passed
- `git diff --check`

The matching Foundry integration test built but could not start because the local Foundry executable is unavailable. Full integration tests and Swift/Kotlin builds remain for CI.

### Rollout dependency

Keep this PR in draft until [Infrastructure #48339](https://github.com/worldcoin/infrastructure/pull/48339), [WalletKit #509](https://github.com/worldcoin/walletkit/pull/509), [Oxide #1190](https://github.com/worldcoin/oxide/pull/1190), [Biometric Engines #648](https://github.com/worldcoin/biometric-engines/pull/648), and [Flamingo #104](https://github.com/worldcoin/flamingo/pull/104) are ready. Version alignment will intentionally fail while the organization variable remains 1.94.1. No live variable or infrastructure change is made here.

### AI usage/prompt(s)

Codex: “Adjust the coordinated Rust upgrade PRs to align on Rust 1.98.1, validate compatibility, and include Flamingo now that it participates in organization version alignment.”

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and CI pinning plus style-level Rust fixes; no dependency or production logic changes beyond equivalent duration/chunking APIs.
> 
> **Overview**
> Pins Bedrock to **Rust 1.98.1** end-to-end: `rust-toolchain.toml` moves from 1.94.1, and CI, cargo-deny, and release workflows stop using floating `stable` in favor of the same fixed version.
> 
> Small **1.98 / Clippy compatibility** tweaks with no intended behavior change: Turnkey migration timeout is expressed via `Duration::from_mins(3)` instead of 180 seconds; paymaster migration pairs multicall results with `as_chunks::<2>()` instead of `chunks_exact(2)`; smart-account tests compare against string literals with `.to_string()` rather than `format!` on constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4582a4e86d71869ff1aa41060d33543b765df365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->