### PR TITLE
feat: export signer-backed Turnkey stamp

### DIFF
--- a/bedrock/src/backup/turnkey/mod.rs
+++ b/bedrock/src/backup/turnkey/mod.rs
@@ -65,7 +65,14 @@ impl TurnkeyManager {
     /// The signer is called with a SHA-256 digest through the existing UniFFI
     /// callback, so its private key never crosses the FFI boundary. The returned
     /// value is suitable for Turnkey's `X-Stamp` header.
-    pub fn stamp_with_signer(body: String, signer: &P256Signer) -> Result<String, TurnkeyError> {
+    // UniFFI only exports methods, not associated functions. `TurnkeyManager` is
+    // stateless, so the receiver is otherwise intentionally unused.
+    #[allow(clippy::unused_self)]
+    pub fn stamp_with_signer(
+        &self,
+        body: String,
+        signer: &P256Signer,
+    ) -> Result<String, TurnkeyError> {
         let body = body.into_bytes();
         let _json: serde_json::Value =
             serde_json::from_slice(&body).map_err(|_| TurnkeyError::DecodeBodyError)?;

--- a/bedrock/src/backup/turnkey/mod.rs
+++ b/bedrock/src/backup/turnkey/mod.rs
@@ -65,15 +65,12 @@ impl TurnkeyManager {
     /// The signer is called with a SHA-256 digest through the existing UniFFI
     /// callback, so its private key never crosses the FFI boundary. The returned
     /// value is suitable for Turnkey's `X-Stamp` header.
-    pub fn stamp_with_signer(
-        &self,
-        body: String,
-        signer: &P256Signer,
-    ) -> Result<String, TurnkeyError> {
+    pub fn stamp_with_signer(body: String, signer: &P256Signer) -> Result<String, TurnkeyError> {
+        let body = body.into_bytes();
         let _json: serde_json::Value =
-            serde_json::from_str(&body).map_err(|_| TurnkeyError::DecodeBodyError)?;
+            serde_json::from_slice(&body).map_err(|_| TurnkeyError::DecodeBodyError)?;
         KeypairSignerStamper::new(signer)
-            .stamp(body.as_bytes())
+            .stamp(&body)
             .map(|stamp| stamp.value)
             .map_err(|_| TurnkeyError::SigningError)
     }

--- a/bedrock/src/backup/turnkey/mod.rs
+++ b/bedrock/src/backup/turnkey/mod.rs
@@ -31,6 +31,9 @@ use migrations::{run_migration_list, TurnkeyMigrationOutcome, MIGRATIONS};
 
 use crate::primitives::config::get_config;
 use crate::primitives::P256Signer;
+use turnkey_api_key_stamper::Stamp;
+
+use self::api::KeypairSignerStamper;
 
 /// Only one migration running at a time.
 static TURNKEY_MIGRATION_LOCK: once_cell::sync::Lazy<tokio::sync::Mutex<()>> =
@@ -55,6 +58,24 @@ impl TurnkeyManager {
     #[must_use]
     pub fn new() -> Self {
         Self
+    }
+
+    /// Produces a Turnkey API-key stamp using a key held in native secure storage.
+    ///
+    /// The signer is called with a SHA-256 digest through the existing UniFFI
+    /// callback, so its private key never crosses the FFI boundary. The returned
+    /// value is suitable for Turnkey's `X-Stamp` header.
+    pub fn stamp_with_signer(
+        &self,
+        body: String,
+        signer: &P256Signer,
+    ) -> Result<String, TurnkeyError> {
+        let _json: serde_json::Value =
+            serde_json::from_str(&body).map_err(|_| TurnkeyError::DecodeBodyError)?;
+        KeypairSignerStamper::new(signer)
+            .stamp(body.as_bytes())
+            .map(|stamp| stamp.value)
+            .map_err(|_| TurnkeyError::SigningError)
     }
 
     /// Reviews the Turnkey account state and applies any required migrations to
@@ -549,12 +570,38 @@ impl From<k256::ecdsa::Error> for TurnkeyError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backup::turnkey::test::TestSigner;
     use base64::prelude::BASE64_URL_SAFE_NO_PAD;
     use base64::Engine;
     use p256::ecdsa::signature::Verifier;
     use p256::ecdsa::VerifyingKey;
     use p256::PublicKey;
     use serde_json::json;
+
+    #[test]
+    fn stamp_with_signer_keeps_private_key_in_callback() {
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+        let body = json!({"example": 123}).to_string();
+
+        let stamp = TurnkeyManager::new()
+            .stamp_with_signer(body.clone(), &signer)
+            .unwrap();
+        let decoded = BASE64_URL_SAFE_NO_PAD.decode(stamp).unwrap();
+        let stamp: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+
+        assert_eq!(stamp["scheme"], "SIGNATURE_SCHEME_TK_API_P256");
+        let signature = p256::ecdsa::Signature::from_der(
+            &hex::decode(stamp["signature"].as_str().unwrap()).unwrap(),
+        )
+        .unwrap();
+        let public_key = PublicKey::from_sec1_bytes(
+            &hex::decode(stamp["publicKey"].as_str().unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert!(VerifyingKey::from(public_key)
+            .verify(body.as_bytes(), &signature)
+            .is_ok());
+    }
 
     #[test]
     fn test_derive_public_key() {


### PR DESCRIPTION
## Summary
- expose `TurnkeyManager.stamp_with_signer` for a verified `P256Signer`
- reuse the existing `KeypairSignerStamper`, keeping private keys inside native secure storage
- verify the generated X-Stamp against the signer public key

## Testing
- `git diff --check`
- Not run: `cargo fmt --check` and `cargo test -p bedrock backup::turnkey::tests::stamp_with_signer_keeps_private_key_in_callback` (Rust toolchain / `cargo` is unavailable in this environment)

Relates to MCORE-1924

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new FFI entry point for Turnkey request authentication; behavior reuses existing stamper logic but any stamping bug could break or weaken API auth from native clients.
> 
> **Overview**
> Adds **`TurnkeyManager::stamp_with_signer`**, a UniFFI-exported path for native clients to build Turnkey **`X-Stamp`** values from a verified **`P256Signer`** without passing a raw API private key over FFI.
> 
> The method validates the request body as JSON, then delegates to the existing **`KeypairSignerStamper`** (SHA-256 digest signing through the signer callback) and returns the base64url stamp string. Invalid JSON maps to **`DecodeBodyError`**; stamping failures map to **`SigningError`**.
> 
> A new unit test **`stamp_with_signer_keeps_private_key_in_callback`** decodes the stamp, checks the P256 scheme, and verifies the signature over the original body bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e00fcdabdfec5e122b7e1f070cbc6e2a652efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->