### PR TITLE
feat(transactions): prepare ERC-20 transfers before signing

### DIFF
--- a/bedrock/src/primitives/contracts.rs
+++ b/bedrock/src/primitives/contracts.rs
@@ -1,5 +1,5 @@
 use crate::primitives::PrimitiveError;
-use crate::transactions::rpc::SponsorUserOperationResponse;
+use crate::transactions::rpc::{PmSponsorshipApproval, SponsorUserOperationResponse};
 use alloy::hex::FromHex;
 use alloy::primitives::{aliases::U48, keccak256, Address, Bytes, FixedBytes, U128};
 use alloy::sol;
@@ -273,6 +273,26 @@ impl UserOperation {
         self.call_gas_limit = sponsor_response.call_gas_limit;
         self.max_fee_per_gas = sponsor_response.max_fee_per_gas;
         self.max_priority_fee_per_gas = sponsor_response.max_priority_fee_per_gas;
+
+        self
+    }
+
+    /// Applies approved V2 sponsorship fields to this `UserOperation`.
+    #[must_use]
+    pub fn with_pm_sponsorship_approval(
+        mut self,
+        approval: &PmSponsorshipApproval,
+    ) -> Self {
+        self.paymaster = approval.paymaster;
+        self.paymaster_data.clone_from(&approval.paymaster_data);
+        self.paymaster_verification_gas_limit =
+            approval.paymaster_verification_gas_limit;
+        self.paymaster_post_op_gas_limit = approval.paymaster_post_op_gas_limit;
+        self.pre_verification_gas = approval.pre_verification_gas;
+        self.verification_gas_limit = approval.verification_gas_limit;
+        self.call_gas_limit = approval.call_gas_limit;
+        self.max_fee_per_gas = approval.max_fee_per_gas;
+        self.max_priority_fee_per_gas = approval.max_priority_fee_per_gas;
 
         self
     }

--- a/bedrock/src/test_utils.rs
+++ b/bedrock/src/test_utils.rs
@@ -269,7 +269,7 @@ where
 
         match method {
             // Respond with minimal, sane gas values and no paymaster
-            "wa_sponsorUserOperation" => {
+            "wa_sponsorUserOperation" | "pm_sponsorUserOperation" => {
                 let result = SponsorUserOperationResponseLite {
                     paymaster: None,
                     paymaster_data: None,

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -61,16 +61,6 @@ pub struct PreparedTransaction {
     network: Network,
 }
 
-/// A prepared ERC-20 transfer and the action details the client should review.
-#[allow(missing_docs)]
-#[derive(Debug, uniffi::Record)]
-pub struct PreparedErc20Transfer {
-    pub transaction: Arc<PreparedTransaction>,
-    pub token_address: String,
-    pub recipient_address: String,
-    pub amount: String,
-}
-
 /// Extensions to `SafeSmartAccount` to enable high-level APIs for transactions.
 #[bedrock_export]
 impl SafeSmartAccount {
@@ -93,7 +83,7 @@ impl SafeSmartAccount {
         to_address: &str,
         amount: &str,
         transfer_association: Option<TransferAssociation>,
-    ) -> Result<PreparedErc20Transfer, TransactionError> {
+    ) -> Result<Arc<PreparedTransaction>, TransactionError> {
         let token_address = Address::parse_from_ffi(token_address, "token_address")?;
         let to_address = Address::parse_from_ffi(to_address, "address")?;
         let amount = U256::parse_from_ffi(amount, "amount")?;
@@ -131,12 +121,7 @@ impl SafeSmartAccount {
             network: Network::WorldChain,
         };
 
-        Ok(PreparedErc20Transfer {
-            transaction: Arc::new(prepared_transaction),
-            token_address: token_address.to_string(),
-            recipient_address: to_address.to_string(),
-            amount: amount.to_string(),
-        })
+        Ok(Arc::new(prepared_transaction))
     }
 
     /// Signs and submits a previously prepared transaction.

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     primitives::{HexEncodedData, Network, ParseFromForeignBinding},
     smart_account::{
         Is4337Encodable, Permit2Approve, SafeSmartAccount, UnparsedPermitTransferFrom,
-        UnparsedTokenPermissions,
+        UnparsedTokenPermissions, UserOperation, ENTRYPOINT_4337,
     },
     transactions::{
         contracts::{
@@ -18,7 +18,10 @@ use crate::{
             usd_legacy_vault::Permit2Data,
             world_gift_manager::WorldGiftManager,
         },
-        rpc::{get_rpc_client, WaGetUserOperationReceiptResponse},
+        rpc::{
+            get_rpc_client, PmSponsorUserOperationResponse, SponsorshipContext,
+            WaGetUserOperationReceiptResponse,
+        },
     },
 };
 
@@ -51,10 +54,27 @@ pub struct WorldGiftManagerResult {
     pub gift_id: Arc<HexEncodedData>,
 }
 
+/// An unsigned `UserOperation` prepared for review before signing.
+#[derive(Debug, uniffi::Object)]
+pub struct PreparedTransaction {
+    user_operation: UserOperation,
+    network: Network,
+}
+
+/// A prepared ERC-20 transfer and the action details the client should review.
+#[allow(missing_docs)]
+#[derive(Debug, uniffi::Record)]
+pub struct PreparedErc20Transfer {
+    pub transaction: Arc<PreparedTransaction>,
+    pub token_address: String,
+    pub recipient_address: String,
+    pub amount: String,
+}
+
 /// Extensions to `SafeSmartAccount` to enable high-level APIs for transactions.
 #[bedrock_export]
 impl SafeSmartAccount {
-    /// Allows executing an ERC-20 token transfer **on World Chain**.
+    /// Prepares an ERC-20 transfer on World Chain without signing it.
     ///
     /// # Arguments
     /// - `token_address`: The address of the ERC-20 token to transfer.
@@ -62,44 +82,18 @@ impl SafeSmartAccount {
     /// - `amount`: The amount of tokens to transfer as a stringified integer with the decimals of the token (e.g. 18 for USDC or WLD)
     /// - `transfer_association`: Metadata value. The association of the transfer.
     ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use std::sync::Arc;
-    /// use bedrock::smart_account::{SafeSmartAccount, SmartAccountKeyManager};
-    /// use bedrock::transactions::TransactionError;
-    /// use bedrock::primitives::Network;
-    ///
-    /// # async fn example(
-    /// #     key_manager: Arc<dyn SmartAccountKeyManager>,
-    /// # ) -> Result<(), TransactionError> {
-    /// // Assume we have a configured SafeSmartAccount
-    /// # let safe_account = SafeSmartAccount::new(key_manager, "0x1234567890123456789012345678901234567890").unwrap();
-    ///
-    /// // Transfer USDC on World Chain
-    /// let tx_hash = safe_account.transaction_transfer(
-    ///     "0x79A02482A880BCE3F13E09Da970dC34DB4cD24d1", // USDC on World Chain
-    ///     "0x1234567890123456789012345678901234567890",
-    ///     "1000000", // 1 USDC (6 decimals)
-    ///     None,
-    /// ).await?;
-    ///
-    /// println!("Transaction hash: {}", tx_hash.to_hex_string());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
     /// # Errors
     /// - Will throw a parsing error if any of the provided attributes are invalid.
-    /// - Will throw an RPC error if the transaction submission fails.
+    /// - Will throw an RPC error if sponsorship preparation fails.
+    /// - Will throw an error if sponsorship is declined.
     /// - Will throw an error if the global HTTP client has not been initialized.
-    pub async fn transaction_transfer(
+    pub async fn prepare_transaction_transfer(
         &self,
         token_address: &str,
         to_address: &str,
         amount: &str,
         transfer_association: Option<TransferAssociation>,
-    ) -> Result<HexEncodedData, TransactionError> {
+    ) -> Result<PreparedErc20Transfer, TransactionError> {
         let token_address = Address::parse_from_ffi(token_address, "token_address")?;
         let to_address = Address::parse_from_ffi(to_address, "address")?;
         let amount = U256::parse_from_ffi(amount, "amount")?;
@@ -110,13 +104,76 @@ impl SafeSmartAccount {
             association: transfer_association,
         };
 
-        let provider = RpcProviderName::Any;
-
-        let user_op_hash = transaction
-            .sign_and_execute(self, Network::WorldChain, None, Some(metadata), provider)
+        let user_operation = transaction
+            .build_preflight_user_operation(self.wallet_address, Some(metadata))?;
+        let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
+            error_message: format!("Failed to prepare transaction: {e}"),
+        })?;
+        let sponsorship = rpc_client
+            .pm_sponsor_user_operation(
+                Network::WorldChain,
+                &user_operation,
+                *ENTRYPOINT_4337,
+                &SponsorshipContext::Protocol,
+            )
             .await
             .map_err(|e| TransactionError::Generic {
-                error_message: format!("Failed to execute transaction: {e}"),
+                error_message: format!("Failed to prepare transaction: {e}"),
+            })?;
+
+        let PmSponsorUserOperationResponse::Approved(approval) = sponsorship else {
+            return Err(TransactionError::Generic {
+                error_message: "Sponsorship declined".to_string(),
+            });
+        };
+        let prepared_transaction = PreparedTransaction {
+            user_operation: user_operation.with_pm_sponsorship_approval(&approval),
+            network: Network::WorldChain,
+        };
+
+        Ok(PreparedErc20Transfer {
+            transaction: Arc::new(prepared_transaction),
+            token_address: token_address.to_string(),
+            recipient_address: to_address.to_string(),
+            amount: amount.to_string(),
+        })
+    }
+
+    /// Signs and submits a previously prepared transaction.
+    ///
+    /// # Errors
+    /// - Will throw an error if the transaction was prepared for another account.
+    /// - Will throw an RPC error if signing or submission fails.
+    /// - Will throw an error if the global HTTP client has not been initialized.
+    pub async fn submit_prepared_transaction(
+        &self,
+        prepared_transaction: Arc<PreparedTransaction>,
+    ) -> Result<HexEncodedData, TransactionError> {
+        if prepared_transaction.user_operation.sender != self.wallet_address {
+            return Err(TransactionError::Generic {
+                error_message: "Prepared transaction belongs to another account"
+                    .to_string(),
+            });
+        }
+
+        let mut user_operation = prepared_transaction.user_operation.clone();
+        self.sign_user_operation(&mut user_operation, prepared_transaction.network)
+            .map_err(|e| TransactionError::Generic {
+                error_message: format!("Failed to sign transaction: {e}"),
+            })?;
+
+        let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
+            error_message: format!("Failed to submit transaction: {e}"),
+        })?;
+        let user_op_hash = rpc_client
+            .send_user_operation_v2(
+                prepared_transaction.network,
+                &user_operation,
+                *ENTRYPOINT_4337,
+            )
+            .await
+            .map_err(|e| TransactionError::Generic {
+                error_message: format!("Failed to submit transaction: {e}"),
             })?;
 
         Ok(HexEncodedData::new(&user_op_hash.to_string())?)

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -83,7 +83,7 @@ impl SafeSmartAccount {
         to_address: &str,
         amount: &str,
         transfer_association: Option<TransferAssociation>,
-    ) -> Result<Arc<PreparedTransaction>, TransactionError> {
+    ) -> Result<PreparedTransaction, TransactionError> {
         let token_address = Address::parse_from_ffi(token_address, "token_address")?;
         let to_address = Address::parse_from_ffi(to_address, "address")?;
         let amount = U256::parse_from_ffi(amount, "amount")?;
@@ -121,7 +121,7 @@ impl SafeSmartAccount {
             network: Network::WorldChain,
         };
 
-        Ok(Arc::new(prepared_transaction))
+        Ok(prepared_transaction)
     }
 
     /// Signs and submits a previously prepared transaction.
@@ -132,7 +132,7 @@ impl SafeSmartAccount {
     /// - Will throw an error if the global HTTP client has not been initialized.
     pub async fn submit_prepared_transaction(
         &self,
-        prepared_transaction: Arc<PreparedTransaction>,
+        prepared_transaction: &PreparedTransaction,
     ) -> Result<HexEncodedData, TransactionError> {
         if prepared_transaction.user_operation.sender != self.wallet_address {
             return Err(TransactionError::Generic {

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -96,7 +96,9 @@ impl SafeSmartAccount {
         let user_operation = transaction
             .build_preflight_user_operation(self.wallet_address, Some(metadata))?;
         let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
-            error_message: format!("Failed to prepare transaction: {e}"),
+            error_message: format!(
+                "Failed to get RPC client for ERC-20 transfer preparation: {e}"
+            ),
         })?;
         let sponsorship = rpc_client
             .pm_sponsor_user_operation(
@@ -106,20 +108,50 @@ impl SafeSmartAccount {
                 &SponsorshipContext::Protocol,
             )
             .await
-            .map_err(|e| TransactionError::Generic {
-                error_message: format!("Failed to prepare transaction: {e}"),
+            .map_err(|e| {
+                crate::error!(
+                    transaction_type = "erc20_transfer",
+                    network = Network::WorldChain.network_name(),
+                    sender = self.wallet_address,
+                    outcome = "error",
+                    user_operation = format!("{user_operation:?}"),
+                    error_message = e,
+                    "Failed to request sponsorship for ERC-20 transfer"
+                );
+                TransactionError::Generic {
+                    error_message: format!("Failed to request sponsorship: {e}"),
+                }
             })?;
 
-        let PmSponsorUserOperationResponse::Approved(approval) = sponsorship else {
-            // TODO: Handle the self-sponsored UserOperation flow.
-            return Err(TransactionError::Generic {
-                error_message: "Sponsorship declined".to_string(),
-            });
+        let approval = match sponsorship {
+            PmSponsorUserOperationResponse::Approved(approval) => approval,
+            PmSponsorUserOperationResponse::Declined(decline) => {
+                crate::info!(
+                    transaction_type = "erc20_transfer",
+                    network = Network::WorldChain.network_name(),
+                    sender = self.wallet_address,
+                    outcome = "sponsorship_declined",
+                    decline_reason = decline.reason,
+                    "Sponsorship declined for ERC-20 transfer"
+                );
+                // TODO: Handle the self-sponsored UserOperation flow.
+                return Err(TransactionError::Generic {
+                    error_message: "Sponsorship declined".to_string(),
+                });
+            }
         };
         let prepared_transaction = PreparedTransaction {
             user_operation: user_operation.with_pm_sponsorship_approval(&approval),
             network: Network::WorldChain,
         };
+
+        crate::debug!(
+            transaction_type = "erc20_transfer",
+            network = Network::WorldChain.network_name(),
+            sender = self.wallet_address,
+            outcome = "prepared",
+            "Prepared ERC-20 transfer"
+        );
 
         Ok(prepared_transaction)
     }
@@ -134,6 +166,11 @@ impl SafeSmartAccount {
         &self,
         prepared_transaction: &PreparedTransaction,
     ) -> Result<HexEncodedData, TransactionError> {
+        crate::info!(
+            sender = prepared_transaction.user_operation.sender,
+            network = prepared_transaction.network.network_name(),
+            "Submitting prepared transaction"
+        );
         if prepared_transaction.user_operation.sender != self.wallet_address {
             return Err(TransactionError::Generic {
                 error_message: "Prepared transaction belongs to another account"
@@ -148,7 +185,9 @@ impl SafeSmartAccount {
             })?;
 
         let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
-            error_message: format!("Failed to get RPC client: {e}"),
+            error_message: format!(
+                "Failed to get RPC client for transaction submission: {e}"
+            ),
         })?;
         let user_op_hash = rpc_client
             .send_user_operation_v2(
@@ -157,9 +196,24 @@ impl SafeSmartAccount {
                 *ENTRYPOINT_4337,
             )
             .await
-            .map_err(|e| TransactionError::Generic {
-                error_message: format!("Failed to submit transaction: {e}"),
+            .map_err(|e| {
+                crate::error!(
+                    user_operation = format!("{user_operation:?}"),
+                    network = prepared_transaction.network.network_name(),
+                    error_message = e,
+                    "Failed to submit prepared transaction"
+                );
+                TransactionError::Generic {
+                    error_message: format!("Failed to submit transaction: {e}"),
+                }
             })?;
+
+        crate::info!(
+            user_op_hash = user_op_hash,
+            sender = user_operation.sender,
+            network = prepared_transaction.network.network_name(),
+            "Submitted prepared transaction"
+        );
 
         Ok(HexEncodedData::new(&user_op_hash.to_string())?)
     }

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -64,7 +64,7 @@ pub struct PreparedTransaction {
 /// Extensions to `SafeSmartAccount` to enable high-level APIs for transactions.
 #[bedrock_export]
 impl SafeSmartAccount {
-    /// Prepares an ERC-20 transfer on World Chain without signing it.
+    /// Prepares an unsigned ERC-20 transfer on World Chain.
     ///
     /// # Arguments
     /// - `token_address`: The address of the ERC-20 token to transfer.
@@ -112,6 +112,7 @@ impl SafeSmartAccount {
             })?;
 
         let PmSponsorUserOperationResponse::Approved(approval) = sponsorship else {
+            // TODO: Handle the self-sponsored UserOperation flow.
             return Err(TransactionError::Generic {
                 error_message: "Sponsorship declined".to_string(),
             });

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -148,7 +148,7 @@ impl SafeSmartAccount {
             })?;
 
         let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
-            error_message: format!("Failed to submit transaction: {e}"),
+            error_message: format!("Failed to get RPC client: {e}"),
         })?;
         let user_op_hash = rpc_client
             .send_user_operation_v2(

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -83,9 +83,29 @@ impl SafeSmartAccount {
         amount: &str,
         transfer_association: Option<TransferAssociation>,
     ) -> Result<PreparedTransaction, TransactionError> {
-        let token_address = Address::parse_from_ffi(token_address, "token_address")?;
-        let to_address = Address::parse_from_ffi(to_address, "address")?;
-        let amount = U256::parse_from_ffi(amount, "amount")?;
+        let log_failure = |stage: &str, error: &dyn std::fmt::Display| {
+            crate::error!(
+                transaction_type = "erc20_transfer",
+                network = Network::WorldChain.network_name(),
+                sender = self.wallet_address,
+                outcome = "error",
+                stage = stage,
+                error_message = error,
+                "Failed to prepare ERC-20 transfer"
+            );
+        };
+
+        let token_address = Address::parse_from_ffi(token_address, "token_address")
+            .inspect_err(|e| {
+                log_failure("parse_token_address", e);
+            })?;
+        let to_address =
+            Address::parse_from_ffi(to_address, "address").inspect_err(|e| {
+                log_failure("parse_to_address", e);
+            })?;
+        let amount = U256::parse_from_ffi(amount, "amount").inspect_err(|e| {
+            log_failure("parse_amount", e);
+        })?;
 
         let transaction = Erc20::new(token_address, to_address, amount);
 
@@ -94,11 +114,17 @@ impl SafeSmartAccount {
         };
 
         let user_operation = transaction
-            .build_preflight_user_operation(self.wallet_address, Some(metadata))?;
-        let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
-            error_message: format!(
-                "Failed to get RPC client for ERC-20 transfer preparation: {e}"
-            ),
+            .build_preflight_user_operation(self.wallet_address, Some(metadata))
+            .inspect_err(|e| {
+                log_failure("build_user_operation", e);
+            })?;
+        let rpc_client = get_rpc_client().map_err(|e| {
+            log_failure("get_rpc_client", &e);
+            TransactionError::Generic {
+                error_message: format!(
+                    "Failed to get RPC client for ERC-20 transfer preparation: {e}"
+                ),
+            }
         })?;
         let sponsorship = rpc_client
             .pm_sponsor_user_operation(
@@ -166,12 +192,28 @@ impl SafeSmartAccount {
         &self,
         prepared_transaction: &PreparedTransaction,
     ) -> Result<HexEncodedData, TransactionError> {
+        let log_failure = |stage: &str, error: &dyn std::fmt::Display| {
+            crate::error!(
+                sender = prepared_transaction.user_operation.sender,
+                wallet_address = self.wallet_address,
+                network = prepared_transaction.network.network_name(),
+                outcome = "error",
+                stage = stage,
+                error_message = error,
+                "Failed to submit prepared transaction"
+            );
+        };
+
         crate::info!(
             sender = prepared_transaction.user_operation.sender,
             network = prepared_transaction.network.network_name(),
             "Submitting prepared transaction"
         );
         if prepared_transaction.user_operation.sender != self.wallet_address {
+            log_failure(
+                "validate_account",
+                &"Prepared transaction belongs to another account",
+            );
             return Err(TransactionError::Generic {
                 error_message: "Prepared transaction belongs to another account"
                     .to_string(),
@@ -180,14 +222,20 @@ impl SafeSmartAccount {
 
         let mut user_operation = prepared_transaction.user_operation.clone();
         self.sign_user_operation(&mut user_operation, prepared_transaction.network)
-            .map_err(|e| TransactionError::Generic {
-                error_message: format!("Failed to sign transaction: {e}"),
+            .map_err(|e| {
+                log_failure("sign", &e);
+                TransactionError::Generic {
+                    error_message: format!("Failed to sign transaction: {e}"),
+                }
             })?;
 
-        let rpc_client = get_rpc_client().map_err(|e| TransactionError::Generic {
-            error_message: format!(
-                "Failed to get RPC client for transaction submission: {e}"
-            ),
+        let rpc_client = get_rpc_client().map_err(|e| {
+            log_failure("get_rpc_client", &e);
+            TransactionError::Generic {
+                error_message: format!(
+                    "Failed to get RPC client for transaction submission: {e}"
+                ),
+            }
         })?;
         let user_op_hash = rpc_client
             .send_user_operation_v2(
@@ -199,7 +247,9 @@ impl SafeSmartAccount {
             .map_err(|e| {
                 crate::error!(
                     user_operation = format!("{user_operation:?}"),
+                    sender = user_operation.sender,
                     network = prepared_transaction.network.network_name(),
+                    outcome = "error",
                     error_message = e,
                     "Failed to submit prepared transaction"
                 );

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -53,11 +53,11 @@ pub struct WorldGiftManagerResult {
     pub gift_id: Arc<HexEncodedData>,
 }
 
-/// An unsigned `UserOperation` prepared for review before signing.
+/// An unsigned World Chain `UserOperation` prepared for review before signing.
 #[derive(Debug, uniffi::Object)]
 pub struct PreparedTransaction {
     user_operation: UserOperation,
-    network: Network,
+    // TODO: Add sponsorship details like sponsorship decline reason, self-sponsorship fee details for user confirmation, etc.
 }
 
 /// Extensions to `SafeSmartAccount` to enable high-level APIs for transactions.
@@ -168,7 +168,6 @@ impl SafeSmartAccount {
         };
         let prepared_transaction = PreparedTransaction {
             user_operation: user_operation.with_pm_sponsorship_approval(&approval),
-            network: Network::WorldChain,
         };
 
         crate::debug!(
@@ -182,7 +181,7 @@ impl SafeSmartAccount {
         Ok(prepared_transaction)
     }
 
-    /// Signs and submits a previously prepared transaction.
+    /// Signs and submits a previously prepared transaction on World Chain.
     ///
     /// # Errors
     /// - Will throw an error if the transaction was prepared for another account.
@@ -196,7 +195,7 @@ impl SafeSmartAccount {
             crate::error!(
                 sender = prepared_transaction.user_operation.sender,
                 wallet_address = self.wallet_address,
-                network = prepared_transaction.network.network_name(),
+                network = Network::WorldChain.network_name(),
                 outcome = "error",
                 stage = stage,
                 error_message = error,
@@ -206,7 +205,7 @@ impl SafeSmartAccount {
 
         crate::info!(
             sender = prepared_transaction.user_operation.sender,
-            network = prepared_transaction.network.network_name(),
+            network = Network::WorldChain.network_name(),
             "Submitting prepared transaction"
         );
         if prepared_transaction.user_operation.sender != self.wallet_address {
@@ -221,7 +220,7 @@ impl SafeSmartAccount {
         }
 
         let mut user_operation = prepared_transaction.user_operation.clone();
-        self.sign_user_operation(&mut user_operation, prepared_transaction.network)
+        self.sign_user_operation(&mut user_operation, Network::WorldChain)
             .map_err(|e| {
                 log_failure("sign", &e);
                 TransactionError::Generic {
@@ -239,7 +238,7 @@ impl SafeSmartAccount {
         })?;
         let user_op_hash = rpc_client
             .send_user_operation_v2(
-                prepared_transaction.network,
+                Network::WorldChain,
                 &user_operation,
                 *ENTRYPOINT_4337,
             )
@@ -248,7 +247,7 @@ impl SafeSmartAccount {
                 crate::error!(
                     user_operation = format!("{user_operation:?}"),
                     sender = user_operation.sender,
-                    network = prepared_transaction.network.network_name(),
+                    network = Network::WorldChain.network_name(),
                     outcome = "error",
                     error_message = e,
                     "Failed to submit prepared transaction"
@@ -261,7 +260,7 @@ impl SafeSmartAccount {
         crate::info!(
             user_op_hash = user_op_hash,
             sender = user_operation.sender,
-            network = prepared_transaction.network.network_name(),
+            network = Network::WorldChain.network_name(),
             "Submitted prepared transaction"
         );
 

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -27,8 +27,7 @@ mod wire;
 pub use wire::{
     Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
     RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
-    SponsorshipDeclineDetails, SponsorshipDeclineReason,
-    WaGetUserOperationReceiptResponse,
+    SponsorshipDecline, SponsorshipDeclineReason, WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
 
@@ -40,17 +39,6 @@ static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
 
 const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
 const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
-
-/// A protocol-sponsorship decline with its JSON-RPC envelope intact.
-#[derive(Debug, PartialEq, Eq)]
-pub struct SponsorshipDecline {
-    /// JSON-RPC error code.
-    pub code: i64,
-    /// JSON-RPC error message.
-    pub error_message: String,
-    /// Parsed sponsorship-decline data.
-    pub details: SponsorshipDeclineDetails,
-}
 
 impl TryFrom<JsonRpcError> for SponsorshipDecline {
     type Error = JsonRpcError;
@@ -65,15 +53,11 @@ impl TryFrom<JsonRpcError> for SponsorshipDecline {
         let Some(data) = error.data.as_ref() else {
             return Err(error);
         };
-        let Ok(details) = serde_json::from_value(data.clone()) else {
+        let Ok(decline) = serde_json::from_value(data.clone()) else {
             return Err(error);
         };
 
-        Ok(Self {
-            code: error.code,
-            error_message: error.message,
-            details,
-        })
+        Ok(decline)
     }
 }
 
@@ -157,15 +141,6 @@ impl From<RpcCallError> for RpcError {
     }
 }
 
-impl From<SponsorshipDecline> for RpcError {
-    fn from(decline: SponsorshipDecline) -> Self {
-        Self::RpcResponseError {
-            code: decline.code,
-            error_message: decline.error_message,
-        }
-    }
-}
-
 impl From<HttpError> for RpcError {
     fn from(e: HttpError) -> Self {
         Self::HttpError(e.to_string())
@@ -184,9 +159,12 @@ impl From<SafeSmartAccountError> for RpcError {
     }
 }
 
+/// Result of requesting paymaster sponsorship for a user operation.
 #[derive(Debug)]
-pub(crate) enum PmSponsorUserOperationOutcome {
+pub enum PmSponsorUserOperationOutcome {
+    /// Sponsorship was approved with the returned gas and paymaster fields.
     Sponsored(PmSponsorUserOperationResponse),
+    /// Protocol sponsorship was declined with a self-sponsorship advisory.
     Declined(SponsorshipDecline),
 }
 
@@ -335,31 +313,14 @@ impl RpcClient {
     /// - The HTTP request fails
     /// - The request serialization fails
     /// - The response parsing fails
-    /// - The RPC returns an error response
+    /// - The RPC returns an unexpected error response
     pub async fn pm_sponsor_user_operation(
         &self,
         network: Network,
         user_operation: &UserOperation,
         entry_point: Address,
         context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationResponse, RpcError> {
-        match self
-            .request_pm_sponsorship(network, user_operation, entry_point, context)
-            .await
-            .map_err(RpcError::from)?
-        {
-            PmSponsorUserOperationOutcome::Sponsored(response) => Ok(response),
-            PmSponsorUserOperationOutcome::Declined(decline) => Err(decline.into()),
-        }
-    }
-
-    pub(crate) async fn request_pm_sponsorship(
-        &self,
-        network: Network,
-        user_operation: &UserOperation,
-        entry_point: Address,
-        context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationOutcome, RpcCallError> {
+    ) -> Result<PmSponsorUserOperationOutcome, RpcError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
@@ -378,10 +339,10 @@ impl RpcClient {
             Err(RpcCallError::Response(error)) => {
                 match SponsorshipDecline::try_from(error) {
                     Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
-                    Err(error) => Err(RpcCallError::Response(error)),
+                    Err(error) => Err(error.into()),
                 }
             }
-            Err(error) => Err(error),
+            Err(RpcCallError::Rpc(error)) => Err(error),
         }
     }
 

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -25,9 +25,10 @@ use std::sync::{Arc, OnceLock};
 mod wire;
 
 pub use wire::{
-    Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
-    RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
-    SponsorshipDecline, SponsorshipDeclineReason, WaGetUserOperationReceiptResponse,
+    Id, PmSponsorshipApproval, PmSponsorshipDecline, PmSponsorshipDeclineReason,
+    RelaySafeTransactionRequest, RpcMethod, RpcProviderName,
+    SponsorUserOperationResponse, SponsorshipContext,
+    WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
 
@@ -40,7 +41,7 @@ static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
 const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
 const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
 
-impl TryFrom<JsonRpcError> for SponsorshipDecline {
+impl TryFrom<JsonRpcError> for PmSponsorshipDecline {
     type Error = JsonRpcError;
 
     fn try_from(error: JsonRpcError) -> Result<Self, Self::Error> {
@@ -159,13 +160,13 @@ impl From<SafeSmartAccountError> for RpcError {
     }
 }
 
-/// Result of requesting paymaster sponsorship for a user operation.
+/// Response from requesting paymaster sponsorship for a user operation.
 #[derive(Debug)]
-pub enum PmSponsorUserOperationOutcome {
+pub enum PmSponsorUserOperationResponse {
     /// Sponsorship was approved with the returned gas and paymaster fields.
-    Sponsored(PmSponsorUserOperationResponse),
+    Approved(PmSponsorshipApproval),
     /// Protocol sponsorship was declined with a self-sponsorship advisory.
-    Declined(SponsorshipDecline),
+    Declined(PmSponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests
@@ -320,7 +321,7 @@ impl RpcClient {
         user_operation: &UserOperation,
         entry_point: Address,
         context: &SponsorshipContext,
-    ) -> Result<PmSponsorUserOperationOutcome, RpcError> {
+    ) -> Result<PmSponsorUserOperationResponse, RpcError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
@@ -335,10 +336,12 @@ impl RpcClient {
             )
             .await
         {
-            Ok(response) => Ok(PmSponsorUserOperationOutcome::Sponsored(response)),
+            Ok(response) => Ok(PmSponsorUserOperationResponse::Approved(response)),
             Err(RpcCallError::Response(error)) => {
-                match SponsorshipDecline::try_from(error) {
-                    Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
+                match PmSponsorshipDecline::try_from(error) {
+                    Ok(decline) => {
+                        Ok(PmSponsorUserOperationResponse::Declined(decline))
+                    }
                     Err(error) => Err(error.into()),
                 }
             }

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -25,9 +25,9 @@ use std::sync::{Arc, OnceLock};
 mod wire;
 
 pub use wire::{
-    Id, PmSponsorshipApproval, PmSponsorshipDecline, PmSponsorshipDeclineReason,
-    RelaySafeTransactionRequest, RpcMethod, RpcProviderName,
-    SponsorUserOperationResponse, SponsorshipContext,
+    Id, PmSponsorUserOperationResponse, PmSponsorshipApproval, PmSponsorshipDecline,
+    PmSponsorshipDeclineReason, RelaySafeTransactionRequest, RpcMethod,
+    RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
     WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
@@ -158,15 +158,6 @@ impl From<SafeSmartAccountError> for RpcError {
     fn from(e: SafeSmartAccountError) -> Self {
         Self::SafeSmartAccountError(e.to_string())
     }
-}
-
-/// Response from requesting paymaster sponsorship for a user operation.
-#[derive(Debug)]
-pub enum PmSponsorUserOperationResponse {
-    /// Sponsorship was approved with the returned gas and paymaster fields.
-    Approved(PmSponsorshipApproval),
-    /// Protocol sponsorship was declined with a self-sponsorship advisory.
-    Declined(PmSponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests

--- a/bedrock/src/transactions/rpc.rs
+++ b/bedrock/src/transactions/rpc.rs
@@ -27,6 +27,7 @@ mod wire;
 pub use wire::{
     Id, PmSponsorUserOperationResponse, RelaySafeTransactionRequest, RpcMethod,
     RpcProviderName, SponsorUserOperationResponse, SponsorshipContext,
+    SponsorshipDeclineDetails, SponsorshipDeclineReason,
     WaGetUserOperationReceiptResponse,
 };
 pub(crate) use wire::{JsonRpcError, JsonRpcRequest};
@@ -36,6 +37,46 @@ mod tests;
 
 /// Global RPC client instance for Bedrock operations
 static RPC_CLIENT_INSTANCE: OnceLock<RpcClient> = OnceLock::new();
+
+const SPONSORSHIP_DECLINED_CODE: i64 = -32602;
+const SPONSORSHIP_DECLINED_MESSAGE: &str = "sponsorship declined";
+
+/// A protocol-sponsorship decline with its JSON-RPC envelope intact.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SponsorshipDecline {
+    /// JSON-RPC error code.
+    pub code: i64,
+    /// JSON-RPC error message.
+    pub error_message: String,
+    /// Parsed sponsorship-decline data.
+    pub details: SponsorshipDeclineDetails,
+}
+
+impl TryFrom<JsonRpcError> for SponsorshipDecline {
+    type Error = JsonRpcError;
+
+    fn try_from(error: JsonRpcError) -> Result<Self, Self::Error> {
+        if error.code != SPONSORSHIP_DECLINED_CODE
+            || error.message != SPONSORSHIP_DECLINED_MESSAGE
+        {
+            return Err(error);
+        }
+
+        let Some(data) = error.data.as_ref() else {
+            return Err(error);
+        };
+        let Ok(details) = serde_json::from_value(data.clone()) else {
+            return Err(error);
+        };
+
+        Ok(Self {
+            code: error.code,
+            error_message: error.message,
+            details,
+        })
+    }
+}
+
 /// Errors that can occur when interacting with RPC operations.
 #[crate::bedrock_error]
 
@@ -116,6 +157,15 @@ impl From<RpcCallError> for RpcError {
     }
 }
 
+impl From<SponsorshipDecline> for RpcError {
+    fn from(decline: SponsorshipDecline) -> Self {
+        Self::RpcResponseError {
+            code: decline.code,
+            error_message: decline.error_message,
+        }
+    }
+}
+
 impl From<HttpError> for RpcError {
     fn from(e: HttpError) -> Self {
         Self::HttpError(e.to_string())
@@ -132,6 +182,12 @@ impl From<SafeSmartAccountError> for RpcError {
     fn from(e: SafeSmartAccountError) -> Self {
         Self::SafeSmartAccountError(e.to_string())
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum PmSponsorUserOperationOutcome {
+    Sponsored(PmSponsorUserOperationResponse),
+    Declined(SponsorshipDecline),
 }
 
 /// RPC client for handling 4337 `UserOperation` requests
@@ -287,19 +343,46 @@ impl RpcClient {
         entry_point: Address,
         context: &SponsorshipContext,
     ) -> Result<PmSponsorUserOperationResponse, RpcError> {
+        match self
+            .request_pm_sponsorship(network, user_operation, entry_point, context)
+            .await
+            .map_err(RpcError::from)?
+        {
+            PmSponsorUserOperationOutcome::Sponsored(response) => Ok(response),
+            PmSponsorUserOperationOutcome::Declined(decline) => Err(decline.into()),
+        }
+    }
+
+    pub(crate) async fn request_pm_sponsorship(
+        &self,
+        network: Network,
+        user_operation: &UserOperation,
+        entry_point: Address,
+        context: &SponsorshipContext,
+    ) -> Result<PmSponsorUserOperationOutcome, RpcCallError> {
         let params = vec![
             serde_json::to_value(user_operation).map_err(|_| RpcError::JsonError)?,
             serde_json::Value::String(format!("{entry_point:?}")),
             context.to_json_value(),
         ];
-        self.rpc_call(
-            network,
-            RpcMethod::PmSponsorUserOperation,
-            params,
-            RpcProviderName::Any,
-        )
-        .await
-        .map_err(RpcError::from)
+        match self
+            .rpc_call(
+                network,
+                RpcMethod::PmSponsorUserOperation,
+                params,
+                RpcProviderName::Any,
+            )
+            .await
+        {
+            Ok(response) => Ok(PmSponsorUserOperationOutcome::Sponsored(response)),
+            Err(RpcCallError::Response(error)) => {
+                match SponsorshipDecline::try_from(error) {
+                    Ok(decline) => Ok(PmSponsorUserOperationOutcome::Declined(decline)),
+                    Err(error) => Err(RpcCallError::Response(error)),
+                }
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Submits a signed `UserOperation` via `eth_sendUserOperation`

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -95,6 +95,127 @@ async fn test_rpc_call_preserves_structured_error_data() {
     assert_eq!(error.data, Some(data));
 }
 
+#[tokio::test]
+async fn test_request_pm_sponsorship_returns_typed_decline() {
+    let response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "tx_test",
+        "error": {
+            "code": SPONSORSHIP_DECLINED_CODE,
+            "message": SPONSORSHIP_DECLINED_MESSAGE,
+            "data": {
+                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+                "reason": "gas_usage",
+            },
+        },
+    }))
+    .unwrap();
+    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
+
+    let outcome = client
+        .request_pm_sponsorship(
+            Network::WorldChain,
+            &UserOperation::default(),
+            Address::ZERO,
+            &SponsorshipContext::Protocol,
+        )
+        .await
+        .unwrap();
+
+    let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
+        panic!("expected sponsorship to be declined");
+    };
+    assert_eq!(decline.code, SPONSORSHIP_DECLINED_CODE);
+    assert_eq!(decline.error_message, SPONSORSHIP_DECLINED_MESSAGE);
+    assert_eq!(
+        decline.details.token,
+        address!("2cfc85d8e48f8eab294be644d9e25c3030863003")
+    );
+    assert_eq!(
+        decline.details.paymaster_address,
+        address!("0000000000000039cd5e8ae05257ce51c473ddd1")
+    );
+    assert_eq!(decline.details.reason, SponsorshipDeclineReason::GasUsage);
+}
+
+#[tokio::test]
+async fn test_pm_sponsor_user_operation_preserves_public_error() {
+    let response = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "tx_test",
+        "error": {
+            "code": SPONSORSHIP_DECLINED_CODE,
+            "message": SPONSORSHIP_DECLINED_MESSAGE,
+            "data": {
+                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+                "reason": "gas_usage",
+            },
+        },
+    }))
+    .unwrap();
+    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
+
+    let error = client
+        .pm_sponsor_user_operation(
+            Network::WorldChain,
+            &UserOperation::default(),
+            Address::ZERO,
+            &SponsorshipContext::Protocol,
+        )
+        .await
+        .unwrap_err();
+
+    let RpcError::RpcResponseError {
+        code,
+        error_message,
+    } = error
+    else {
+        panic!("expected the legacy JSON-RPC error");
+    };
+    assert_eq!(code, SPONSORSHIP_DECLINED_CODE);
+    assert_eq!(error_message, SPONSORSHIP_DECLINED_MESSAGE);
+}
+
+#[test]
+fn test_malformed_sponsorship_decline_preserves_rpc_error() {
+    let data = json!({
+        "token": "not-an-address",
+        "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+        "reason": "gas_usage",
+    });
+    let error = JsonRpcError {
+        code: SPONSORSHIP_DECLINED_CODE,
+        message: SPONSORSHIP_DECLINED_MESSAGE.to_string(),
+        data: Some(data.clone()),
+    };
+
+    let error = SponsorshipDecline::try_from(error).unwrap_err();
+
+    assert_eq!(error.data, Some(data));
+}
+
+#[test]
+fn test_sponsorship_decline_preserves_unknown_reason() {
+    let error = JsonRpcError {
+        code: SPONSORSHIP_DECLINED_CODE,
+        message: SPONSORSHIP_DECLINED_MESSAGE.to_string(),
+        data: Some(json!({
+            "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
+            "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
+            "reason": "new_policy",
+        })),
+    };
+
+    let decline = SponsorshipDecline::try_from(error).unwrap();
+
+    assert_eq!(
+        decline.details.reason,
+        SponsorshipDeclineReason::Unknown("new_policy".to_string())
+    );
+}
+
 #[test]
 fn test_user_operation_serialization_with_null_fields() {
     let user_op = UserOperation {

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -123,7 +123,7 @@ async fn test_pm_sponsor_user_operation_returns_typed_decline() {
         .await
         .unwrap();
 
-    let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
+    let PmSponsorUserOperationResponse::Declined(decline) = outcome else {
         panic!("expected sponsorship to be declined");
     };
     assert_eq!(
@@ -134,7 +134,7 @@ async fn test_pm_sponsor_user_operation_returns_typed_decline() {
         decline.paymaster_address,
         address!("0000000000000039cd5e8ae05257ce51c473ddd1")
     );
-    assert_eq!(decline.reason, SponsorshipDeclineReason::GasUsage);
+    assert_eq!(decline.reason, PmSponsorshipDeclineReason::GasUsage);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn test_malformed_sponsorship_decline_preserves_rpc_error() {
         data: Some(data.clone()),
     };
 
-    let error = SponsorshipDecline::try_from(error).unwrap_err();
+    let error = PmSponsorshipDecline::try_from(error).unwrap_err();
 
     assert_eq!(error.data, Some(data));
 }
@@ -167,11 +167,11 @@ fn test_sponsorship_decline_preserves_unknown_reason() {
         })),
     };
 
-    let decline = SponsorshipDecline::try_from(error).unwrap();
+    let decline = PmSponsorshipDecline::try_from(error).unwrap();
 
     assert_eq!(
         decline.reason,
-        SponsorshipDeclineReason::Unknown("new_policy".to_string())
+        PmSponsorshipDeclineReason::Unknown("new_policy".to_string())
     );
 }
 
@@ -361,8 +361,7 @@ fn test_pm_sponsor_response_parsing() {
         "maxFeePerGas": "0x0",
         "maxPriorityFeePerGas": "0x0",
     });
-    let r: PmSponsorUserOperationResponse =
-        serde_json::from_value(no_paymaster).unwrap();
+    let r: PmSponsorshipApproval = serde_json::from_value(no_paymaster).unwrap();
     assert_eq!(r.call_gas_limit, U128::ZERO);
     assert_eq!(r.verification_gas_limit, U128::ZERO);
     assert_eq!(r.pre_verification_gas, U256::ZERO);
@@ -386,8 +385,7 @@ fn test_pm_sponsor_response_parsing() {
         "paymasterPostOpGasLimit": "0x706e",
         "paymasterData": "0x01000066d1a1a4",
     });
-    let r: PmSponsorUserOperationResponse =
-        serde_json::from_value(with_paymaster).unwrap();
+    let r: PmSponsorshipApproval = serde_json::from_value(with_paymaster).unwrap();
     assert_eq!(
         r.paymaster,
         Some(address!("0000000000000039cd5e8aE05257CE51C473ddd1"))

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -96,7 +96,7 @@ async fn test_rpc_call_preserves_structured_error_data() {
 }
 
 #[tokio::test]
-async fn test_request_pm_sponsorship_returns_typed_decline() {
+async fn test_pm_sponsor_user_operation_returns_typed_decline() {
     let response = serde_json::to_vec(&json!({
         "jsonrpc": "2.0",
         "id": "tx_test",
@@ -114,7 +114,7 @@ async fn test_request_pm_sponsorship_returns_typed_decline() {
     let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
 
     let outcome = client
-        .request_pm_sponsorship(
+        .pm_sponsor_user_operation(
             Network::WorldChain,
             &UserOperation::default(),
             Address::ZERO,
@@ -126,56 +126,15 @@ async fn test_request_pm_sponsorship_returns_typed_decline() {
     let PmSponsorUserOperationOutcome::Declined(decline) = outcome else {
         panic!("expected sponsorship to be declined");
     };
-    assert_eq!(decline.code, SPONSORSHIP_DECLINED_CODE);
-    assert_eq!(decline.error_message, SPONSORSHIP_DECLINED_MESSAGE);
     assert_eq!(
-        decline.details.token,
+        decline.token,
         address!("2cfc85d8e48f8eab294be644d9e25c3030863003")
     );
     assert_eq!(
-        decline.details.paymaster_address,
+        decline.paymaster_address,
         address!("0000000000000039cd5e8ae05257ce51c473ddd1")
     );
-    assert_eq!(decline.details.reason, SponsorshipDeclineReason::GasUsage);
-}
-
-#[tokio::test]
-async fn test_pm_sponsor_user_operation_preserves_public_error() {
-    let response = serde_json::to_vec(&json!({
-        "jsonrpc": "2.0",
-        "id": "tx_test",
-        "error": {
-            "code": SPONSORSHIP_DECLINED_CODE,
-            "message": SPONSORSHIP_DECLINED_MESSAGE,
-            "data": {
-                "token": "0x2cfc85d8e48f8eab294be644d9e25c3030863003",
-                "paymasterAddress": "0x0000000000000039cd5e8ae05257ce51c473ddd1",
-                "reason": "gas_usage",
-            },
-        },
-    }))
-    .unwrap();
-    let client = RpcClient::new(Arc::new(StaticHttpClient { response }));
-
-    let error = client
-        .pm_sponsor_user_operation(
-            Network::WorldChain,
-            &UserOperation::default(),
-            Address::ZERO,
-            &SponsorshipContext::Protocol,
-        )
-        .await
-        .unwrap_err();
-
-    let RpcError::RpcResponseError {
-        code,
-        error_message,
-    } = error
-    else {
-        panic!("expected the legacy JSON-RPC error");
-    };
-    assert_eq!(code, SPONSORSHIP_DECLINED_CODE);
-    assert_eq!(error_message, SPONSORSHIP_DECLINED_MESSAGE);
+    assert_eq!(decline.reason, SponsorshipDeclineReason::GasUsage);
 }
 
 #[test]
@@ -211,7 +170,7 @@ fn test_sponsorship_decline_preserves_unknown_reason() {
     let decline = SponsorshipDecline::try_from(error).unwrap();
 
     assert_eq!(
-        decline.details.reason,
+        decline.reason,
         SponsorshipDeclineReason::Unknown("new_policy".to_string())
     );
 }

--- a/bedrock/src/transactions/rpc/tests.rs
+++ b/bedrock/src/transactions/rpc/tests.rs
@@ -1,6 +1,19 @@
 use super::*;
 use alloy::primitives::{address, bytes, U128, U256};
 use serde_json::json;
+use strum::IntoEnumIterator;
+
+#[test]
+fn test_sponsorship_decline_reason_display_round_trip() {
+    for reason in PmSponsorshipDeclineReason::iter().chain(std::iter::once(
+        PmSponsorshipDeclineReason::Unknown("future_policy".to_string()),
+    )) {
+        let value = serde_json::Value::String(reason.to_string());
+        let decoded: PmSponsorshipDeclineReason =
+            serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, reason);
+    }
+}
 
 struct StaticHttpClient {
     response: Vec<u8>,

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -100,18 +100,18 @@ pub struct JsonRpcError {
 /// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct SponsorshipDecline {
+pub struct PmSponsorshipDecline {
     /// ERC-20 token the user can use to pay the transaction fee.
     pub token: Address,
     /// Paymaster contract that accepts the fee token.
     pub paymaster_address: Address,
     /// Policy reason for declining protocol sponsorship.
-    pub reason: SponsorshipDeclineReason,
+    pub reason: PmSponsorshipDeclineReason,
 }
 
-/// Reason protocol sponsorship was declined.
+/// Reason a `pm_sponsorUserOperation` request was declined.
 #[derive(Debug, PartialEq, Eq)]
-pub enum SponsorshipDeclineReason {
+pub enum PmSponsorshipDeclineReason {
     /// The L2 base fee exceeded the sponsorship threshold.
     L2BaseFee,
     /// The L1 data fee exceeded the sponsorship threshold.
@@ -124,7 +124,7 @@ pub enum SponsorshipDeclineReason {
     Unknown(String),
 }
 
-impl<'de> Deserialize<'de> for SponsorshipDeclineReason {
+impl<'de> Deserialize<'de> for PmSponsorshipDeclineReason {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -166,7 +166,7 @@ pub struct SponsorUserOperationResponse {
     pub provider_name: RpcProviderName,
 }
 
-/// Response from `pm_sponsorUserOperation` (V2)
+/// Approved sponsorship fields returned by `pm_sponsorUserOperation` (V2).
 ///
 /// Paymaster fields (`paymaster`, `paymaster_data`,
 /// `paymaster_verification_gas_limit`, `paymaster_post_op_gas_limit`) are
@@ -176,7 +176,7 @@ pub struct SponsorUserOperationResponse {
 /// `Option<T>` so both shapes deserialize.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PmSponsorUserOperationResponse {
+pub struct PmSponsorshipApproval {
     /// Call gas limit
     pub call_gas_limit: U128,
     /// Verification gas limit

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -97,6 +97,15 @@ pub struct JsonRpcError {
     pub data: Option<Value>,
 }
 
+/// Response from requesting paymaster sponsorship for a user operation.
+#[derive(Debug)]
+pub enum PmSponsorUserOperationResponse {
+    /// Sponsorship was approved with the returned gas and paymaster fields.
+    Approved(PmSponsorshipApproval),
+    /// Protocol sponsorship was declined with a self-sponsorship advisory.
+    Declined(PmSponsorshipDecline),
+}
+
 /// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::{Address, Bytes, U128, U256};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 /// JSON-RPC request ID
@@ -95,6 +95,49 @@ pub struct JsonRpcError {
     pub message: String,
     #[serde(default)]
     pub data: Option<Value>,
+}
+
+/// Structured details returned when protocol sponsorship is declined.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SponsorshipDeclineDetails {
+    /// ERC-20 token the user can use to pay the transaction fee.
+    pub token: Address,
+    /// Paymaster contract that accepts the fee token.
+    pub paymaster_address: Address,
+    /// Policy reason for declining protocol sponsorship.
+    pub reason: SponsorshipDeclineReason,
+}
+
+/// Reason protocol sponsorship was declined.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SponsorshipDeclineReason {
+    /// The L2 base fee exceeded the sponsorship threshold.
+    L2BaseFee,
+    /// The L1 data fee exceeded the sponsorship threshold.
+    L1DataFee,
+    /// The user's transaction count exceeded the sponsorship threshold.
+    TransactionCount,
+    /// The estimated gas usage exceeded the sponsorship threshold.
+    GasUsage,
+    /// A reason introduced by a newer sponsorship service.
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for SponsorshipDeclineReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "l2_base_fee" => Self::L2BaseFee,
+            "l1_data_fee" => Self::L1DataFee,
+            "tx_count" => Self::TransactionCount,
+            "gas_usage" => Self::GasUsage,
+            _ => Self::Unknown(value),
+        })
+    }
 }
 
 /// Response from `wa_sponsorUserOperation`

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -102,11 +102,11 @@ pub struct JsonRpcError {
 pub enum PmSponsorUserOperationResponse {
     /// Sponsorship was approved with the returned gas and paymaster fields.
     Approved(PmSponsorshipApproval),
-    /// Protocol sponsorship was declined with a self-sponsorship advisory.
+    /// Sponsorship was declined with a self-sponsorship advisory.
     Declined(PmSponsorshipDecline),
 }
 
-/// Self-sponsorship advisory returned when protocol sponsorship is declined.
+/// Self-sponsorship advisory returned when sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PmSponsorshipDecline {
@@ -114,7 +114,7 @@ pub struct PmSponsorshipDecline {
     pub token: Address,
     /// Paymaster contract that accepts the fee token.
     pub paymaster_address: Address,
-    /// Policy reason for declining protocol sponsorship.
+    /// Policy reason for declining sponsorship.
     pub reason: PmSponsorshipDeclineReason,
 }
 

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -97,10 +97,10 @@ pub struct JsonRpcError {
     pub data: Option<Value>,
 }
 
-/// Structured details returned when protocol sponsorship is declined.
+/// Self-sponsorship advisory returned when protocol sponsorship is declined.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct SponsorshipDeclineDetails {
+pub struct SponsorshipDecline {
     /// ERC-20 token the user can use to pay the transaction fee.
     pub token: Address,
     /// Paymaster contract that accepts the fee token.

--- a/bedrock/src/transactions/rpc/wire.rs
+++ b/bedrock/src/transactions/rpc/wire.rs
@@ -119,7 +119,7 @@ pub struct PmSponsorshipDecline {
 }
 
 /// Reason a `pm_sponsorUserOperation` request was declined.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, strum::EnumIter)]
 pub enum PmSponsorshipDeclineReason {
     /// The L2 base fee exceeded the sponsorship threshold.
     L2BaseFee,
@@ -131,6 +131,18 @@ pub enum PmSponsorshipDeclineReason {
     GasUsage,
     /// A reason introduced by a newer sponsorship service.
     Unknown(String),
+}
+
+impl std::fmt::Display for PmSponsorshipDeclineReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::L2BaseFee => "l2_base_fee",
+            Self::L1DataFee => "l1_data_fee",
+            Self::TransactionCount => "tx_count",
+            Self::GasUsage => "gas_usage",
+            Self::Unknown(value) => value,
+        })
+    }
 }
 
 impl<'de> Deserialize<'de> for PmSponsorshipDeclineReason {

--- a/bedrock/tests/test_smart_account_transfer.rs
+++ b/bedrock/tests/test_smart_account_transfer.rs
@@ -91,7 +91,7 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
 
     // 9) Sign and submit the exact operation that was prepared
     let _user_op_hash = safe_account
-        .submit_prepared_transaction(prepared)
+        .submit_prepared_transaction(&prepared)
         .await
         .expect("submit_prepared_transaction failed");
 

--- a/bedrock/tests/test_smart_account_transfer.rs
+++ b/bedrock/tests/test_smart_account_transfer.rs
@@ -86,15 +86,12 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
         .await
         .expect("prepare_transaction_transfer failed");
 
-    assert_eq!(prepared.token_address, wld_token_address.to_string());
-    assert_eq!(prepared.recipient_address, recipient.to_string());
-    assert_eq!(prepared.amount, amount);
     assert_eq!(wld.balanceOf(recipient).call().await?, before_recipient);
     assert_eq!(wld.balanceOf(safe_address).call().await?, before_safe);
 
     // 9) Sign and submit the exact operation that was prepared
     let _user_op_hash = safe_account
-        .submit_prepared_transaction(prepared.transaction)
+        .submit_prepared_transaction(prepared)
         .await
         .expect("submit_prepared_transaction failed");
 

--- a/bedrock/tests/test_smart_account_transfer.rs
+++ b/bedrock/tests/test_smart_account_transfer.rs
@@ -14,7 +14,7 @@ use bedrock::{
     test_utils::{AnvilBackedHttpClient, IEntryPoint},
 };
 
-// ------------------ The test for the full transaction_transfer flow ------------------
+// ------------------ The test for the full transaction transfer flow ------------------
 
 #[tokio::test]
 async fn test_transaction_transfer_full_flow_executes_user_operation(
@@ -70,23 +70,35 @@ async fn test_transaction_transfer_full_flow_executes_user_operation(
 
     set_http_client(Arc::new(client));
 
-    // 8) Execute high-level transfer via transaction_transfer
+    // 8) Prepare the transfer without signing or executing it
     let safe_account = SafeSmartAccount::from_private_key_hex(
         owner_key_hex,
         &safe_address.to_string(),
     )?;
     let amount = "1000000000000000000"; // 1 WLD
-    let _user_op_hash = safe_account
-        .transaction_transfer(
+    let prepared = safe_account
+        .prepare_transaction_transfer(
             &wld_token_address.to_string(),
             &recipient.to_string(),
             amount,
             None,
         )
         .await
-        .expect("transaction_transfer failed");
+        .expect("prepare_transaction_transfer failed");
 
-    // 9) Verify balances updated
+    assert_eq!(prepared.token_address, wld_token_address.to_string());
+    assert_eq!(prepared.recipient_address, recipient.to_string());
+    assert_eq!(prepared.amount, amount);
+    assert_eq!(wld.balanceOf(recipient).call().await?, before_recipient);
+    assert_eq!(wld.balanceOf(safe_address).call().await?, before_safe);
+
+    // 9) Sign and submit the exact operation that was prepared
+    let _user_op_hash = safe_account
+        .submit_prepared_transaction(prepared.transaction)
+        .await
+        .expect("submit_prepared_transaction failed");
+
+    // 10) Verify balances updated
     let after_recipient = wld.balanceOf(recipient).call().await?;
     let after_safe = wld.balanceOf(safe_address).call().await?;
 


### PR DESCRIPTION
Adds the first client-side ERC-20 transaction lifecycle in Bedrock.

`prepare_transaction_transfer` constructs the exact unsigned UserOperation, requests sponsorship from `pm_sponsorUserOperation` (V2), and returns an opaque prepared transaction. `submit_prepared_transaction` signs and submits that same operation through `/v2/rpc/worldchain`.

This intentionally covers the sponsored happy path only. WLD self-sponsorship and its cost advisory remain follow-up work.

Stacked on #435, which provides the typed `pm_sponsorUserOperation` response.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public ERC-20 transfer API and submission path (V2 sponsor + send); sponsorship decline is a hard error with no fallback yet.
> 
> **Overview**
> Splits World Chain ERC-20 transfers into a **prepare → submit** flow so clients can review an unsigned operation (with sponsorship applied) before signing.
> 
> **`prepare_transaction_transfer`** builds the preflight `UserOperation`, calls **`pm_sponsorUserOperation`** with protocol sponsorship context, merges approved paymaster/gas fields via new **`UserOperation::with_pm_sponsorship_approval`**, and returns a **`PreparedTransaction`** (UniFFI object). Declined sponsorship currently errors out (self-sponsor left as TODO).
> 
> **`submit_prepared_transaction`** checks the prepared sender matches the account, signs the operation, and submits through **`send_user_operation_v2`**. Structured logging was added for both stages.
> 
> Supporting changes: test HTTP mock handles **`pm_sponsorUserOperation`**; **`PmSponsorshipDeclineReason`** gets **`Display`** + **`EnumIter`** and a serde round-trip test; the Anvil integration test now asserts balances are unchanged until submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e1d307de6ef54955f11da46a2d2f609b6846c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->