### PR TITLE
feat: batch backup file changes

### DIFF
--- a/bedrock/src/backup/manifest.rs
+++ b/bedrock/src/backup/manifest.rs
@@ -197,11 +197,10 @@ impl ManifestManager {
         Ok(files)
     }
 
-    /// Adds a file entry for a given designator. Will trigger a backup sync.
+    /// Adds or refreshes a file and syncs the backup when its manifest entry changes.
     ///
     /// # Errors
-    /// - Returns an error if remote hash does not match local (remote is ahead).
-    /// - Returns an error if serialization fails.
+    /// Returns an error if the remote backup is ahead or the file cannot be backed up.
     pub async fn store_file(
         &self,
         designator: BackupFileDesignator,
@@ -209,45 +208,21 @@ impl ManifestManager {
         root_secret: &str,
         backup_keypair_public_key: String,
     ) -> Result<(), BackupError> {
-        let normalized_path = Self::normalize_input_path(&file_path).to_string();
-        let result = self
-            .mutate_manifest_and_sync(
-                root_secret,
-                backup_keypair_public_key,
-                |manifest| {
-                    if manifest
-                        .files
-                        .iter()
-                        .any(|e| e.file_path == normalized_path)
-                    {
-                        crate::warn!(
-                            "File already exists in the manifest: {}",
-                            normalized_path.get(..14).unwrap_or(&normalized_path)
-                        );
-                        return Ok(ManifestMutation::NoChange);
-                    }
-                    let (checksum_hex, _file_size_bytes) =
-                        Self::checksum_and_size_for_file(&normalized_path)?;
-                    manifest.files.push(V0BackupManifestEntry {
-                        designator,
-                        file_path: normalized_path,
-                        checksum_hex,
-                    });
-                    Ok(ManifestMutation::Changed)
-                },
-            )
-            .await;
-
-        Self::send_sync_event(&result).await;
-
-        result
+        self.sync_changes(
+            root_secret,
+            backup_keypair_public_key,
+            vec![BackupFileChange::Put {
+                designator,
+                path: file_path,
+            }],
+        )
+        .await
     }
 
-    /// Replaces all the file entries for a given designator by removing all existing entries for a given designator
-    /// and adding a new file.
+    /// Replaces a designator's files and syncs the backup when the manifest changes.
     ///
     /// # Errors
-    /// Returns an error if the remote hash does not match local or downstream operations fail.
+    /// Returns an error if the remote backup is ahead or the file cannot be backed up.
     pub async fn replace_all_files_for_designator(
         &self,
         designator: BackupFileDesignator,
@@ -255,65 +230,34 @@ impl ManifestManager {
         root_secret: &str,
         backup_keypair_public_key: String,
     ) -> Result<(), BackupError> {
-        let normalized_path = Self::normalize_input_path(&new_file_path).to_string();
-        let result = self
-            .mutate_manifest_and_sync(
-                root_secret,
-                backup_keypair_public_key,
-                |manifest| {
-                    let (checksum_hex, _file_size_bytes) =
-                        Self::checksum_and_size_for_file(&normalized_path)?;
-                    manifest.files.retain(|e| e.designator != designator);
-                    manifest.files.push(V0BackupManifestEntry {
-                        designator,
-                        file_path: normalized_path,
-                        checksum_hex,
-                    });
-                    Ok(ManifestMutation::Changed)
-                },
-            )
-            .await;
-
-        Self::send_sync_event(&result).await;
-
-        result
+        self.sync_changes(
+            root_secret,
+            backup_keypair_public_key,
+            vec![BackupFileChange::ReplaceFiles {
+                designator,
+                paths: vec![new_file_path],
+            }],
+        )
+        .await
     }
 
-    /// Removes a specific file entry. Triggers a backup sync.
+    /// Removes a file from the manifest and syncs the backup.
     ///
     /// # Errors
-    /// - Returns an error if the file does not exist in the backup.
-    /// - Returns an error if the remote hash does not match local (remote is ahead).
-    /// - Returns an error if serialization fails.
+    /// Returns an error if the file is not registered, the remote backup is ahead,
+    /// or the remaining files cannot be backed up.
     pub async fn remove_file(
         &self,
         file_path: String,
         root_secret: &str,
         backup_keypair_public_key: String,
     ) -> Result<(), BackupError> {
-        let normalized_path = Self::normalize_input_path(&file_path).to_string();
-        let result = self
-            .mutate_manifest_and_sync(
-                root_secret,
-                backup_keypair_public_key,
-                |manifest| {
-                    let before_len = manifest.files.len();
-                    manifest.files.retain(|e| e.file_path != normalized_path);
-                    if manifest.files.len() == before_len {
-                        return Err(BackupError::InvalidFileForBackup(format!(
-                            "File not found in manifest: {}",
-                            // only log the first 14 characters of the path to avoid leaking info
-                            normalized_path.get(..14).unwrap_or(&normalized_path)
-                        )));
-                    }
-                    Ok(ManifestMutation::Changed)
-                },
-            )
-            .await;
-
-        Self::send_sync_event(&result).await;
-
-        result
+        self.sync_changes(
+            root_secret,
+            backup_keypair_public_key,
+            vec![BackupFileChange::Remove { path: file_path }],
+        )
+        .await
     }
 }
 
@@ -516,59 +460,115 @@ impl ManifestManager {
             })
     }
 
-    /// Applies a manifest mutation and, if changed, rebuilds, syncs, and commits the update.
-    async fn mutate_manifest_and_sync<F>(
+    pub(super) async fn sync_changes(
         &self,
         root_secret: &str,
         backup_keypair_public_key: String,
-        mutator: F,
-    ) -> Result<(), BackupError>
-    where
-        F: FnOnce(&mut V0BackupManifest) -> Result<ManifestMutation, BackupError>,
-    {
+        changes: Vec<BackupFileChange>,
+    ) -> Result<(), BackupError> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+        let result = self
+            .mutate_manifest_and_sync(root_secret, backup_keypair_public_key, changes)
+            .await;
+        Self::send_sync_event(&result).await;
+        result
+    }
+
+    async fn mutate_manifest_and_sync(
+        &self,
+        root_secret: &str,
+        backup_keypair_public_key: String,
+        changes: Vec<BackupFileChange>,
+    ) -> Result<(), BackupError> {
         let root = RootKey::from_json(root_secret).map_err(|_| {
-            BackupError::InvalidRootSecretError(format!(
-                "invalid secret provided for mutating the manifest: {}",
-                root_secret.chars().next().unwrap_or_default() == '{'
-            ))
+            BackupError::InvalidRootSecretError(
+                "invalid root secret for backup sync".to_string(),
+            )
         })?;
         let pk_bytes = hex::decode(backup_keypair_public_key)
             .map_err(|_| BackupError::DecodeBackupKeypairError)?;
         let pk = PublicKey::from_slice(&pk_bytes)
             .map_err(|_| BackupError::DecodeBackupKeypairError)?;
-
-        let (mut manifest, local_hash) = self.load_manifest_gated().await?;
-
-        match mutator(&mut manifest)? {
-            ManifestMutation::NoChange => return Ok(()),
-            ManifestMutation::Changed => (),
+        let (manifest, remote_hash) = self.load_manifest_gated().await?;
+        let mut manifest = BackupManifest::V0(manifest);
+        let original_hash = manifest.to_hash()?;
+        let BackupManifest::V0(contents) = &mut manifest;
+        Self::apply_changes(contents, changes)?;
+        let new_hash = manifest.to_hash()?;
+        if original_hash == new_hash && remote_hash == new_hash {
+            return Ok(());
         }
 
-        let files = self.build_unsealed_backup_files_from_manifest(&manifest)?;
+        let BackupManifest::V0(contents) = &manifest;
+        let files = self.build_unsealed_backup_files_from_manifest(contents)?;
         let unsealed_backup = V0Backup::new(root, files).to_bytes()?;
         let sealed_backup =
             BackupManager::seal_backup_with_public_key(&unsealed_backup, &pk)?;
-
-        let updated_manifest = BackupManifest::V0(manifest);
-        let new_manifest_hash = updated_manifest.to_hash()?;
-
         BackupServiceClient::sync(
-            hex::encode(local_hash),
-            hex::encode(new_manifest_hash),
+            hex::encode(remote_hash),
+            hex::encode(new_hash),
             sealed_backup,
         )
         .await?;
-
-        // commit the updated manifest once the remote sync has been successful
-        self.write_manifest(&updated_manifest)?;
-
-        // Refresh backup report from manifest; ignore errors
-        if let Err(e) = ClientEventsReporter::new().sync_base_report_with_manifest() {
+        self.write_manifest(&manifest)?;
+        if let Err(error) = ClientEventsReporter::new().sync_base_report_with_manifest()
+        {
             crate::warn!(
-                "[ClientEvents] failed to refresh backup report after manifest update: {e:?}"
+                error_message = error,
+                "Failed to refresh backup report after sync"
             );
         }
+        Ok(())
+    }
 
+    fn apply_changes(
+        manifest: &mut V0BackupManifest,
+        changes: Vec<BackupFileChange>,
+    ) -> Result<(), BackupError> {
+        for change in changes {
+            match change {
+                BackupFileChange::Put { designator, path } => {
+                    Self::put_file(manifest, designator, &path)?;
+                }
+                BackupFileChange::Remove { path } => {
+                    let path = Self::normalize_input_path(&path);
+                    let before = manifest.files.len();
+                    manifest.files.retain(|entry| entry.file_path != path);
+                    if manifest.files.len() == before {
+                        return Err(BackupError::InvalidFileForBackup(format!(
+                            "File not found in manifest: {}",
+                            path.get(..14).unwrap_or(path)
+                        )));
+                    }
+                }
+                BackupFileChange::ReplaceFiles { designator, paths } => {
+                    manifest
+                        .files
+                        .retain(|entry| entry.designator != designator);
+                    for path in paths {
+                        Self::put_file(manifest, designator.clone(), &path)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn put_file(
+        manifest: &mut V0BackupManifest,
+        designator: BackupFileDesignator,
+        path: &str,
+    ) -> Result<(), BackupError> {
+        let path = Self::normalize_input_path(path);
+        let (checksum_hex, _) = Self::checksum_and_size_for_file(path)?;
+        manifest.files.retain(|entry| entry.file_path != path);
+        manifest.files.push(V0BackupManifestEntry {
+            designator,
+            file_path: path.to_string(),
+            checksum_hex,
+        });
         Ok(())
     }
 
@@ -594,10 +594,18 @@ impl Default for ManifestManager {
     }
 }
 
-/// Internal signal indicating whether a manifest mutation produced a change.
-enum ManifestMutation {
-    NoChange,
-    Changed,
+pub(super) enum BackupFileChange {
+    Put {
+        designator: BackupFileDesignator,
+        path: String,
+    },
+    Remove {
+        path: String,
+    },
+    ReplaceFiles {
+        designator: BackupFileDesignator,
+        paths: Vec<String>,
+    },
 }
 
 #[cfg(test)]

--- a/bedrock/src/backup/test.rs
+++ b/bedrock/src/backup/test.rs
@@ -1,7 +1,7 @@
 use crate::backup::backup_format::v0::{V0Backup, V0BackupFile};
 use crate::backup::backup_format::v0::{V0BackupManifest, V0BackupManifestEntry};
 use crate::backup::backup_format::BackupFormat;
-use crate::backup::manifest::{BackupManifest, ManifestManager};
+use crate::backup::manifest::{BackupFileChange, BackupManifest, ManifestManager};
 use crate::backup::service_client::{
     set_backup_service_api, BackupServiceApi, RetrieveMetadataResponsePayload,
     SyncSubmitRequest,
@@ -428,6 +428,58 @@ async fn test_store_file_happy_path_and_commit() {
 
 #[tokio::test]
 #[serial]
+async fn test_store_file_refreshes_changed_contents_without_removing_entry() {
+    let api = init_test_globals();
+    api.reset();
+    let prefix = "backup_test_store_refresh";
+    write_manifest_with_prefix(&BackupManifest::default(), prefix);
+    let manager = ManifestManager::new_with_prefix(prefix);
+    let root = RootKey::new_random().danger_to_json().unwrap();
+    let key = SecretKey::generate(&mut rand::thread_rng());
+    let public_key = hex::encode(key.public_key().as_bytes());
+    let path = "pcp/refresh.bin";
+
+    write_global_file(path, b"before");
+    manager
+        .store_file(
+            BackupFileDesignator::OrbPkg,
+            path.into(),
+            &root,
+            public_key.clone(),
+        )
+        .await
+        .unwrap();
+    write_global_file(path, b"after");
+    manager
+        .store_file(
+            BackupFileDesignator::OrbPkg,
+            path.into(),
+            &root,
+            public_key.clone(),
+        )
+        .await
+        .unwrap();
+
+    let BackupManifest::V0(manifest) = get_manifest_from_disk(prefix);
+    assert_eq!(manifest.files.len(), 1);
+    assert_eq!(
+        manifest.files[0].checksum_hex,
+        hex::encode(blake3::hash(b"after").as_bytes())
+    );
+    let uploaded = api.state.lock().unwrap().last_sync.clone().unwrap();
+    let archive = key.unseal(&uploaded.sealed_backup).unwrap();
+    let BackupFormat::V0(backup) = BackupFormat::from_bytes(&archive).unwrap();
+    assert_eq!(backup.files[0].data, b"after");
+
+    manager
+        .store_file(BackupFileDesignator::OrbPkg, path.into(), &root, public_key)
+        .await
+        .unwrap();
+    assert_eq!(api.state.lock().unwrap().sync_count, 2);
+}
+
+#[tokio::test]
+#[serial]
 async fn test_store_file_accepts_dot_slash_path() {
     let api = init_test_globals();
     api.reset();
@@ -572,6 +624,10 @@ async fn test_store_file_propagates_sync_failure() {
     // The error should be an HTTP error propagated through BackupError
     let msg = err.to_string();
     assert!(msg.contains("Bad status code"), "unexpected error: {msg}");
+    assert_eq!(
+        compute_manifest_hash_from_disk("backup_test_store_sync_failure"),
+        compute_manifest_hash(&m0)
+    );
 }
 
 #[tokio::test]
@@ -887,6 +943,177 @@ async fn test_remove_file_happy_and_not_found() {
         .await
         .expect_err("expected file-not-found error");
     assert!(err.to_string().contains("File not found in manifest"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_changes_uploads_one_complete_backup() {
+    let api = init_test_globals();
+    api.reset();
+    let prefix = "backup_test_batch";
+    let before = BackupManifest::V0(V0BackupManifest {
+        files: vec![
+            V0BackupManifestEntry {
+                designator: BackupFileDesignator::OrbPkg,
+                file_path: "orb/old.bin".into(),
+                checksum_hex: hex::encode(blake3::hash(b"old").as_bytes()),
+            },
+            V0BackupManifestEntry {
+                designator: BackupFileDesignator::DocumentPkg,
+                file_path: "docs/remove.bin".into(),
+                checksum_hex: hex::encode(blake3::hash(b"remove").as_bytes()),
+            },
+            V0BackupManifestEntry {
+                designator: BackupFileDesignator::DocumentPkg,
+                file_path: "docs/keep.bin".into(),
+                checksum_hex: hex::encode(blake3::hash(b"keep").as_bytes()),
+            },
+        ],
+    });
+    write_manifest_with_prefix(&before, prefix);
+    api.set_remote_hash(compute_manifest_hash(&before));
+    let expected_files = [
+        ("docs/keep.bin", b"keep".as_slice()),
+        ("docs/new.bin", b"new".as_slice()),
+        ("orb/one.bin", b"one".as_slice()),
+        ("orb/two.bin", b"two".as_slice()),
+    ];
+    for (path, contents) in expected_files {
+        write_global_file(path, contents);
+    }
+    let key = SecretKey::generate(&mut rand::thread_rng());
+    ManifestManager::new_with_prefix(prefix)
+        .sync_changes(
+            &RootKey::new_random().danger_to_json().unwrap(),
+            hex::encode(key.public_key().as_bytes()),
+            vec![
+                BackupFileChange::Put {
+                    designator: BackupFileDesignator::DocumentPkg,
+                    path: "docs/new.bin".into(),
+                },
+                BackupFileChange::Remove {
+                    path: "docs/remove.bin".into(),
+                },
+                BackupFileChange::ReplaceFiles {
+                    designator: BackupFileDesignator::OrbPkg,
+                    paths: vec!["orb/one.bin".into(), "orb/two.bin".into()],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+    let uploaded = api.state.lock().unwrap().last_sync.clone().unwrap();
+    assert_eq!(api.state.lock().unwrap().sync_count, 1);
+    assert_eq!(
+        uploaded.current_manifest_hash,
+        compute_manifest_hash(&before)
+    );
+    assert_eq!(
+        uploaded.new_manifest_hash,
+        compute_manifest_hash_from_disk(prefix)
+    );
+    let archive = key.unseal(&uploaded.sealed_backup).unwrap();
+    let BackupFormat::V0(backup) = BackupFormat::from_bytes(&archive).unwrap();
+    assert_eq!(backup.files.len(), expected_files.len());
+    for (path, contents) in expected_files {
+        let file = backup.files.iter().find(|file| file.path == path).unwrap();
+        assert_eq!(file.data, contents);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_changes_failure_preserves_manifest() {
+    let api = init_test_globals();
+    let prefix = "backup_test_batch_failure";
+    let manager = ManifestManager::new_with_prefix(prefix);
+    let root = RootKey::new_random().danger_to_json().unwrap();
+    let key = SecretKey::generate(&mut rand::thread_rng());
+    let public_key = hex::encode(key.public_key().as_bytes());
+    write_global_file("batch/valid.bin", b"valid");
+    let cases = [
+        BackupFileChange::Put {
+            designator: BackupFileDesignator::OrbPkg,
+            path: "batch/missing.bin".into(),
+        },
+        BackupFileChange::Remove {
+            path: "batch/missing.bin".into(),
+        },
+        BackupFileChange::ReplaceFiles {
+            designator: BackupFileDesignator::OrbPkg,
+            paths: vec!["batch/valid.bin".into(), "batch/missing.bin".into()],
+        },
+    ];
+    for failing_change in cases {
+        api.reset();
+        write_manifest_with_prefix(&BackupManifest::default(), prefix);
+        let before = read_manifest_bytes(prefix);
+        manager
+            .sync_changes(
+                &root,
+                public_key.clone(),
+                vec![
+                    BackupFileChange::Put {
+                        designator: BackupFileDesignator::OrbPkg,
+                        path: "batch/valid.bin".into(),
+                    },
+                    failing_change,
+                ],
+            )
+            .await
+            .expect_err("an invalid edit must reject the whole batch");
+        assert_eq!(read_manifest_bytes(prefix), before);
+        assert!(api.state.lock().unwrap().last_sync.is_none());
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_changes_recreates_missing_remote_without_local_changes() {
+    let api = init_test_globals();
+    api.reset();
+    let prefix = "backup_test_batch_missing_remote";
+    let path = "batch/existing.bin";
+    write_global_file(path, b"existing");
+    let manifest = BackupManifest::V0(V0BackupManifest {
+        files: vec![V0BackupManifestEntry {
+            designator: BackupFileDesignator::OrbPkg,
+            file_path: path.into(),
+            checksum_hex: hex::encode(blake3::hash(b"existing").as_bytes()),
+        }],
+    });
+    write_manifest_with_prefix(&manifest, prefix);
+    api.set_no_remote_backup();
+    let key = SecretKey::generate(&mut rand::thread_rng());
+    ManifestManager::new_with_prefix(prefix)
+        .replace_all_files_for_designator(
+            BackupFileDesignator::OrbPkg,
+            path.into(),
+            &RootKey::new_random().danger_to_json().unwrap(),
+            hex::encode(key.public_key().as_bytes()),
+        )
+        .await
+        .unwrap();
+    let uploaded = api.state.lock().unwrap().last_sync.clone().unwrap();
+    assert_eq!(
+        uploaded.current_manifest_hash,
+        BackupManifest::default_hash_hex()
+    );
+    assert_eq!(uploaded.new_manifest_hash, compute_manifest_hash(&manifest));
+    assert_eq!(api.state.lock().unwrap().sync_count, 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_sync_changes_empty_batch_needs_no_credentials_or_manifest() {
+    let api = init_test_globals();
+    api.reset();
+    ManifestManager::new_with_prefix("backup_test_empty_batch")
+        .sync_changes("", String::new(), vec![])
+        .await
+        .unwrap();
+    assert_eq!(api.state.lock().unwrap().sync_count, 0);
 }
 
 // =========================

--- a/bedrock/src/primitives/retry.rs
+++ b/bedrock/src/primitives/retry.rs
@@ -62,7 +62,8 @@ pub enum RetryError<E> {
 ///
 /// # Errors
 /// Returns the last error from `op` once retries are exhausted or `is_retryable`
-/// returns `false`.
+/// returns `false`. Returns [`RetryError::Timeout`] when the total deadline expires,
+/// dropping any in-flight operation; a submitted mutation may still commit remotely.
 pub async fn retry_with_backoff<T, E, Fut>(
     policy: &RetryPolicy,
     operation: &str,


### PR DESCRIPTION
Changes the internal interface for updating backup files to allow a single atomic update from multiple file changes. In a follow up PR, a single `sync` method will be exposed to foreign code to allow simple file syncs and delegate all the complex logic to Bedrock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup manifest mutation and sync orchestration, including re-store semantics and atomic batch failure behavior, in security-sensitive backup code.
> 
> **Overview**
> Introduces **`BackupFileChange`** (`Put`, `Remove`, `ReplaceFiles`) and **`sync_changes`** so multiple manifest edits apply in one pass and produce a **single** sealed backup upload and remote sync. **`store_file`**, **`remove_file`**, and **`replace_all_files_for_designator`** now delegate to this path instead of ad-hoc closure mutations.
> 
> **`Put`** upserts by path: re-storing the same path **refreshes the checksum** and can trigger another sync when on-disk content changed (previously an existing path was a no-op). Batches are **all-or-nothing** before sync—any invalid change leaves the on-disk manifest untouched—and an **empty** change list returns immediately without touching credentials or the network.
> 
> Sync can **short-circuit** when local and remote hashes already match the post-change manifest; invalid root secret errors use a generic message instead of hinting at input shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ba0c94e9ee173ff18f714f2d9b9d32f24c5f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->