### PR TITLE
feat: Update Worldchain URLs.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-WORLDCHAIN_RPC_URL=https://worldchain-mainnet.g.alchemy.com/public # substitute with your own RPC in case of rate limits
+WORLDCHAIN_RPC_URL=https://rpc.worldchain.worldcoin.org # substitute with your own RPC in case of rate limits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Run tests
         env:
           # Details in http://go/rpc-ci-account (`bedrock` app)
-          WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://worldchain-mainnet.g.alchemy.com/public' }}
+          WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://rpc.worldchain.worldcoin.org' }}
         run: |
           cp .env.example .env
           cargo test --all --features test_utils

--- a/bedrock/src/transactions/contracts/usd_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/usd_legacy_vault.rs
@@ -48,7 +48,7 @@ pub struct Permit2Data {
 
 sol! {
     /// The USD Vault contract interface.
-    /// Reference: <https://worldchain-mainnet.explorer.alchemy.com/address/0xB0e31149c03F1300BD9fF8C165B1fa38fDA2F0bB?tab=contract>
+    /// Reference: <https://explorer.worldchain.worldcoin.org/address/0xB0e31149c03F1300BD9fF8C165B1fa38fDA2F0bB?tab=contract>
     #[derive(serde::Serialize)]
     interface USDVault {
         function USDC() public view returns (address);

--- a/bedrock/src/transactions/contracts/wld_legacy_vault.rs
+++ b/bedrock/src/transactions/contracts/wld_legacy_vault.rs
@@ -32,7 +32,7 @@ use crate::{
 
 sol! {
     /// The WLD Vault contract interface.
-    /// Reference: <https://worldchain-mainnet.explorer.alchemy.com/address/0x14a028cC500108307947dca4a1Aa35029FB66CE0?tab=contract>
+    /// Reference: <https://explorer.worldchain.worldcoin.org/address/0x14a028cC500108307947dca4a1Aa35029FB66CE0?tab=contract>
     #[derive(serde::Serialize)]
     interface WLDVault {
         function token() public view returns (address);

--- a/bedrock/tests/common.rs
+++ b/bedrock/tests/common.rs
@@ -103,7 +103,7 @@ pub fn setup_anvil() -> AnvilInstance {
     dotenvy::dotenv().ok();
     let rpc_url = std::env::var("WORLDCHAIN_RPC_URL").unwrap_or_else(|_| {
         // Fallback to a public, no-key RPC if available.
-        "https://worldchain-mainnet.g.alchemy.com/public".to_string()
+        "https://rpc.worldchain.worldcoin.org".to_string()
     });
 
     alloy::node_bindings::Anvil::new().fork(rpc_url).spawn()


### PR DESCRIPTION
We are introducing new URLs for Worldchain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> URL and documentation-only updates; behavior depends on the new RPC/explorer being available and equivalent for forks and CI.
> 
> **Overview**
> Replaces **Alchemy** Worldchain defaults with **Worldcoin-hosted** URLs across local dev, CI, and tests.
> 
> `WORLDCHAIN_RPC_URL` in `.env.example`, the CI test job fallback (when `secrets.WORLDCHAIN_RPC_URL` is unset), and `setup_anvil()` in `bedrock/tests/common.rs` now default to `https://rpc.worldchain.worldcoin.org` instead of the public Alchemy RPC.
> 
> Contract interface doc links in `usd_legacy_vault.rs` and `wld_legacy_vault.rs` point at `explorer.worldchain.worldcoin.org` instead of `worldchain-mainnet.explorer.alchemy.com`. No runtime or contract logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3df84ba638016fdacd27acc58d034f16019dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->