### PR TITLE
fix(transactions): use NTP time for on-chain signature deadlines

### DIFF
--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -4,12 +4,13 @@
 //!
 
 use crate::primitives::contracts::{EncodedSafeOpStruct, UserOperation};
+use crate::primitives::ntp::now_with_ntp;
 use crate::primitives::{Network, PrimitiveError};
 use crate::smart_account::{SafeSmartAccount, SafeSmartAccountSigner};
 use crate::transactions::rpc::{RpcError, RpcProviderName};
 
 use alloy::primitives::{aliases::U48, Address, Bytes, FixedBytes};
-use chrono::{Duration, Utc};
+use chrono::Duration;
 
 use crate::primitives::contracts::{ENTRYPOINT_4337, GNOSIS_SAFE_4337_MODULE};
 
@@ -38,7 +39,7 @@ impl SafeSmartAccount {
         let valid_after_bytes: [u8; 6] = [0u8; 6];
 
         // validUntil = now + configured duration
-        let valid_until_seconds = (Utc::now()
+        let valid_until_seconds = (now_with_ntp()
             + Duration::minutes(USER_OPERATION_VALIDITY_DURATION_MINUTES))
         .timestamp();
         let valid_until_seconds: u64 = valid_until_seconds.try_into().unwrap_or(0);
@@ -494,8 +495,14 @@ mod tests {
             Bytes::from_str("0x1234").unwrap(),
         );
 
+        let earliest_expiry = (now_with_ntp()
+            + Duration::minutes(USER_OPERATION_VALIDITY_DURATION_MINUTES))
+        .timestamp() as u64;
         safe.sign_user_operation(&mut user_op, Network::WorldChain)
             .unwrap();
+        let latest_expiry = (now_with_ntp()
+            + Duration::minutes(USER_OPERATION_VALIDITY_DURATION_MINUTES))
+        .timestamp() as u64;
 
         // Signature should be exactly 77 bytes (6 + 6 + 65)
         assert_eq!(user_op.signature.len(), 77);
@@ -510,6 +517,7 @@ mod tests {
         // The timestamps should be extractable from the signed operation
         let (valid_after, valid_until) = user_op.extract_validity_timestamps().unwrap();
         assert_eq!(valid_after, U48::from(0u64));
-        assert!(valid_until > U48::from(0u64));
+        assert!(valid_until >= U48::from(earliest_expiry));
+        assert!(valid_until <= U48::from(latest_expiry));
     }
 }

--- a/bedrock/src/smart_account/transaction_4337.rs
+++ b/bedrock/src/smart_account/transaction_4337.rs
@@ -495,14 +495,8 @@ mod tests {
             Bytes::from_str("0x1234").unwrap(),
         );
 
-        let earliest_expiry = (now_with_ntp()
-            + Duration::minutes(USER_OPERATION_VALIDITY_DURATION_MINUTES))
-        .timestamp() as u64;
         safe.sign_user_operation(&mut user_op, Network::WorldChain)
             .unwrap();
-        let latest_expiry = (now_with_ntp()
-            + Duration::minutes(USER_OPERATION_VALIDITY_DURATION_MINUTES))
-        .timestamp() as u64;
 
         // Signature should be exactly 77 bytes (6 + 6 + 65)
         assert_eq!(user_op.signature.len(), 77);
@@ -517,7 +511,6 @@ mod tests {
         // The timestamps should be extractable from the signed operation
         let (valid_after, valid_until) = user_op.extract_validity_timestamps().unwrap();
         assert_eq!(valid_after, U48::from(0u64));
-        assert!(valid_until >= U48::from(earliest_expiry));
-        assert!(valid_until <= U48::from(latest_expiry));
+        assert!(valid_until > U48::from(0u64));
     }
 }

--- a/bedrock/src/transactions/mod.rs
+++ b/bedrock/src/transactions/mod.rs
@@ -1,13 +1,12 @@
 use alloy::primitives::{Address, U256};
 use bedrock_macros::bedrock_export;
-use chrono::Utc;
 use rand::{Rng, RngCore};
 use std::sync::Arc;
 
 use alloy::primitives::aliases::{U160, U48};
 
 use crate::{
-    primitives::{HexEncodedData, Network, ParseFromForeignBinding},
+    primitives::{ntp::now_with_ntp, HexEncodedData, Network, ParseFromForeignBinding},
     smart_account::{
         Is4337Encodable, Permit2Approve, SafeSmartAccount, UnparsedPermitTransferFrom,
         UnparsedTokenPermissions,
@@ -535,7 +534,7 @@ impl SafeSmartAccount {
             U256::from_be_bytes(rng.gen::<[u8; 32]>())
         };
 
-        let deadline = Utc::now().timestamp() + 180; // 3 minutes from now
+        let deadline = now_with_ntp().timestamp() + 180; // 3 minutes from now
 
         let transfer = UnparsedPermitTransferFrom {
             permitted,


### PR DESCRIPTION
Use the existing `now_with_ntp()` helper when calculating the 30-minute UserOperation signature expiry and the USD legacy-vault migration's 3-minute Permit2 deadline. This honors the host application's configured time provider instead of always using a potentially skewed device clock.

Preserves the helper's existing device-clock fallback when no provider is configured or its timestamp is invalid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong or skewed time from the NTP provider could shorten or extend signature validity and cause UserOperation or Permit2 rejections, though invalid/missing provider still falls back to device time.
> 
> **Overview**
> **4337 UserOperation signing** and **Permit2 deadlines** now use `now_with_ntp()` instead of `Utc::now()` when computing time-based validity.
> 
> In `sign_user_operation`, the **validUntil** timestamp is still “now + 30 minutes”, but “now” comes from the host-configured NTP provider when set. The USD legacy vault migration path applies the same change for the **3-minute Permit2 transfer deadline**.
> 
> Behavior when no provider is configured or the provider timestamp is invalid is unchanged: the helper still falls back to the device clock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8d616a5914419f90f13c20af409887f799d24c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

