### PR TITLE
feat: reconcile legacy sync factor cleanup with Secure Enclave signer

### DIFF
--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -684,16 +684,17 @@ impl TurnkeyApiClient {
     ) -> Result<(), TurnkeyApiError> {
         let legacy_user_id = uuid::Uuid::try_parse(legacy_user_id)
             .map_err(|_| {
-                TurnkeyApiError::Client("legacy sync-factor user id is not a UUID".to_string())
+                TurnkeyApiError::Client(
+                    "legacy sync-factor user id is not a UUID".to_string(),
+                )
             })?
             .to_string();
 
         let users = self
             .get_users(suborganization_id, replacement_sync_factor)
             .await?;
-        let Some(legacy_user) = users
-            .iter()
-            .find(|user| user.user_id == legacy_user_id)
+        let Some(legacy_user) =
+            users.iter().find(|user| user.user_id == legacy_user_id)
         else {
             // A previous attempt may have deleted the user after the caller
             // lost the activity response. Absence is the desired terminal state.
@@ -1162,7 +1163,11 @@ mod tests {
         let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
 
         TurnkeyApiClient::with_base_url(server.uri())
-            .reconcile_legacy_sync_factor_user(SUBORGANIZATION_ID, USER_ID, SyncFactor(&signer))
+            .reconcile_legacy_sync_factor_user(
+                SUBORGANIZATION_ID,
+                USER_ID,
+                SyncFactor(&signer),
+            )
             .await
             .unwrap();
     }
@@ -1216,12 +1221,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconcile_legacy_sync_factor_user_rejects_an_invalid_user_id_without_a_request() {
+    async fn reconcile_legacy_sync_factor_user_rejects_an_invalid_user_id_without_a_request(
+    ) {
         let server = MockServer::start().await;
         let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
 
         let error = TurnkeyApiClient::with_base_url(server.uri())
-            .reconcile_legacy_sync_factor_user("suborg-1", "not-a-uuid", SyncFactor(&signer))
+            .reconcile_legacy_sync_factor_user(
+                "suborg-1",
+                "not-a-uuid",
+                SyncFactor(&signer),
+            )
             .await
             .unwrap_err();
 

--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -682,11 +682,11 @@ impl TurnkeyApiClient {
         legacy_user_id: &str,
         replacement_sync_factor: SyncFactor<'_>,
     ) -> Result<(), TurnkeyApiError> {
-        if uuid::Uuid::try_parse(legacy_user_id).is_err() {
-            return Err(TurnkeyApiError::Client(
-                "legacy sync-factor user id is not a UUID".to_string(),
-            ));
-        }
+        let legacy_user_id = uuid::Uuid::try_parse(legacy_user_id)
+            .map_err(|_| {
+                TurnkeyApiError::Client("legacy sync-factor user id is not a UUID".to_string())
+            })?
+            .to_string();
 
         let users = self
             .get_users(suborganization_id, replacement_sync_factor)
@@ -709,7 +709,7 @@ impl TurnkeyApiClient {
 
         let client = self.sdk_client(replacement_sync_factor.0)?;
         let intent = DeleteUsersIntent {
-            user_ids: vec![legacy_user_id.to_string()],
+            user_ids: vec![legacy_user_id.clone()],
         };
         // Compute this once outside retries to keep the submitted activity
         // idempotent if the first response is lost.
@@ -728,7 +728,7 @@ impl TurnkeyApiClient {
             })
             .await?;
 
-        if !deleted_user_ids.iter().any(|id| id == legacy_user_id) {
+        if !deleted_user_ids.iter().any(|id| id == &legacy_user_id) {
             crate::critical!(
                 "turnkey.reconcile_legacy_sync_factor_user.response_missing_requested_user"
             );
@@ -1065,6 +1065,8 @@ mod tests {
     async fn reconcile_legacy_sync_factor_user_deletes_a_verified_sync_factor() {
         const SUBORGANIZATION_ID: &str = "suborg-1";
         const USER_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        // `UUID.uuidString` on iOS uses uppercase hexadecimal characters.
+        const IOS_USER_ID: &str = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -1098,9 +1100,20 @@ mod tests {
 
         let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
         TurnkeyApiClient::with_base_url(server.uri())
-            .reconcile_legacy_sync_factor_user(SUBORGANIZATION_ID, USER_ID, SyncFactor(&signer))
+            .reconcile_legacy_sync_factor_user(
+                SUBORGANIZATION_ID,
+                IOS_USER_ID,
+                SyncFactor(&signer),
+            )
             .await
             .unwrap();
+
+        assert!(server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|request| request.url.path() == "/public/v1/submit/delete_users"));
     }
 
     #[tokio::test]

--- a/bedrock/src/backup/turnkey/api.rs
+++ b/bedrock/src/backup/turnkey/api.rs
@@ -19,7 +19,7 @@ use turnkey_client::generated::external::data::v1::{Policy, User};
 use turnkey_client::generated::immutable::activity::v1::{
     CreateOauthProvidersIntentV2, CreatePolicyIntentV3, DeleteAuthenticatorsIntent,
     DeleteOauthProvidersIntent, DeletePolicyIntent, DeleteSubOrganizationIntent,
-    OauthProviderParamsV2, UpdatePolicyIntentV2,
+    DeleteUsersIntent, OauthProviderParamsV2, UpdatePolicyIntentV2,
 };
 use turnkey_client::generated::services::coordinator::public::v1::{
     GetPoliciesRequest, GetUsersRequest, GetWhoamiRequest,
@@ -32,6 +32,7 @@ use crate::primitives::retry::{retry_with_backoff, RetryError, RetryPolicy};
 use crate::primitives::P256Signer;
 
 use super::error::TurnkeyApiError;
+use super::policies::UserRole;
 
 /// Adapts a [`P256Signer`] into the Turnkey SDK's [`Stamp`] trait, so the SDK
 /// client can stamp requests with a key held in native secure storage.
@@ -661,6 +662,81 @@ impl TurnkeyApiClient {
         self.policies_cache.clear();
         Ok(())
     }
+
+    /// Reconciles deletion of a legacy sync-factor user from a Turnkey sub-organization.
+    ///
+    /// The request is stamped by the replacement sync factor. This makes the
+    /// operation convergent: if a previous delete was accepted but its response
+    /// was lost, a later invocation observes that the legacy user is absent and
+    /// completes successfully without needing the legacy credential to sign.
+    ///
+    /// The replacement signer's private key remains in native secure storage and
+    /// is never passed into Bedrock as bytes.
+    ///
+    /// # Errors
+    /// Returns [`TurnkeyApiError`] on input validation, transport, stamping,
+    /// activity, or response-consistency failures.
+    pub async fn reconcile_legacy_sync_factor_user(
+        &self,
+        suborganization_id: &str,
+        legacy_user_id: &str,
+        replacement_sync_factor: SyncFactor<'_>,
+    ) -> Result<(), TurnkeyApiError> {
+        if uuid::Uuid::try_parse(legacy_user_id).is_err() {
+            return Err(TurnkeyApiError::Client(
+                "legacy sync-factor user id is not a UUID".to_string(),
+            ));
+        }
+
+        let users = self
+            .get_users(suborganization_id, replacement_sync_factor)
+            .await?;
+        let Some(legacy_user) = users
+            .iter()
+            .find(|user| user.user_id == legacy_user_id)
+        else {
+            // A previous attempt may have deleted the user after the caller
+            // lost the activity response. Absence is the desired terminal state.
+            return Ok(());
+        };
+
+        if UserRole::classify(&legacy_user.user_name) != UserRole::SyncFactor {
+            crate::critical!(
+                "turnkey.reconcile_legacy_sync_factor_user.target_is_not_sync_factor"
+            );
+            return Err(TurnkeyApiError::Consistency);
+        }
+
+        let client = self.sdk_client(replacement_sync_factor.0)?;
+        let intent = DeleteUsersIntent {
+            user_ids: vec![legacy_user_id.to_string()],
+        };
+        // Compute this once outside retries to keep the submitted activity
+        // idempotent if the first response is lost.
+        let timestamp_ms = ntp_timestamp_ms()?;
+        let deleted_user_ids = self
+            .with_retry("reconcile_legacy_sync_factor_user", || async {
+                client
+                    .delete_users(
+                        suborganization_id.to_string(),
+                        timestamp_ms,
+                        intent.clone(),
+                    )
+                    .await
+                    .map(|activity| activity.result.user_ids)
+                    .map_err(TurnkeyApiError::from)
+            })
+            .await?;
+
+        if !deleted_user_ids.iter().any(|id| id == legacy_user_id) {
+            crate::critical!(
+                "turnkey.reconcile_legacy_sync_factor_user.response_missing_requested_user"
+            );
+            return Err(TurnkeyApiError::Consistency);
+        }
+
+        Ok(())
+    }
 }
 
 /// Current NTP time in milliseconds, for Turnkey activity timestamps.
@@ -983,5 +1059,160 @@ mod tests {
                 reason: NeedsReauthReason::SyncFactorInvalid,
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_legacy_sync_factor_user_deletes_a_verified_sync_factor() {
+        const SUBORGANIZATION_ID: &str = "suborg-1";
+        const USER_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "users": [{
+                    "userId": USER_ID,
+                    "userName": "sync_factor_user_legacy"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/delete_users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "activity-1",
+                    "organizationId": SUBORGANIZATION_ID,
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "type": "ACTIVITY_TYPE_DELETE_USERS",
+                    "fingerprint": "fingerprint-1",
+                    "result": {
+                        "deleteUsersResult": { "userIds": [USER_ID] }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+        TurnkeyApiClient::with_base_url(server.uri())
+            .reconcile_legacy_sync_factor_user(SUBORGANIZATION_ID, USER_ID, SyncFactor(&signer))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_legacy_sync_factor_user_retries_a_transient_delete_failure() {
+        const SUBORGANIZATION_ID: &str = "suborg-1";
+        const USER_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "users": [{
+                    "userId": USER_ID,
+                    "userName": "sync_factor_user_legacy"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/delete_users"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .expect(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/delete_users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "activity-1",
+                    "organizationId": SUBORGANIZATION_ID,
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "type": "ACTIVITY_TYPE_DELETE_USERS",
+                    "fingerprint": "fingerprint-1",
+                    "result": {
+                        "deleteUsersResult": { "userIds": [USER_ID] }
+                    }
+                }
+            })))
+            .expect(1)
+            .with_priority(2)
+            .mount(&server)
+            .await;
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+
+        TurnkeyApiClient::with_base_url(server.uri())
+            .reconcile_legacy_sync_factor_user(SUBORGANIZATION_ID, USER_ID, SyncFactor(&signer))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_legacy_sync_factor_user_completes_when_already_absent() {
+        const USER_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_users"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "users": [] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+
+        TurnkeyApiClient::with_base_url(server.uri())
+            .reconcile_legacy_sync_factor_user("suborg-1", USER_ID, SyncFactor(&signer))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_legacy_sync_factor_user_rejects_a_non_sync_factor_target() {
+        const USER_ID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "users": [{
+                    "userId": USER_ID,
+                    "userName": "auth_user_main"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+
+        let error = TurnkeyApiClient::with_base_url(server.uri())
+            .reconcile_legacy_sync_factor_user("suborg-1", USER_ID, SyncFactor(&signer))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, TurnkeyApiError::Consistency));
+    }
+
+    #[tokio::test]
+    async fn reconcile_legacy_sync_factor_user_rejects_an_invalid_user_id_without_a_request() {
+        let server = MockServer::start().await;
+        let signer = P256Signer::verify(Arc::new(TestSigner::new())).unwrap();
+
+        let error = TurnkeyApiClient::with_base_url(server.uri())
+            .reconcile_legacy_sync_factor_user("suborg-1", "not-a-uuid", SyncFactor(&signer))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, TurnkeyApiError::Client(_)));
+        assert!(server.received_requests().await.unwrap().is_empty());
     }
 }

--- a/bedrock/src/backup/turnkey/error.rs
+++ b/bedrock/src/backup/turnkey/error.rs
@@ -174,6 +174,17 @@ impl TurnkeyApiError {
             TurnkeyMigrationError::Failed
         }
     }
+
+    /// Collapses internal Turnkey diagnostics to the stable cleanup API error.
+    pub(super) const fn to_cleanup_error(&self) -> TurnkeyCleanupError {
+        if self.is_retryable() || matches!(self, Self::Timeout) {
+            TurnkeyCleanupError::Retryable
+        } else if matches!(self, Self::ActivityPollingExceeded { .. }) {
+            TurnkeyCleanupError::Pending
+        } else {
+            TurnkeyCleanupError::Failed
+        }
+    }
 }
 
 /// Maps a signer failure to [`TurnkeyApiError::Signer`], preserving its message.
@@ -270,6 +281,24 @@ pub enum TurnkeyMigrationError {
     AlreadyInProgress,
 }
 
+/// Opaque error returned to clients when a signer-backed Turnkey cleanup fails.
+///
+/// Diagnostic detail is logged inside Bedrock. Native clients must retain the
+/// legacy credential on `Retryable` or `Pending`, then reconcile later using
+/// the replacement sync factor.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum TurnkeyCleanupError {
+    /// The cleanup failed permanently; retrying unchanged input will not help.
+    #[error("turnkey cleanup failed")]
+    Failed,
+    /// The cleanup did not complete because of a transient dependency failure.
+    #[error("turnkey cleanup failed transiently; retry later")]
+    Retryable,
+    /// Turnkey accepted the activity but it was still pending when polling ended.
+    #[error("turnkey cleanup activity is still pending")]
+    Pending,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -330,5 +359,30 @@ mod tests {
                 crate::backup::BackupOperationError::NeedsReauth { .. }
             ));
         }
+    }
+
+    #[test]
+    fn cleanup_error_preserves_retry_and_pending_semantics() {
+        assert!(matches!(
+            TurnkeyApiError::Transport {
+                error_message: "connection reset".to_string()
+            }
+            .to_cleanup_error(),
+            TurnkeyCleanupError::Retryable
+        ));
+        assert!(matches!(
+            TurnkeyApiError::ActivityPollingExceeded {
+                error_message: "still pending".to_string()
+            }
+            .to_cleanup_error(),
+            TurnkeyCleanupError::Pending
+        ));
+        assert!(matches!(
+            TurnkeyApiError::Unauthorized {
+                body: "denied".to_string()
+            }
+            .to_cleanup_error(),
+            TurnkeyCleanupError::Failed
+        ));
     }
 }

--- a/bedrock/src/backup/turnkey/mod.rs
+++ b/bedrock/src/backup/turnkey/mod.rs
@@ -26,7 +26,7 @@ mod policies;
 pub(in crate::backup) mod test;
 
 pub use api::TurnkeyApiClient;
-pub use error::{TurnkeyApiError, TurnkeyMigrationError};
+pub use error::{TurnkeyApiError, TurnkeyCleanupError, TurnkeyMigrationError};
 use migrations::{run_migration_list, TurnkeyMigrationOutcome, MIGRATIONS};
 
 use crate::primitives::config::get_config;
@@ -162,6 +162,41 @@ impl TurnkeyManager {
             }
         }
         Ok(outcome)
+    }
+
+    /// Reconciles deletion of one legacy sync-factor user after its Secure
+    /// Enclave-backed replacement has been accepted by the backup service.
+    ///
+    /// This is deliberately an operation-level API. The replacement signer can
+    /// observe whether the legacy user is already absent, so retries are safe
+    /// after a timeout or a pending Turnkey activity. Native clients must retain
+    /// the legacy credential until this succeeds, but never construct Turnkey
+    /// stamps or receive private key material.
+    pub async fn reconcile_legacy_sync_factor_user(
+        &self,
+        suborganization_id: String,
+        legacy_user_id: String,
+        replacement_sync_factor: &P256Signer,
+    ) -> Result<(), TurnkeyCleanupError> {
+        let api = TurnkeyApiClient::new();
+        match api
+            .reconcile_legacy_sync_factor_user(
+                &suborganization_id,
+                &legacy_user_id,
+                SyncFactor(replacement_sync_factor),
+            )
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                crate::warn!(
+                    operation = "reconcile_legacy_sync_factor_user",
+                    error_class = error.code(),
+                    "turnkey.legacy_sync_factor_cleanup_failed"
+                );
+                Err(error.to_cleanup_error())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- add a Bedrock-owned `TurnkeyManager.reconcile_legacy_sync_factor_user` operation for MCORE-1924 / MCORE-595
- use the replacement Secure Enclave-backed `P256Signer` for the read-and-delete workflow; no private key bytes cross the FFI boundary
- make cleanup convergent: if an earlier delete was accepted but its response was lost, a later invocation observes the legacy user is already absent and succeeds
- validate the target is a UUID and an existing sync-factor user before deleting it; reject main, break-glass, and unknown users
- preserve stable retryable/pending errors so iOS keeps the legacy local credential and retries reconciliation

This intentionally replaces the generic signer-backed stamping approach from #438. The use case is one migration cleanup operation, with the backup/recovery workflow kept in Bedrock as Paolo requested.

## Testing

- `git diff --check`
- Added unit coverage for successful verified cleanup, already-absent convergence, non-sync-factor rejection, invalid input, and a transient 503 retry.
- Not run: `cargo fmt` / `cargo test` (Rust toolchain is unavailable in this environment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes Turnkey users with safeguards (role check, UUID validation), but mistaken targeting or policy gaps could remove the wrong principal; convergent retries reduce duplicate-delete risk.
> 
> **Overview**
> Adds a Bedrock-owned **`TurnkeyManager.reconcile_legacy_sync_factor_user`** flow to remove a legacy sync-factor Turnkey user after migration, stamped only by the replacement **`P256Signer`** (no private key bytes over FFI).
> 
> The API client lists users, no-ops if the legacy user is already gone (safe retries after lost responses), refuses non–sync-factor targets and invalid UUIDs, then submits **`delete_users`** with a fixed activity timestamp for idempotent retries. Failures surface as a new opaque **`TurnkeyCleanupError`** (`Failed` / `Retryable` / `Pending`) so native clients can keep the legacy credential until cleanup succeeds.
> 
> Unit tests cover happy path, uppercase iOS UUIDs, transient 503 retry, already-absent convergence, wrong user role, and invalid ID without network calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf050cb7892e15c53968e3d82711a24df14f5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->