### PR TITLE
feat: improvements to SIWE parsing

### DIFF
--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -215,9 +215,8 @@ fn parse_datetime(s: &str, label: &str) -> Result<DateTime<Utc>, ParseError> {
 
 /// Trims surrounding whitespace and enforces the maximum length.
 ///
-/// Angle brackets are rejected rather than stripped: stripping them makes the message
-/// that gets signed differ from the one the user was shown, so a domain written as
-/// `example.com<@evil.com>` would be consented to as one origin and signed as another.
+/// Angle brackets are rejected rather than stripped, because stripping them makes the
+/// message that gets signed differ from the one the user was shown.
 fn normalize(s: &str) -> Result<&str, ParseError> {
     let cleaned = s.trim();
     if cleaned.len() > MAX_MESSAGE_LEN {
@@ -409,42 +408,44 @@ impl SiweMessage {
                 error_message: e.to_string(),
             })?;
 
-        let expected_origin = {
-            let mut found = None;
-            for authorized_url in authorized_urls {
-                let origin = parse_origin(authorized_url).map_err(|e| {
-                    PrimitiveError::InvalidInput {
-                        attribute: "authorized_url".to_string(),
-                        error_message: e.to_string(),
-                    }
-                })?;
-
-                if origin == current_origin {
-                    found = Some(origin);
-                    break;
+        let mut authorized = false;
+        for authorized_url in authorized_urls {
+            let origin = parse_origin(authorized_url).map_err(|e| {
+                PrimitiveError::InvalidInput {
+                    attribute: "authorized_url".to_string(),
+                    error_message: e.to_string(),
                 }
+            })?;
+
+            if origin == current_origin {
+                authorized = true;
+                break;
             }
-            found.ok_or(SiweError::UnauthorizedHost)?
-        };
+        }
+        if !authorized {
+            crate::warn!(check = "querying_url", "SIWE request is not authorized");
+            return Err(SiweError::UnauthorizedHost);
+        }
         let Origin {
             scheme: expected_scheme,
             authority: expected_authority,
-        } = expected_origin;
+        } = current_origin;
 
         let mut msg = Self::from_str(&s)?;
         msg.address = smart_account.wallet_address;
 
         let claimed_scheme = msg.scheme.clone().unwrap_or(Scheme::HTTPS);
         if msg.domain != expected_authority || claimed_scheme != expected_scheme {
+            crate::warn!(check = "message_domain", "SIWE request is not authorized");
             return Err(SiweError::UnauthorizedHost);
         }
 
-        // unlike the domain, ERC-4361 requires the `URI` field to be a full RFC-3986 URI,
-        // so an authority with no scheme of its own does not name an authorized origin.
+        // unlike the domain, ERC-4361 requires `URI` to be a full RFC-3986 URI.
         let uri_authority = msg.uri.authority().ok_or(SiweError::UnauthorizedHost)?;
         if uri_authority != &expected_authority
             || msg.uri.scheme() != Some(&expected_scheme)
         {
+            crate::warn!(check = "message_uri", "SIWE request is not authorized");
             return Err(SiweError::UnauthorizedHost);
         }
 
@@ -516,15 +517,13 @@ impl SiweMessage {
                 error_message: "does not have a valid scheme".to_string(),
             })?;
 
-        // the authority, not the bare host: the port is part of the web origin, and without
-        // it a Mini App on another port of the same host would reuse an auto-login
-        // approval that was never granted to it.
+        // the authority rather than the host: the port is part of the web origin.
         let authority =
             current_url
                 .authority()
                 .ok_or_else(|| SiweError::InvalidInput {
                     attribute: "current_url".to_string(),
-                    error_message: "does not have a valid host".to_string(),
+                    error_message: "does not have a valid authority".to_string(),
                 })?;
 
         let address = self.address.to_checksum(None);

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -218,10 +218,10 @@ fn parse_datetime(s: &str, label: &str) -> Result<DateTime<Utc>, ParseError> {
 /// Angle brackets are rejected rather than stripped, because stripping them makes the
 /// message that gets signed differ from the one the user was shown.
 fn normalize(s: &str) -> Result<&str, ParseError> {
-    let cleaned = s.trim();
-    if cleaned.len() > MAX_MESSAGE_LEN {
+    if s.len() > MAX_MESSAGE_LEN {
         return Err(ParseError::Field("message too long".into()));
     }
+    let cleaned = s.trim();
     if cleaned.contains(['<', '>']) {
         return Err(ParseError::Field(
             "message must not contain angle brackets".into(),
@@ -400,7 +400,8 @@ impl SiweMessage {
         authorized_urls: &Vec<String>,
         querying_url: &str,
     ) -> Result<Self, SiweError> {
-        let s = s.replacen("{address}", &Address::ZERO.to_checksum(None), 1);
+        let s =
+            normalize(s)?.replacen("{address}", &Address::ZERO.to_checksum(None), 1);
 
         let current_origin =
             parse_origin(querying_url).map_err(|e| PrimitiveError::InvalidInput {

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -441,8 +441,7 @@ impl SiweMessage {
         }
 
         // unlike the domain, ERC-4361 requires `URI` to be a full RFC-3986 URI.
-        let uri_authority = msg.uri.authority().ok_or(SiweError::UnauthorizedHost)?;
-        if uri_authority != &expected_authority
+        if msg.uri.authority() != Some(&expected_authority)
             || msg.uri.scheme() != Some(&expected_scheme)
         {
             crate::warn!(check = "message_uri", "SIWE request is not authorized");

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -213,22 +213,29 @@ fn parse_datetime(s: &str, label: &str) -> Result<DateTime<Utc>, ParseError> {
         .map_err(|_| ParseError::Field(format!("invalid {label} datetime")))
 }
 
-/// Sanitizes raw input: strips `<>` brackets, trims whitespace, enforces max length.
-fn sanitize(s: &str) -> Result<String, ParseError> {
-    let cleaned = s.replace(['<', '>'], "");
-    let cleaned = cleaned.trim();
+/// Trims surrounding whitespace and enforces the maximum length.
+///
+/// Angle brackets are rejected rather than stripped: stripping them makes the message
+/// that gets signed differ from the one the user was shown, so a domain written as
+/// `example.com<@evil.com>` would be consented to as one origin and signed as another.
+fn normalize(s: &str) -> Result<&str, ParseError> {
+    let cleaned = s.trim();
     if cleaned.len() > MAX_MESSAGE_LEN {
         return Err(ParseError::Field("message too long".into()));
     }
-    Ok(cleaned.to_owned())
+    if cleaned.contains(['<', '>']) {
+        return Err(ParseError::Field(
+            "message must not contain angle brackets".into(),
+        ));
+    }
+    Ok(cleaned)
 }
 
 impl FromStr for SiweMessage {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let sanitized = sanitize(s)?;
-        let mut lines = sanitized.split('\n');
+        let mut lines = normalize(s)?.split('\n');
 
         let preamble = lines.next().ok_or(ParseError::Missing("preamble"))?;
         let domain_str = preamble
@@ -396,40 +403,47 @@ impl SiweMessage {
     ) -> Result<Self, SiweError> {
         let s = s.replacen("{address}", &Address::ZERO.to_checksum(None), 1);
 
-        let (current_authority, _) = parse_authority(querying_url).map_err(|e| {
-            PrimitiveError::InvalidInput {
+        let current_origin =
+            parse_origin(querying_url).map_err(|e| PrimitiveError::InvalidInput {
                 attribute: "querying_url".to_string(),
                 error_message: e.to_string(),
-            }
-        })?;
+            })?;
 
-        let expected_authority: Authority =
-            {
-                let mut found = None;
-                for authorized_url in authorized_urls {
-                    let (expected_authority, _) = parse_authority(authorized_url)
-                        .map_err(|e| PrimitiveError::InvalidInput {
-                            attribute: "authorized_url".to_string(),
-                            error_message: e.to_string(),
-                        })?;
-
-                    if expected_authority == current_authority {
-                        found = Some(expected_authority);
-                        break;
+        let expected_origin = {
+            let mut found = None;
+            for authorized_url in authorized_urls {
+                let origin = parse_origin(authorized_url).map_err(|e| {
+                    PrimitiveError::InvalidInput {
+                        attribute: "authorized_url".to_string(),
+                        error_message: e.to_string(),
                     }
+                })?;
+
+                if origin == current_origin {
+                    found = Some(origin);
+                    break;
                 }
-                found.ok_or(SiweError::UnauthorizedHost)?
-            };
+            }
+            found.ok_or(SiweError::UnauthorizedHost)?
+        };
+        let Origin {
+            scheme: expected_scheme,
+            authority: expected_authority,
+        } = expected_origin;
 
         let mut msg = Self::from_str(&s)?;
         msg.address = smart_account.wallet_address;
 
-        if msg.domain != expected_authority {
+        if msg.domain != expected_authority
+            || !scheme_authorized(msg.scheme.as_ref(), expected_scheme.as_ref())
+        {
             return Err(SiweError::UnauthorizedHost);
         }
 
         let uri_authority = msg.uri.authority().ok_or(SiweError::UnauthorizedHost)?;
-        if uri_authority != &expected_authority {
+        if uri_authority != &expected_authority
+            || !scheme_authorized(msg.uri.scheme(), expected_scheme.as_ref())
+        {
             return Err(SiweError::UnauthorizedHost);
         }
 
@@ -505,10 +519,15 @@ impl SiweMessage {
             attribute: "current_url".to_string(),
             error_message: "does not have a valid host".to_string(),
         })?;
+        // the port is part of the web origin: without it a Mini App on another port of the
+        // same host would reuse an auto-login approval that was never granted to it.
+        let port = current_url
+            .port_u16()
+            .map_or_else(String::new, |port| format!(":{port}"));
 
         let address = self.address.to_checksum(None);
         let statement = self.statement.as_deref().unwrap_or("");
-        let input = format!("{scheme}://{host}{address}{statement}");
+        let input = format!("{scheme}://{host}{port}{address}{statement}");
         Ok(hex::encode(keccak256(input.as_bytes())).try_into()?)
     }
 
@@ -547,15 +566,33 @@ impl SiweMessage {
     }
 }
 
-/// Parses an authority and scheme (per [RFC-3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1)) from
-/// a full URL or bare authority string.
+/// The scheme and authority (per [RFC-3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1))
+/// a signing request is bound to.
 ///
 /// Per ERC-4361, the `scheme` is optional for SIWE messages.
-fn parse_authority(s: &str) -> Result<(Authority, Option<Scheme>), &str> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Origin {
+    scheme: Option<Scheme>,
+    authority: Authority,
+}
+
+/// Parses an [`Origin`] from a full URL or bare authority string.
+fn parse_origin(s: &str) -> Result<Origin, &str> {
     let uri: Uri = s.parse().map_err(|_| "invalid uri")?;
-    let scheme = uri.scheme().cloned();
     let authority = uri.authority().ok_or("invalid authority")?.clone();
-    Ok((authority, scheme))
+    Ok(Origin {
+        scheme: uri.scheme().cloned(),
+        authority,
+    })
+}
+
+/// Whether a scheme claimed by a SIWE message is covered by the authorized origin.
+///
+/// ERC-4361 makes the scheme optional, so a message that omits it claims no scheme at
+/// all; one that states a scheme must state the authorized one, otherwise a request
+/// served over `custom://` would inherit the authorization of `https://` on the same host.
+fn scheme_authorized(claimed: Option<&Scheme>, expected: Option<&Scheme>) -> bool {
+    claimed.is_none() || claimed == expected
 }
 
 #[cfg(test)]

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -434,9 +434,8 @@ impl SiweMessage {
         let mut msg = Self::from_str(&s)?;
         msg.address = smart_account.wallet_address;
 
-        if msg.domain != expected_authority
-            || !scheme_authorized(msg.scheme.as_ref(), expected_scheme.as_ref())
-        {
+        let claimed_scheme = msg.scheme.clone().unwrap_or(Scheme::HTTPS);
+        if msg.domain != expected_authority || claimed_scheme != expected_scheme {
             return Err(SiweError::UnauthorizedHost);
         }
 
@@ -444,7 +443,7 @@ impl SiweMessage {
         // so an authority with no scheme of its own does not name an authorized origin.
         let uri_authority = msg.uri.authority().ok_or(SiweError::UnauthorizedHost)?;
         if uri_authority != &expected_authority
-            || msg.uri.scheme() != expected_scheme.as_ref()
+            || msg.uri.scheme() != Some(&expected_scheme)
         {
             return Err(SiweError::UnauthorizedHost);
         }
@@ -571,31 +570,23 @@ impl SiweMessage {
 
 /// The scheme and authority (per [RFC-3986](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1))
 /// a signing request is bound to.
-///
-/// Per ERC-4361, the `scheme` is optional for SIWE messages.
 #[derive(Debug, PartialEq, Eq)]
 struct Origin {
-    scheme: Option<Scheme>,
+    scheme: Scheme,
     authority: Authority,
 }
 
 /// Parses an [`Origin`] from a full URL or bare authority string.
+///
+/// ERC-4361 makes the scheme optional and assumes HTTPS when it is absent, so a request
+/// served over `custom://` never inherits the authorization of `https://` on the same host.
 fn parse_origin(s: &str) -> Result<Origin, &str> {
     let uri: Uri = s.parse().map_err(|_| "invalid uri")?;
     let authority = uri.authority().ok_or("invalid authority")?.clone();
     Ok(Origin {
-        scheme: uri.scheme().cloned(),
+        scheme: uri.scheme().cloned().unwrap_or(Scheme::HTTPS),
         authority,
     })
-}
-
-/// Whether the scheme claimed by a SIWE message's domain is covered by the authorized origin.
-///
-/// ERC-4361 makes the domain's scheme optional, so a message that omits it claims no scheme
-/// at all; one that states a scheme must state the authorized one, otherwise a request
-/// served over `custom://` would inherit the authorization of `https://` on the same host.
-fn scheme_authorized(claimed: Option<&Scheme>, expected: Option<&Scheme>) -> bool {
-    claimed.is_none() || claimed == expected
 }
 
 #[cfg(test)]

--- a/bedrock/src/siwe/mod.rs
+++ b/bedrock/src/siwe/mod.rs
@@ -440,9 +440,11 @@ impl SiweMessage {
             return Err(SiweError::UnauthorizedHost);
         }
 
+        // unlike the domain, ERC-4361 requires the `URI` field to be a full RFC-3986 URI,
+        // so an authority with no scheme of its own does not name an authorized origin.
         let uri_authority = msg.uri.authority().ok_or(SiweError::UnauthorizedHost)?;
         if uri_authority != &expected_authority
-            || !scheme_authorized(msg.uri.scheme(), expected_scheme.as_ref())
+            || msg.uri.scheme() != expected_scheme.as_ref()
         {
             return Err(SiweError::UnauthorizedHost);
         }
@@ -515,19 +517,20 @@ impl SiweMessage {
                 error_message: "does not have a valid scheme".to_string(),
             })?;
 
-        let host = current_url.host().ok_or_else(|| SiweError::InvalidInput {
-            attribute: "current_url".to_string(),
-            error_message: "does not have a valid host".to_string(),
-        })?;
-        // the port is part of the web origin: without it a Mini App on another port of the
-        // same host would reuse an auto-login approval that was never granted to it.
-        let port = current_url
-            .port_u16()
-            .map_or_else(String::new, |port| format!(":{port}"));
+        // the authority, not the bare host: the port is part of the web origin, and without
+        // it a Mini App on another port of the same host would reuse an auto-login
+        // approval that was never granted to it.
+        let authority =
+            current_url
+                .authority()
+                .ok_or_else(|| SiweError::InvalidInput {
+                    attribute: "current_url".to_string(),
+                    error_message: "does not have a valid host".to_string(),
+                })?;
 
         let address = self.address.to_checksum(None);
         let statement = self.statement.as_deref().unwrap_or("");
-        let input = format!("{scheme}://{host}{port}{address}{statement}");
+        let input = format!("{scheme}://{authority}{address}{statement}");
         Ok(hex::encode(keccak256(input.as_bytes())).try_into()?)
     }
 
@@ -570,7 +573,7 @@ impl SiweMessage {
 /// a signing request is bound to.
 ///
 /// Per ERC-4361, the `scheme` is optional for SIWE messages.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 struct Origin {
     scheme: Option<Scheme>,
     authority: Authority,
@@ -586,10 +589,10 @@ fn parse_origin(s: &str) -> Result<Origin, &str> {
     })
 }
 
-/// Whether a scheme claimed by a SIWE message is covered by the authorized origin.
+/// Whether the scheme claimed by a SIWE message's domain is covered by the authorized origin.
 ///
-/// ERC-4361 makes the scheme optional, so a message that omits it claims no scheme at
-/// all; one that states a scheme must state the authorized one, otherwise a request
+/// ERC-4361 makes the domain's scheme optional, so a message that omits it claims no scheme
+/// at all; one that states a scheme must state the authorized one, otherwise a request
 /// served over `custom://` would inherit the authorization of `https://` on the same host.
 fn scheme_authorized(claimed: Option<&Scheme>, expected: Option<&Scheme>) -> bool {
     claimed.is_none() || claimed == expected

--- a/bedrock/src/siwe/test.rs
+++ b/bedrock/src/siwe/test.rs
@@ -238,8 +238,6 @@ fn cache_hash_deterministic() {
     assert_eq!(h1.to_hex_string().len(), 66); // "0x" + 64 hex chars
 }
 
-/// The port is part of the web origin, so an approval for one port must not auto-login
-/// a Mini App served from another port of the same host.
 #[test]
 fn cache_hash_separates_ports_and_schemes() {
     let msg = SiweMessage {
@@ -857,38 +855,21 @@ fn rejects_message_domain_with_unauthorized_scheme() {
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
 }
 
-/// ERC-4361 requires the `URI` field to be a full URI, so an authority on its own must
-/// not pass the origin check the way a scheme-less domain does.
+/// ERC-4361 requires `URI` to be a full URI naming the authorized origin, so neither a
+/// bare authority nor another scheme on the same host passes as one.
 #[test]
-fn rejects_message_uri_without_scheme() {
-    let account = test_smart_account();
-    let raw_msg = make_siwe_raw("app.example.com", "app.example.com", &now_rfc3339());
-    let err = SiweMessage::from_str_with_account(
-        &raw_msg,
-        &account,
-        &vec!["https://app.example.com".to_string()],
-        "https://app.example.com",
-    )
-    .unwrap_err();
-    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
-}
-
-#[test]
-fn rejects_message_uri_with_unauthorized_scheme() {
-    let account = test_smart_account();
-    let raw_msg = make_siwe_raw(
-        "app.example.com",
-        "custom://app.example.com/callback",
-        &now_rfc3339(),
-    );
-    let err = SiweMessage::from_str_with_account(
-        &raw_msg,
-        &account,
-        &vec!["https://app.example.com".to_string()],
-        "https://app.example.com",
-    )
-    .unwrap_err();
-    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+fn rejects_message_uri_not_on_the_authorized_scheme() {
+    for uri in ["app.example.com", "custom://app.example.com/callback"] {
+        let raw_msg = make_siwe_raw("app.example.com", uri, &now_rfc3339());
+        let err = SiweMessage::from_str_with_account(
+            &raw_msg,
+            &test_smart_account(),
+            &vec!["https://app.example.com".to_string()],
+            "https://app.example.com",
+        )
+        .unwrap_err();
+        assert!(matches!(err, SiweError::UnauthorizedHost), "{uri}: {err}");
+    }
 }
 
 /// ERC-4361 assumes HTTPS when the domain states no scheme, so a bare domain must not
@@ -909,6 +890,26 @@ fn rejects_scheme_less_message_domain_on_http_origin() {
     )
     .unwrap_err();
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
+/// ERC-4361 assumes HTTPS for an absent scheme on the authorized URL as well, so a bare
+/// authority registered in the Developer Portal still matches an https Mini App.
+#[test]
+fn accepts_authorized_url_without_scheme() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "app.example.com",
+        "https://app.example.com/callback",
+        &now_rfc3339(),
+    );
+    let msg = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["app.example.com".to_string()],
+        "https://app.example.com",
+    )
+    .unwrap();
+    assert_eq!(msg.domain, "app.example.com");
 }
 
 /// The other authorization tests omit the scheme, which ERC-4361 allows; a message that

--- a/bedrock/src/siwe/test.rs
+++ b/bedrock/src/siwe/test.rs
@@ -253,10 +253,14 @@ fn cache_hash_separates_ports_and_schemes() {
     let port_8080 = msg.to_cache_hash("https://test.com:8080").unwrap();
     let port_9090 = msg.to_cache_hash("https://test.com:9090").unwrap();
     let http = msg.to_cache_hash("http://test.com").unwrap();
+    // `Uri::port_u16` reports no port at all for one this large, so hashing the parsed
+    // port rather than the authority would collide with the portless origin.
+    let out_of_range_port = msg.to_cache_hash("https://test.com:65536").unwrap();
 
     assert_ne!(port_8080, port_9090);
     assert_ne!(no_port, port_8080);
     assert_ne!(no_port, http);
+    assert_ne!(no_port, out_of_range_port);
 }
 
 #[test]
@@ -853,6 +857,22 @@ fn rejects_message_domain_with_unauthorized_scheme() {
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
 }
 
+/// ERC-4361 requires the `URI` field to be a full URI, so an authority on its own must
+/// not pass the origin check the way a scheme-less domain does.
+#[test]
+fn rejects_message_uri_without_scheme() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw("app.example.com", "app.example.com", &now_rfc3339());
+    let err = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["https://app.example.com".to_string()],
+        "https://app.example.com",
+    )
+    .unwrap_err();
+    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
 #[test]
 fn rejects_message_uri_with_unauthorized_scheme() {
     let account = test_smart_account();
@@ -871,8 +891,8 @@ fn rejects_message_uri_with_unauthorized_scheme() {
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
 }
 
-/// ERC-4361 leaves the scheme optional, so a message that states the authorized one
-/// stays valid.
+/// The other authorization tests omit the scheme, which ERC-4361 allows; a message that
+/// does state one is accepted when it names the authorized scheme.
 #[test]
 fn accepts_message_domain_matching_authorized_scheme() {
     let account = test_smart_account();

--- a/bedrock/src/siwe/test.rs
+++ b/bedrock/src/siwe/test.rs
@@ -891,6 +891,26 @@ fn rejects_message_uri_with_unauthorized_scheme() {
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
 }
 
+/// ERC-4361 assumes HTTPS when the domain states no scheme, so a bare domain must not
+/// pass on an origin that is not HTTPS.
+#[test]
+fn rejects_scheme_less_message_domain_on_http_origin() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "app.example.com",
+        "http://app.example.com/callback",
+        &now_rfc3339(),
+    );
+    let err = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["http://app.example.com".to_string()],
+        "http://app.example.com",
+    )
+    .unwrap_err();
+    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
 /// The other authorization tests omit the scheme, which ERC-4361 allows; a message that
 /// does state one is accepted when it names the authorized scheme.
 #[test]

--- a/bedrock/src/siwe/test.rs
+++ b/bedrock/src/siwe/test.rs
@@ -238,6 +238,27 @@ fn cache_hash_deterministic() {
     assert_eq!(h1.to_hex_string().len(), 66); // "0x" + 64 hex chars
 }
 
+/// The port is part of the web origin, so an approval for one port must not auto-login
+/// a Mini App served from another port of the same host.
+#[test]
+fn cache_hash_separates_ports_and_schemes() {
+    let msg = SiweMessage {
+        scheme: Some(Scheme::HTTPS),
+        domain: Authority::from_static("test.com"),
+        address: Address::from_str(TEST_WALLET).unwrap(),
+        statement: Some("statement".into()),
+        ..SiweMessage::default()
+    };
+    let no_port = msg.to_cache_hash("https://test.com").unwrap();
+    let port_8080 = msg.to_cache_hash("https://test.com:8080").unwrap();
+    let port_9090 = msg.to_cache_hash("https://test.com:9090").unwrap();
+    let http = msg.to_cache_hash("http://test.com").unwrap();
+
+    assert_ne!(port_8080, port_9090);
+    assert_ne!(no_port, port_8080);
+    assert_ne!(no_port, http);
+}
+
 #[test]
 fn default_produces_valid_message() {
     let msg = SiweMessage::default();
@@ -400,11 +421,13 @@ fn no_placeholder_still_parses() {
     assert_eq!(msg.address, account.wallet_address);
 }
 
+/// Angle brackets must not be stripped: the hidden `@evil.com` would be dropped from
+/// the domain that gets signed while the raw message the user saw still contains it.
 #[test]
-fn parse_strips_angle_brackets() {
+fn parse_rejects_angle_brackets() {
     let datetime = now_rfc3339();
     let raw = format!(
-        "<https://example.com>{PREAMBLE}\n\
+        "example.com<@evil.com>{PREAMBLE}\n\
          0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045\n\n\n\
          URI: https://example.com\n\
          Version: 1\n\
@@ -412,8 +435,11 @@ fn parse_strips_angle_brackets() {
          Nonce: 12345678\n\
          Issued At: {datetime}"
     );
-    let msg = SiweMessage::from_str(&raw).unwrap();
-    assert_eq!(msg.domain, "example.com");
+    let err = SiweMessage::from_str(&raw).unwrap_err();
+    assert!(
+        matches!(err, ParseError::Field(ref msg) if msg.contains("angle brackets")),
+        "got: {err}"
+    );
 }
 
 #[test]
@@ -790,6 +816,79 @@ fn rejects_different_port_on_same_host() {
     )
     .unwrap_err();
     assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
+/// A Mini App that navigates the webview to a custom scheme on an authorized host must
+/// not inherit that host's `https` authorization.
+#[test]
+fn rejects_querying_url_with_unauthorized_scheme() {
+    let account = test_smart_account();
+    let raw_msg =
+        make_siwe_raw("app.example.com", "https://app.example.com", &now_rfc3339());
+    let err = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["https://app.example.com".to_string()],
+        "custom://app.example.com",
+    )
+    .unwrap_err();
+    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
+#[test]
+fn rejects_message_domain_with_unauthorized_scheme() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "custom://app.example.com",
+        "https://app.example.com",
+        &now_rfc3339(),
+    );
+    let err = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["https://app.example.com".to_string()],
+        "https://app.example.com",
+    )
+    .unwrap_err();
+    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
+#[test]
+fn rejects_message_uri_with_unauthorized_scheme() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "app.example.com",
+        "custom://app.example.com/callback",
+        &now_rfc3339(),
+    );
+    let err = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["https://app.example.com".to_string()],
+        "https://app.example.com",
+    )
+    .unwrap_err();
+    assert!(matches!(err, SiweError::UnauthorizedHost), "got: {err}");
+}
+
+/// ERC-4361 leaves the scheme optional, so a message that states the authorized one
+/// stays valid.
+#[test]
+fn accepts_message_domain_matching_authorized_scheme() {
+    let account = test_smart_account();
+    let raw_msg = make_siwe_raw(
+        "https://app.example.com",
+        "https://app.example.com/callback",
+        &now_rfc3339(),
+    );
+    let msg = SiweMessage::from_str_with_account(
+        &raw_msg,
+        &account,
+        &vec!["https://app.example.com".to_string()],
+        "https://app.example.com",
+    )
+    .unwrap();
+    assert_eq!(msg.scheme.unwrap(), Scheme::HTTPS);
 }
 
 #[test]


### PR DESCRIPTION
### Changes
1. When checking for an authorized domain, it'll ensure the protocol matches (e.g. `https`)
2. Includes the port when users authorize "remember my login"
3. Prevents angle brackets instead of sanitizing, so the rendered domain in the UI is always what gets signed.

AI-driven

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes SIWE authorization and signed-message normalization in security-sensitive auth flows; misconfiguration could block legitimate apps or affect auto-login behavior.
> 
> **Overview**
> Tightens **SIWE (EIP-4361)** parsing and Mini App authorization so origins are matched as **scheme + authority** (including port), not host alone.
> 
> **Input handling:** `sanitize` is replaced by `normalize`, which trims and enforces max length but **rejects** angle brackets instead of stripping them, so the signed message cannot diverge from what the user saw.
> 
> **Authorization (`from_str_with_account`):** `parse_authority` becomes `parse_origin` with an `Origin` type; absent schemes default to **HTTPS** per ERC-4361. The querying URL must match an authorized URL on the full origin; the message **domain** and **URI** must both match the expected scheme and authority (URI must be a full RFC-3986 URI). Failed checks log warnings and return `UnauthorizedHost`.
> 
> **Auto-login cache:** `to_cache_hash` hashes **`authority`** (not `host`) so different ports/schemes do not share the same “remember login” key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f62f6feb3e7786356b2547c9108e3e318e575f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->